### PR TITLE
chore(lint): Add Taplo for TOML

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,10 @@ repos:
       - id: trailing-whitespace
       - id: check-yaml
       - id: check-toml
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: taplo-format
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.3
     hooks:


### PR DESCRIPTION
This PR adds a linter for TOML, which is mostly used as pyproject configuration.