### PR TITLE
feat: Expose `__ffi_init__` as a de-facto shortcut to calling `_C___init__`

### DIFF
--- a/python/tvm_ffi/core.pyi
+++ b/python/tvm_ffi/core.pyi
@@ -45,6 +45,15 @@ class Object:
     def __ne__(self, other: Any) -> bool: ...
     def __hash__(self) -> int: ...
     def __init_handle_by_constructor__(self, fconstructor: Function, *args: Any) -> None: ...
+    def __ffi_init__(self, *args: Any) -> None:
+        """Initialize the instance using the ` __init__` method registered on C++ side.
+
+        Parameters
+        ----------
+        args: list of objects
+            The arguments to the constructor
+
+        """
     def same_as(self, other: Any) -> bool: ...
     def _move(self) -> ObjectRValueRef: ...
     def __move_handle_from__(self, other: Object) -> None: ...
@@ -240,6 +249,7 @@ class TypeField:
     frozen: bool
     getter: Any
     setter: Any
+    dataclass_field: Any | None
 
     def as_property(self, cls: type) -> property: ...
 

--- a/python/tvm_ffi/cython/object.pxi
+++ b/python/tvm_ffi/cython/object.pxi
@@ -138,6 +138,16 @@ cdef class Object:
             (<Object>fconstructor).chandle, <PyObject*>args, &chandle, NULL)
         self.chandle = chandle
 
+    def __ffi_init__(self, *args) -> None:
+        """Initialize the instance using the ` __init__` method registered on C++ side.
+
+        Parameters
+        ----------
+        args: list of objects
+            The arguments to the constructor
+        """
+        self.__init_handle_by_constructor__(type(self)._C___init__, *args)
+
     def same_as(self, other):
         """Check object identity.
 

--- a/python/tvm_ffi/cython/object.pxi
+++ b/python/tvm_ffi/cython/object.pxi
@@ -139,12 +139,12 @@ cdef class Object:
         self.chandle = chandle
 
     def __ffi_init__(self, *args) -> None:
-        """Initialize the instance using the ` __init__` method registered on C++ side.
+        """Initialize the instance using the `__init__` method registered on the C++ side.
 
         Parameters
         ----------
-        args: list of objects
-            The arguments to the constructor
+        args : Any
+            Positional arguments forwarded to the registered C++ __init__.
         """
         self.__init_handle_by_constructor__(type(self)._C___init__, *args)
 


### PR DESCRIPTION
Per discussion w/ @tqchen.

In dataclass-syntax classes as introduced in #8, we likely always use the reflected `_C___init__` method to initialize an instance. This PR gives a shortcut to this convention, where

```pytthon
self.__init_handle_by_constructor__(_MyClass._C___init__, ...)
```

is equivalent to

```
self.__ffi_init__(v_i64 + 1, v_i32 + 2)
```