### PR TITLE
feat: Metadata and JSON-based type schemas for fields, methods and global funcs

### DIFF
--- a/include/tvm/ffi/base_details.h
+++ b/include/tvm/ffi/base_details.h
@@ -290,6 +290,22 @@ TVM_FFI_INLINE uint64_t StableHashSmallStrBytes(const TVMFFIAny* data) {
   return StableHashBytes(reinterpret_cast<const void*>(data), sizeof(data->v_uint64));
 }
 
+/*!
+ * \brief Helper to generate a JSON-based type schema for a given type.
+ * \tparam T The type to generate the schema for. Assuming `T` is not
+ *        const-qualified or reference-qualified.
+ */
+template <typename T>
+struct TypeSchemaImpl;
+/*!
+ * \brief Helper to generate a JSON-based type schema for a given type.
+ * \tparam T The type to generate the schema for.
+ * \note This type removes const and reference qualifiers from `T` before
+ *       passing it to `TypeSchemaImpl`.
+ */
+template <typename T>
+using TypeSchema = TypeSchemaImpl<std::remove_const_t<std::remove_reference_t<T>>>;
+
 }  // namespace details
 }  // namespace ffi
 }  // namespace tvm

--- a/include/tvm/ffi/container/array.h
+++ b/include/tvm/ffi/container/array.h
@@ -1135,6 +1135,13 @@ struct TypeTraits<Array<T>> : public ObjectRefTypeTraitsBase<Array<T>> {
   }
 
   TVM_FFI_INLINE static std::string TypeStr() { return "Array<" + details::Type2Str<T>::v() + ">"; }
+  TVM_FFI_INLINE static std::string TypeSchema() {
+    std::ostringstream oss;
+    oss << "{\"type\":\"" << StaticTypeKey::kTVMFFIArray << "\",\"args\":[";
+    oss << details::TypeSchema<T>::v();
+    oss << "]}";
+    return oss.str();
+  }
 };
 
 namespace details {

--- a/include/tvm/ffi/container/map.h
+++ b/include/tvm/ffi/container/map.h
@@ -1755,6 +1755,14 @@ struct TypeTraits<Map<K, V>> : public ObjectRefTypeTraitsBase<Map<K, V>> {
   TVM_FFI_INLINE static std::string TypeStr() {
     return "Map<" + details::Type2Str<K>::v() + ", " + details::Type2Str<V>::v() + ">";
   }
+  TVM_FFI_INLINE static std::string TypeSchema() {
+    std::ostringstream oss;
+    oss << "{\"type\":\"" << StaticTypeKey::kTVMFFIMap << "\",\"args\":[";
+    oss << details::TypeSchema<K>::v() << ",";
+    oss << details::TypeSchema<V>::v();
+    oss << "]}";
+    return oss.str();
+  }
 };
 
 namespace details {

--- a/include/tvm/ffi/container/tensor.h
+++ b/include/tvm/ffi/container/tensor.h
@@ -615,6 +615,9 @@ struct TypeTraits<TensorView> : public TypeTraitsBase {
   }
 
   TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIDLTensorPtr; }
+  TVM_FFI_INLINE static std::string TypeSchema() {
+    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIDLTensorPtr) + "\"}";
+  }
 };
 
 }  // namespace ffi

--- a/include/tvm/ffi/container/tuple.h
+++ b/include/tvm/ffi/container/tuple.h
@@ -267,8 +267,7 @@ struct TypeTraits<Tuple<Types...>> : public ObjectRefTypeTraitsBase<Tuple<Types.
     return true;
   }
 
-  TVM_FFI_INLINE static std::optional<Tuple<Types...>> TryCastFromAnyView(const TVMFFIAny* src  //
-  ) {
+  TVM_FFI_INLINE static std::optional<Tuple<Types...>> TryCastFromAnyView(const TVMFFIAny* src) {
     if (src->type_index != TypeIndex::kTVMFFIArray) return std::nullopt;
     const ArrayObj* n = reinterpret_cast<const ArrayObj*>(src->v_obj);
     if (n->size() != sizeof...(Types)) return std::nullopt;
@@ -304,6 +303,14 @@ struct TypeTraits<Tuple<Types...>> : public ObjectRefTypeTraitsBase<Tuple<Types.
 
   TVM_FFI_INLINE static std::string TypeStr() {
     return details::ContainerTypeStr<Types...>("Tuple");
+  }
+  TVM_FFI_INLINE static std::string TypeSchema() {
+    std::ostringstream oss;
+    oss << "{\"type\":\"Tuple\",\"args\":[";
+    const char* sep = "";
+    ((oss << sep << details::TypeSchema<Types>::v(), sep = ","), ...);
+    oss << "]}";
+    return oss.str();
   }
 };
 

--- a/include/tvm/ffi/container/variant.h
+++ b/include/tvm/ffi/container/variant.h
@@ -280,6 +280,14 @@ struct TypeTraits<Variant<V...>> : public TypeTraitsBase {
   }
 
   TVM_FFI_INLINE static std::string TypeStr() { return details::ContainerTypeStr<V...>("Variant"); }
+  TVM_FFI_INLINE static std::string TypeSchema() {
+    std::ostringstream oss;
+    oss << "{\"type\":\"Variant\",\"args\":[";
+    const char* sep = "";
+    ((oss << sep << details::TypeSchema<V>::v(), sep = ","), ...);
+    oss << "]}";
+    return oss.str();
+  }
 };
 
 template <typename... V>

--- a/include/tvm/ffi/dtype.h
+++ b/include/tvm/ffi/dtype.h
@@ -178,6 +178,9 @@ struct TypeTraits<DLDataType> : public TypeTraitsBase {
   }
 
   TVM_FFI_INLINE static std::string TypeStr() { return ffi::StaticTypeKey::kTVMFFIDataType; }
+  TVM_FFI_INLINE static std::string TypeSchema() {
+    return "{\"type\":\"" + std::string(ffi::StaticTypeKey::kTVMFFIDataType) + "\"}";
+  }
 };
 }  // namespace ffi
 }  // namespace tvm

--- a/include/tvm/ffi/function.h
+++ b/include/tvm/ffi/function.h
@@ -740,6 +740,11 @@ class TypedFunction<R(Args...)> {
   bool operator==(std::nullptr_t null) const { return packed_ == nullptr; }
   /*! \return Whether the packed function is not nullptr */
   bool operator!=(std::nullptr_t null) const { return packed_ != nullptr; }
+  /*!
+   * \brief Get the type schema of `TypedFunction<R(Args...)>` in json format.
+   * \return The type schema of the function in json format.
+   */
+  static std::string TypeSchema() { return details::FuncFunctorImpl<R, Args...>::TypeSchema(); }
 
  private:
   /*! \brief The internal packed function */
@@ -780,6 +785,7 @@ struct TypeTraits<TypedFunction<FType>> : public TypeTraitsBase {
   }
 
   TVM_FFI_INLINE static std::string TypeStr() { return details::FunctionInfo<FType>::Sig(); }
+  TVM_FFI_INLINE static std::string TypeSchema() { return TypedFunction<FType>::TypeSchema(); }
 };
 
 /*!

--- a/include/tvm/ffi/reflection/registry.h
+++ b/include/tvm/ffi/reflection/registry.h
@@ -25,27 +25,117 @@
 
 #include <tvm/ffi/any.h>
 #include <tvm/ffi/c_api.h>
+#include <tvm/ffi/container/map.h>
+#include <tvm/ffi/container/variant.h>
 #include <tvm/ffi/function.h>
+#include <tvm/ffi/optional.h>
+#include <tvm/ffi/string.h>
 #include <tvm/ffi/type_traits.h>
 
+#include <iterator>
+#include <optional>
+#include <sstream>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace tvm {
 namespace ffi {
 /*! \brief Reflection namespace */
 namespace reflection {
+/*!
+ * \brief Types of temporary metadata hold in FieldInfoBuilder and MethodInfoBuilder,
+ * before they are filled into final C metadata
+ */
+using _MetadataType = std::vector<std::pair<String, Any>>;
+/*!
+ * \brief Builder for TVMFFIFieldInfo
+ * \sa TVMFFIFieldInfo
+ */
+struct FieldInfoBuilder : public TVMFFIFieldInfo {
+  /*! \brief Temporary metadata info to be filled into TVMFFIFieldInfo::metadata */
+  _MetadataType metadata_;
+};
+/*!
+ * \brief Builder for TVMFFIMethodInfo
+ * \sa TVMFFIMethodInfo
+ */
+struct MethodInfoBuilder : public TVMFFIMethodInfo {
+  /*! \brief Temporary metadata info to be filled into TVMFFIMethodInfo::metadata */
+  _MetadataType metadata_;
+};
 
 /*!
- * \brief Trait that can be used to set field info
+ * \brief Trait that can be used to set information attached to a field or a method.
  * \sa DefaultValue, AttachFieldFlag
  */
-struct FieldInfoTrait {};
+struct InfoTrait {};
 
+/*! \brief User-supplied metadata attached to a field or a method */
+class Metadata : public InfoTrait {
+ public:
+  /*!
+   * \brief Constructor
+   * \param dict The initial dictionary
+   */
+  explicit Metadata(std::initializer_list<std::pair<String, Any>> dict) : dict_(dict) {}
+  /*!
+   * \brief Move metadata into `FieldInfoBuilder`
+   * \param info The field info builder.
+   */
+  inline void Apply(FieldInfoBuilder* info) const { this->Apply(&info->metadata_); }
+  /*!
+   * \brief Move metadata into `MethodInfoBuilder`
+   * \param info The method info builder.
+   */
+  inline void Apply(MethodInfoBuilder* info) const { this->Apply(&info->metadata_); }
+
+ private:
+  friend class GlobalDef;
+  template <typename T>
+  friend class ObjectDef;
+  /*!
+   * \brief Move metadata into a vector of key-value pairs.
+   * \param out The output vector.
+   */
+  inline void Apply(_MetadataType* out) const {
+    std::copy(std::make_move_iterator(dict_.begin()), std::make_move_iterator(dict_.end()),
+              std::back_inserter(*out));
+  }
+  /*! \brief Convert the metadata to JSON string */
+  static std::string ToJSON(const _MetadataType& metadata) {
+    using ::tvm::ffi::details::StringObj;
+    std::ostringstream os;
+    os << "{";
+    bool first = true;
+    for (const auto& [key, value] : metadata) {
+      if (!first) {
+        os << ",";
+      }
+      os << "\"" << key << "\":";
+      if (std::optional<int> v = value.as<int>()) {
+        os << *v;
+      } else if (std::optional<bool> v = value.as<bool>()) {
+        os << (*v ? "true" : "false");
+      } else if (std::optional<String> v = value.as<String>()) {
+        String escaped = EscapeString(*v);
+        os << escaped.c_str();
+      } else {
+        TVM_FFI_LOG_AND_THROW(TypeError) << "Metadata can be only int, bool or string, but on key `"
+                                         << key << "`, the type is " << value.GetTypeKey();
+      }
+      first = false;
+    }
+    os << "}";
+    return os.str();
+  }
+
+  std::vector<std::pair<String, Any>> dict_;
+};
 /*!
  * \brief Trait that can be used to set field default value
  */
-class DefaultValue : public FieldInfoTrait {
+class DefaultValue : public InfoTrait {
  public:
   /*!
    * \brief Constructor
@@ -69,7 +159,7 @@ class DefaultValue : public FieldInfoTrait {
 /*!
  * \brief Trait that can be used to attach field flag
  */
-class AttachFieldFlag : public FieldInfoTrait {
+class AttachFieldFlag : public InfoTrait {
  public:
   /*!
    * \brief Attach a field flag to the field
@@ -154,8 +244,8 @@ class ReflectionDefBase {
   }
 
   template <typename T>
-  TVM_FFI_INLINE static void ApplyFieldInfoTrait(TVMFFIFieldInfo* info, const T& value) {
-    if constexpr (std::is_base_of_v<FieldInfoTrait, std::decay_t<T>>) {
+  TVM_FFI_INLINE static void ApplyFieldInfoTrait(FieldInfoBuilder* info, const T& value) {
+    if constexpr (std::is_base_of_v<InfoTrait, std::decay_t<T>>) {
       value.Apply(info);
     }
     if constexpr (std::is_same_v<std::decay_t<T>, char*>) {
@@ -164,7 +254,10 @@ class ReflectionDefBase {
   }
 
   template <typename T>
-  TVM_FFI_INLINE static void ApplyMethodInfoTrait(TVMFFIMethodInfo* info, const T& value) {
+  TVM_FFI_INLINE static void ApplyMethodInfoTrait(MethodInfoBuilder* info, const T& value) {
+    if constexpr (std::is_base_of_v<InfoTrait, std::decay_t<T>>) {
+      value.Apply(info);
+    }
     if constexpr (std::is_same_v<std::decay_t<T>, char*>) {
       info->doc = TVMFFIByteArray{value, std::char_traits<char>::length(value)};
     }
@@ -244,14 +337,15 @@ class GlobalDef : public ReflectionDefBase {
    *
    * \param name The name of the function.
    * \param func The function to be registered.
-   * \param extra The extra arguments that can be docstring or subclass of FieldInfoTrait.
+   * \param extra The extra arguments that can be docstring or subclass of InfoTrait.
    *
    * \return The reflection definition.
    */
   template <typename Func, typename... Extra>
   GlobalDef& def(const char* name, Func&& func, Extra&&... extra) {
+    using FuncInfo = details::FunctionInfo<std::decay_t<Func>>;
     RegisterFunc(name, ffi::Function::FromTyped(std::forward<Func>(func), std::string(name)),
-                 std::forward<Extra>(extra)...);
+                 FuncInfo::TypeSchema(), std::forward<Extra>(extra)...);
     return *this;
   }
 
@@ -263,13 +357,14 @@ class GlobalDef : public ReflectionDefBase {
    *
    * \param name The name of the function.
    * \param func The function to be registered.
-   * \param extra The extra arguments that can be docstring or subclass of FieldInfoTrait.
+   * \param extra The extra arguments that can be docstring or subclass of InfoTrait.
    *
    * \return The reflection definition.
    */
   template <typename Func, typename... Extra>
   GlobalDef& def_packed(const char* name, Func func, Extra&&... extra) {
-    RegisterFunc(name, ffi::Function::FromPacked(func), std::forward<Extra>(extra)...);
+    RegisterFunc(name, ffi::Function::FromPacked(func), details::TypeSchemaImpl<Function>::v(),
+                 std::forward<Extra>(extra)...);
     return *this;
   }
 
@@ -289,23 +384,24 @@ class GlobalDef : public ReflectionDefBase {
    */
   template <typename Func, typename... Extra>
   GlobalDef& def_method(const char* name, Func&& func, Extra&&... extra) {
+    using FuncInfo = details::FunctionInfo<std::decay_t<Func>>;
     RegisterFunc(name, GetMethod(std::string(name), std::forward<Func>(func)),
-                 std::forward<Extra>(extra)...);
+                 FuncInfo::TypeSchema(), std::forward<Extra>(extra)...);
     return *this;
   }
 
  private:
   template <typename... Extra>
-  void RegisterFunc(const char* name, ffi::Function func, Extra&&... extra) {
-    TVMFFIMethodInfo info;
+  void RegisterFunc(const char* name, ffi::Function func, String type_schema, Extra&&... extra) {
+    MethodInfoBuilder info;
     info.name = TVMFFIByteArray{name, std::char_traits<char>::length(name)};
     info.doc = TVMFFIByteArray{nullptr, 0};
-    info.metadata = TVMFFIByteArray{nullptr, 0};
     info.flags = 0;
-    // obtain the method function
     info.method = AnyView(func).CopyToTVMFFIAny();
-    // apply method info traits
+    info.metadata_.emplace_back("type_schema", type_schema);
     ((ApplyMethodInfoTrait(&info, std::forward<Extra>(extra)), ...));
+    std::string metadata_str = Metadata::ToJSON(info.metadata_);
+    info.metadata = TVMFFIByteArray{metadata_str.c_str(), metadata_str.size()};
     TVM_FFI_CHECK_SAFE_CALL(TVMFFIFunctionSetGlobalFromMethodInfo(&info, 0));
   }
 };
@@ -430,7 +526,7 @@ class ObjectDef : public ReflectionDefBase {
   void RegisterField(const char* name, T BaseClass::* field_ptr, bool writable,
                      ExtraArgs&&... extra_args) {
     static_assert(std::is_base_of_v<BaseClass, Class>, "BaseClass must be a base class of Class");
-    TVMFFIFieldInfo info;
+    FieldInfoBuilder info;
     info.name = TVMFFIByteArray{name, std::char_traits<char>::length(name)};
     info.field_static_type_index = TypeToFieldStaticTypeIndex<T>::value;
     // store byte offset and setter, getter
@@ -447,20 +543,22 @@ class ObjectDef : public ReflectionDefBase {
     // initialize default value to nullptr
     info.default_value = AnyView(nullptr).CopyToTVMFFIAny();
     info.doc = TVMFFIByteArray{nullptr, 0};
-    info.metadata = TVMFFIByteArray{nullptr, 0};
+    info.metadata_.emplace_back("type_schema", details::TypeSchema<T>::v());
     // apply field info traits
     ((ApplyFieldInfoTrait(&info, std::forward<ExtraArgs>(extra_args)), ...));
     // call register
+    std::string metadata_str = Metadata::ToJSON(info.metadata_);
+    info.metadata = TVMFFIByteArray{metadata_str.c_str(), metadata_str.size()};
     TVM_FFI_CHECK_SAFE_CALL(TVMFFITypeRegisterField(type_index_, &info));
   }
 
   // register a method
   template <typename Func, typename... Extra>
   void RegisterMethod(const char* name, bool is_static, Func&& func, Extra&&... extra) {
-    TVMFFIMethodInfo info;
+    using FuncInfo = details::FunctionInfo<std::decay_t<Func>>;
+    MethodInfoBuilder info;
     info.name = TVMFFIByteArray{name, std::char_traits<char>::length(name)};
     info.doc = TVMFFIByteArray{nullptr, 0};
-    info.metadata = TVMFFIByteArray{nullptr, 0};
     info.flags = 0;
     if (is_static) {
       info.flags |= kTVMFFIFieldFlagBitMaskIsStaticMethod;
@@ -468,8 +566,11 @@ class ObjectDef : public ReflectionDefBase {
     // obtain the method function
     Function method = GetMethod(std::string(type_key_) + "." + name, std::forward<Func>(func));
     info.method = AnyView(method).CopyToTVMFFIAny();
+    info.metadata_.emplace_back("type_schema", FuncInfo::TypeSchema());
     // apply method info traits
     ((ApplyMethodInfoTrait(&info, std::forward<Extra>(extra)), ...));
+    std::string metadata_str = Metadata::ToJSON(info.metadata_);
+    info.metadata = TVMFFIByteArray{metadata_str.c_str(), metadata_str.size()};
     TVM_FFI_CHECK_SAFE_CALL(TVMFFITypeRegisterMethod(type_index_, &info));
   }
 

--- a/include/tvm/ffi/rvalue_ref.h
+++ b/include/tvm/ffi/rvalue_ref.h
@@ -148,6 +148,14 @@ struct TypeTraits<RValueRef<TObjRef>> : public TypeTraitsBase {
   TVM_FFI_INLINE static std::string TypeStr() {
     return "RValueRef<" + TypeTraits<TObjRef>::TypeStr() + ">";
   }
+
+  TVM_FFI_INLINE static std::string TypeSchema() {
+    std::ostringstream oss;
+    oss << "{\"type\":\"" << StaticTypeKey::kTVMFFIObjectRValueRef << "\",\"args\":[";
+    oss << TypeTraits<TObjRef>::TypeSchema();
+    oss << "]}";
+    return oss.str();
+  }
 };
 }  // namespace ffi
 }  // namespace tvm

--- a/include/tvm/ffi/type_traits.h
+++ b/include/tvm/ffi/type_traits.h
@@ -167,6 +167,9 @@ struct TypeTraits<std::nullptr_t> : public TypeTraitsBase {
   }
 
   TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFINone; }
+  TVM_FFI_INLINE static std::string TypeSchema() {
+    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFINone) + "\"}";
+  }
 };
 
 /**
@@ -226,6 +229,9 @@ struct TypeTraits<StrictBool> : public TypeTraitsBase {
   }
 
   TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIBool; }
+  TVM_FFI_INLINE static std::string TypeSchema() {
+    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIBool) + "\"}";
+  }
 };
 
 // Bool type, allow implicit casting from int
@@ -262,6 +268,9 @@ struct TypeTraits<bool> : public TypeTraitsBase {
   }
 
   TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIBool; }
+  TVM_FFI_INLINE static std::string TypeSchema() {
+    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIBool) + "\"}";
+  }
 };
 
 // Integer POD values
@@ -299,6 +308,9 @@ struct TypeTraits<Int, std::enable_if_t<std::is_integral_v<Int>>> : public TypeT
   }
 
   TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIInt; }
+  TVM_FFI_INLINE static std::string TypeSchema() {
+    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIInt) + "\"}";
+  }
 };
 
 /// \cond Doxygen_Suppress
@@ -351,6 +363,9 @@ struct TypeTraits<IntEnum, std::enable_if_t<is_integeral_enum_v<IntEnum>>> : pub
   }
 
   TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIInt; }
+  TVM_FFI_INLINE static std::string TypeSchema() {
+    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIInt) + "\"}";
+  }
 };
 
 // Float POD values
@@ -392,6 +407,9 @@ struct TypeTraits<Float, std::enable_if_t<std::is_floating_point_v<Float>>>
   }
 
   TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIFloat; }
+  TVM_FFI_INLINE static std::string TypeSchema() {
+    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIFloat) + "\"}";
+  }
 };
 
 // void*
@@ -431,6 +449,9 @@ struct TypeTraits<void*> : public TypeTraitsBase {
   }
 
   TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIOpaquePtr; }
+  TVM_FFI_INLINE static std::string TypeSchema() {
+    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIOpaquePtr) + "\"}";
+  }
 };
 
 // Device
@@ -471,6 +492,9 @@ struct TypeTraits<DLDevice> : public TypeTraitsBase {
   }
 
   TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIDevice; }
+  TVM_FFI_INLINE static std::string TypeSchema() {
+    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIDevice) + "\"}";
+  }
 };
 
 // DLTensor*, requirement: not nullable, do not retain ownership
@@ -514,6 +538,7 @@ struct TypeTraits<DLTensor*> : public TypeTraitsBase {
   }
 
   TVM_FFI_INLINE static std::string TypeStr() { return "DLTensor*"; }
+  TVM_FFI_INLINE static std::string TypeSchema() { return "{\"type\":\"DLTensor*\"}"; }
 };
 
 // Traits for ObjectRef, None to ObjectRef will always fail.
@@ -599,6 +624,9 @@ struct ObjectRefTypeTraitsBase : public TypeTraitsBase {
   }
 
   TVM_FFI_INLINE static std::string TypeStr() { return ContainerType::_type_key; }
+  TVM_FFI_INLINE static std::string TypeSchema() {
+    return "{\"type\":\"" + std::string(ContainerType::_type_key) + "\"}";
+  }
 };
 
 template <typename TObjRef>
@@ -725,6 +753,9 @@ struct TypeTraits<TObject*, std::enable_if_t<std::is_base_of_v<Object, TObject>>
   }
 
   TVM_FFI_INLINE static std::string TypeStr() { return TObject::_type_key; }
+  TVM_FFI_INLINE static std::string TypeSchema() {
+    return "{\"type\":\"" + std::string(TObject::_type_key) + "\"}";
+  }
 };
 
 template <typename T>
@@ -785,6 +816,9 @@ struct TypeTraits<Optional<T>> : public TypeTraitsBase {
 
   TVM_FFI_INLINE static std::string TypeStr() {
     return "Optional<" + TypeTraits<T>::TypeStr() + ">";
+  }
+  TVM_FFI_INLINE static std::string TypeSchema() {
+    return "{\"type\":\"Optional\",\"args\":[" + details::TypeSchema<T>::v() + "]}";
   }
 };
 }  // namespace ffi

--- a/python/tvm_ffi/__init__.py
+++ b/python/tvm_ffi/__init__.py
@@ -30,6 +30,7 @@ from .registry import (
     register_object,
     register_global_func,
     get_global_func,
+    get_global_func_metadata,
     remove_global_func,
     init_ffi_api,
 )
@@ -71,6 +72,7 @@ __all__ = [
     "dtype",
     "from_dlpack",
     "get_global_func",
+    "get_global_func_metadata",
     "init_ffi_api",
     "load_module",
     "register_error",

--- a/python/tvm_ffi/core.pyi
+++ b/python/tvm_ffi/core.pyi
@@ -246,6 +246,17 @@ class Bytes(bytes, PyNativeObject):
 # Type reflection metadata (from cython/type_info.pxi)
 # ---------------------------------------------------------------------------
 
+class TypeSchema:
+    """Type schema for a TVM FFI type."""
+
+    origin: str
+    args: tuple[TypeSchema, ...] = ()
+
+    @staticmethod
+    def from_json_obj(obj: dict[str, Any]) -> TypeSchema: ...
+    @staticmethod
+    def from_json_str(s: str) -> TypeSchema: ...
+
 class TypeField:
     """Description of a single reflected field on an FFI-backed type."""
 
@@ -254,6 +265,7 @@ class TypeField:
     size: int
     offset: int
     frozen: bool
+    metadata: dict[str, Any]
     getter: Any
     setter: Any
     dataclass_field: Any | None
@@ -267,6 +279,7 @@ class TypeMethod:
     doc: str | None
     func: Any
     is_static: bool
+    metadata: dict[str, Any]
 
     def as_callable(self, cls: type) -> Callable[..., Any]: ...
 

--- a/python/tvm_ffi/registry.py
+++ b/python/tvm_ffi/registry.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from typing import Any, Callable, Literal, overload
 
@@ -58,6 +59,7 @@ def register_object(type_key: str | type | None = None) -> Callable[[type], type
             raise ValueError(f"Cannot find object type index for {object_name}")
         info = core._register_object_by_index(type_index, cls)
         _add_class_attrs(type_cls=cls, type_info=info)
+        setattr(cls, "__tvm_ffi_type_info__", info)
         return cls
 
     if isinstance(type_key, str):
@@ -199,6 +201,23 @@ def remove_global_func(name: str) -> None:
     get_global_func("ffi.FunctionRemoveGlobal")(name)
 
 
+def get_global_func_metadata(name: str) -> dict[str, Any]:
+    """Get the type schema string of a global function by name.
+
+    Parameters
+    ----------
+    name : str
+        The name of the global function
+
+    Returns
+    -------
+    metadata : dict
+        The metadata of the function
+
+    """
+    return json.loads(get_global_func("ffi.GetGlobalFuncMetadata")(name))
+
+
 def init_ffi_api(namespace: str, target_module_name: str | None = None) -> None:
     """Initialize register ffi api  functions into a given module.
 
@@ -265,6 +284,7 @@ def _add_class_attrs(type_cls: type, type_info: TypeInfo) -> type:
 
 __all__ = [
     "get_global_func",
+    "get_global_func_metadata",
     "init_ffi_api",
     "list_global_func_names",
     "register_global_func",

--- a/python/tvm_ffi/testing.py
+++ b/python/tvm_ffi/testing.py
@@ -122,3 +122,7 @@ class _TestCxxInitSubset:
     required_field: int
     optional_field: int = field(init=False)
     note: str = field(default_factory=lambda: "py-default", init=False)
+
+
+@register_object("testing.SchemaAllTypes")
+class _SchemaAllTypes: ...

--- a/src/ffi/extra/json_writer.cc
+++ b/src/ffi/extra/json_writer.cc
@@ -35,16 +35,6 @@
 #include <limits>
 #include <string>
 
-#ifdef _MSC_VER
-#define TVM_FFI_SNPRINTF _snprintf_s
-#pragma warning(push)
-#pragma warning(disable : 4244)
-#pragma warning(disable : 4127)
-#pragma warning(disable : 4702)
-#else
-#define TVM_FFI_SNPRINTF snprintf
-#endif
-
 namespace tvm {
 namespace ffi {
 namespace json {
@@ -188,41 +178,8 @@ class JSONWriter {
   }
 
   void WriteString(const String& value) {
-    *out_iter_++ = '"';
-    const char* data = value.data();
-    const size_t size = value.size();
-    for (size_t i = 0; i < size; ++i) {
-      switch (data[i]) {
-// handle escape characters per JSON spec(RFC 8259)
-#define HANDLE_ESCAPE_CHAR(pattern, val)                    \
-  case pattern:                                             \
-    WriteLiteral(val, std::char_traits<char>::length(val)); \
-    break
-        HANDLE_ESCAPE_CHAR('\"', "\\\"");
-        HANDLE_ESCAPE_CHAR('\\', "\\\\");
-        HANDLE_ESCAPE_CHAR('/', "\\/");
-        HANDLE_ESCAPE_CHAR('\b', "\\b");
-        HANDLE_ESCAPE_CHAR('\f', "\\f");
-        HANDLE_ESCAPE_CHAR('\n', "\\n");
-        HANDLE_ESCAPE_CHAR('\r', "\\r");
-        HANDLE_ESCAPE_CHAR('\t', "\\t");
-#undef HANDLE_ESCAPE_CHAR
-        default: {
-          uint8_t u8_val = static_cast<uint8_t>(data[i]);
-          // this is a control character, print as \uXXXX
-          if (u8_val < 0x20 || u8_val == 0x7f) {
-            char buffer[8];
-            int size = TVM_FFI_SNPRINTF(buffer, sizeof(buffer), "\\u%04x",
-                                        static_cast<int32_t>(data[i]) & 0xff);
-            WriteLiteral(buffer, size);
-          } else {
-            *out_iter_++ = data[i];
-          }
-          break;
-        }
-      }
-    }
-    *out_iter_++ = '"';
+    String escaped = EscapeString(value);
+    std::copy(escaped.data(), escaped.data() + escaped.size(), out_iter_);
   }
 
   void WriteArray(const json::Array& value) {
@@ -303,5 +260,3 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 }  // namespace json
 }  // namespace ffi
 }  // namespace tvm
-
-#undef TVM_FFI_SNPRINTF

--- a/src/ffi/function.cc
+++ b/src/ffi/function.cc
@@ -225,5 +225,12 @@ TVM_FFI_STATIC_INIT_BLOCK() {
              return tvm::ffi::Function::FromTyped(return_functor);
            })
       .def("ffi.String", [](tvm::ffi::String val) -> tvm::ffi::String { return val; })
-      .def("ffi.Bytes", [](tvm::ffi::Bytes val) -> tvm::ffi::Bytes { return val; });
+      .def("ffi.Bytes", [](tvm::ffi::Bytes val) -> tvm::ffi::Bytes { return val; })
+      .def("ffi.GetGlobalFuncMetadata", [](tvm::ffi::String name) -> tvm::ffi::String {
+        const auto* f = tvm::ffi::GlobalFunctionTable::Global()->Get(name);
+        if (f == nullptr) {
+          TVM_FFI_THROW(RuntimeError) << "Global Function is not found: " << name;
+        }
+        return f->metadata_data;
+      });
 }

--- a/tests/cpp/test_metadata.cc
+++ b/tests/cpp/test_metadata.cc
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <gtest/gtest.h>
+#include <tvm/ffi/c_api.h>
+#include <tvm/ffi/container/array.h>
+#include <tvm/ffi/container/map.h>
+#include <tvm/ffi/container/variant.h>
+#include <tvm/ffi/dtype.h>
+#include <tvm/ffi/extra/json.h>
+#include <tvm/ffi/function.h>
+#include <tvm/ffi/object.h>
+#include <tvm/ffi/optional.h>
+#include <tvm/ffi/reflection/accessor.h>
+#include <tvm/ffi/string.h>
+
+namespace {
+
+using namespace tvm::ffi;
+using namespace tvm::ffi::reflection;
+
+static std::string ParseMetadataToSchema(const String& metadata) {
+  return json::Parse(metadata)
+      .cast<Map<String, Any>>()["type_schema"]  //
+      .cast<String>();                          //
+}
+
+static std::string ParseMetadataToSchema(const TVMFFIByteArray& metadata) {
+  return json::Parse(String(metadata))
+      .cast<Map<String, Any>>()["type_schema"]  //
+      .cast<String>();                          //
+}
+
+TEST(Schema, GlobalFuncTypeSchema) {
+  // Helper to fetch global function type schema via the exposed utility
+  Function get_metadata = Function::GetGlobalRequired("ffi.GetGlobalFuncMetadata");
+  auto fetch = [&](const char* name) -> std::string {
+    String metadata = get_metadata(String(name)).cast<String>();
+    return ParseMetadataToSchema(metadata);
+  };
+  // Simple IDs
+  EXPECT_EQ(fetch("testing.schema_id_int"),
+            R"({"type":"ffi.Function","args":[{"type":"int"},{"type":"int"}]})");
+  EXPECT_EQ(fetch("testing.schema_id_float"),
+            R"({"type":"ffi.Function","args":[{"type":"float"},{"type":"float"}]})");
+  EXPECT_EQ(fetch("testing.schema_id_bool"),
+            R"({"type":"ffi.Function","args":[{"type":"bool"},{"type":"bool"}]})");
+  EXPECT_EQ(fetch("testing.schema_id_device"),
+            R"({"type":"ffi.Function","args":[{"type":"Device"},{"type":"Device"}]})");
+  EXPECT_EQ(fetch("testing.schema_id_dtype"),
+            R"({"type":"ffi.Function","args":[{"type":"DataType"},{"type":"DataType"}]})");
+  EXPECT_EQ(fetch("testing.schema_id_string"),
+            R"({"type":"ffi.Function","args":[{"type":"ffi.String"},{"type":"ffi.String"}]})");
+  EXPECT_EQ(fetch("testing.schema_id_bytes"),
+            R"({"type":"ffi.Function","args":[{"type":"ffi.Bytes"},{"type":"ffi.Bytes"}]})");
+  EXPECT_EQ(fetch("testing.schema_id_func"),
+            R"({"type":"ffi.Function","args":[{"type":"ffi.Function"},{"type":"ffi.Function"}]})");
+
+  EXPECT_EQ(fetch("testing.schema_id_any"),
+            R"({"type":"ffi.Function","args":[{"type":"Any"},{"type":"Any"}]})");
+  EXPECT_EQ(fetch("testing.schema_id_object"),
+            R"({"type":"ffi.Function","args":[{"type":"ffi.Object"},{"type":"ffi.Object"}]})");
+  EXPECT_EQ(fetch("testing.schema_id_dltensor"),
+            R"({"type":"ffi.Function","args":[{"type":"DLTensor*"},{"type":"DLTensor*"}]})");
+  EXPECT_EQ(fetch("testing.schema_id_tensor"),
+            R"({"type":"ffi.Function","args":[{"type":"ffi.Tensor"},{"type":"ffi.Tensor"}]})");
+  EXPECT_EQ(fetch("testing.schema_tensor_view_input"),
+            R"({"type":"ffi.Function","args":[{"type":"None"},{"type":"DLTensor*"}]})");
+  EXPECT_EQ(
+      fetch("testing.schema_id_opt_int"),
+      R"({"type":"ffi.Function","args":[{"type":"Optional","args":[{"type":"int"}]},{"type":"Optional","args":[{"type":"int"}]}]})");
+  EXPECT_EQ(
+      fetch("testing.schema_id_opt_str"),
+      R"({"type":"ffi.Function","args":[{"type":"Optional","args":[{"type":"ffi.String"}]},{"type":"Optional","args":[{"type":"ffi.String"}]}]})");
+  EXPECT_EQ(
+      fetch("testing.schema_id_opt_obj"),
+      R"({"type":"ffi.Function","args":[{"type":"Optional","args":[{"type":"ffi.Object"}]},{"type":"Optional","args":[{"type":"ffi.Object"}]}]})");
+  EXPECT_EQ(
+      fetch("testing.schema_id_arr_int"),
+      R"({"type":"ffi.Function","args":[{"type":"ffi.Array","args":[{"type":"int"}]},{"type":"ffi.Array","args":[{"type":"int"}]}]})");
+  EXPECT_EQ(
+      fetch("testing.schema_id_arr_str"),
+      R"({"type":"ffi.Function","args":[{"type":"ffi.Array","args":[{"type":"ffi.String"}]},{"type":"ffi.Array","args":[{"type":"ffi.String"}]}]})");
+  EXPECT_EQ(
+      fetch("testing.schema_id_arr_obj"),
+      R"({"type":"ffi.Function","args":[{"type":"ffi.Array","args":[{"type":"ffi.Object"}]},{"type":"ffi.Array","args":[{"type":"ffi.Object"}]}]})");
+  EXPECT_EQ(
+      fetch("testing.schema_id_map_str_int"),
+      R"({"type":"ffi.Function","args":[{"type":"ffi.Map","args":[{"type":"ffi.String"},{"type":"int"}]},{"type":"ffi.Map","args":[{"type":"ffi.String"},{"type":"int"}]}]})");
+  EXPECT_EQ(
+      fetch("testing.schema_id_map_str_str"),
+      R"({"type":"ffi.Function","args":[{"type":"ffi.Map","args":[{"type":"ffi.String"},{"type":"ffi.String"}]},{"type":"ffi.Map","args":[{"type":"ffi.String"},{"type":"ffi.String"}]}]})");
+  EXPECT_EQ(
+      fetch("testing.schema_id_map_str_obj"),
+      R"({"type":"ffi.Function","args":[{"type":"ffi.Map","args":[{"type":"ffi.String"},{"type":"ffi.Object"}]},{"type":"ffi.Map","args":[{"type":"ffi.String"},{"type":"ffi.Object"}]}]})");
+  EXPECT_EQ(
+      fetch("testing.schema_id_variant_int_str"),
+      R"({"type":"ffi.Function","args":[{"type":"Variant","args":[{"type":"int"},{"type":"ffi.String"}]},{"type":"Variant","args":[{"type":"int"},{"type":"ffi.String"}]}]})");
+
+  // Packed function registered via def_packed: schema is plain ffi.Function
+  EXPECT_EQ(fetch("testing.schema_packed"), R"({"type":"ffi.Function"})");
+
+  // Mixed containers and optionals
+  EXPECT_EQ(
+      fetch("testing.schema_arr_map_opt"),
+      R"({"type":"ffi.Function","args":[{"type":"ffi.Map","args":[{"type":"ffi.String"},{"type":"ffi.Array","args":[{"type":"int"}]}]},{"type":"ffi.Array","args":[{"type":"Optional","args":[{"type":"int"}]}]},{"type":"ffi.Map","args":[{"type":"ffi.String"},{"type":"ffi.Array","args":[{"type":"int"}]}]},{"type":"Optional","args":[{"type":"ffi.String"}]}]})");
+
+  EXPECT_EQ(
+      fetch("testing.schema_variant_mix"),
+      R"({"type":"ffi.Function","args":[{"type":"Variant","args":[{"type":"int"},{"type":"ffi.String"},{"type":"ffi.Array","args":[{"type":"int"}]}]},{"type":"Variant","args":[{"type":"int"},{"type":"ffi.String"},{"type":"ffi.Array","args":[{"type":"int"}]}]}]})");
+
+  // No-arg and no-return combinations
+  EXPECT_EQ(fetch("testing.schema_no_args"), R"({"type":"ffi.Function","args":[{"type":"int"}]})");
+  EXPECT_EQ(fetch("testing.schema_no_return"),
+            R"({"type":"ffi.Function","args":[{"type":"None"},{"type":"int"}]})");
+  EXPECT_EQ(fetch("testing.schema_no_args_no_return"),
+            R"({"type":"ffi.Function","args":[{"type":"None"}]})");
+}
+
+TEST(Schema, FieldTypeSchemas) {
+  // Validate type schema JSON on fields of testing.SchemaAllTypes
+  const char* kTypeKey = "testing.SchemaAllTypes";
+  // Helper to fetch a field's type schema by name
+  auto field_schema = [&](const char* field_name) -> std::string {
+    const TVMFFIFieldInfo* info = GetFieldInfo(kTypeKey, field_name);
+    return ParseMetadataToSchema(info->metadata);
+  };
+
+  EXPECT_EQ(field_schema("v_bool"), R"({"type":"bool"})");
+  EXPECT_EQ(field_schema("v_int"), R"({"type":"int"})");
+  EXPECT_EQ(field_schema("v_float"), R"({"type":"float"})");
+  EXPECT_EQ(field_schema("v_device"), R"({"type":"Device"})");
+  EXPECT_EQ(field_schema("v_dtype"), R"({"type":"DataType"})");
+  EXPECT_EQ(field_schema("v_string"), R"({"type":"ffi.String"})");
+  EXPECT_EQ(field_schema("v_bytes"), R"({"type":"ffi.Bytes"})");
+  EXPECT_EQ(field_schema("v_opt_int"), R"({"type":"Optional","args":[{"type":"int"}]})");
+  EXPECT_EQ(field_schema("v_opt_str"), R"({"type":"Optional","args":[{"type":"ffi.String"}]})");
+  EXPECT_EQ(field_schema("v_arr_int"), R"({"type":"ffi.Array","args":[{"type":"int"}]})");
+  EXPECT_EQ(field_schema("v_arr_str"), R"({"type":"ffi.Array","args":[{"type":"ffi.String"}]})");
+  EXPECT_EQ(field_schema("v_map_str_int"),
+            R"({"type":"ffi.Map","args":[{"type":"ffi.String"},{"type":"int"}]})");
+  EXPECT_EQ(
+      field_schema("v_map_str_arr_int"),
+      R"({"type":"ffi.Map","args":[{"type":"ffi.String"},{"type":"ffi.Array","args":[{"type":"int"}]}]})");
+  EXPECT_EQ(
+      field_schema("v_variant"),
+      R"({"type":"Variant","args":[{"type":"ffi.String"},{"type":"ffi.Array","args":[{"type":"int"}]},{"type":"ffi.Map","args":[{"type":"ffi.String"},{"type":"int"}]}]})");
+  EXPECT_EQ(
+      field_schema("v_opt_arr_variant"),
+      R"({"type":"Optional","args":[{"type":"ffi.Array","args":[{"type":"Variant","args":[{"type":"int"},{"type":"ffi.String"}]}]}]})");
+}
+
+TEST(Schema, MethodTypeSchemas) {
+  const char* kTypeKey = "testing.SchemaAllTypes";
+  auto method_schema = [&](const char* method_name) -> std::string {
+    const TVMFFIMethodInfo* info = GetMethodInfo(kTypeKey, method_name);
+    return ParseMetadataToSchema(info->metadata);
+  };
+
+  // Instance methods
+  EXPECT_EQ(method_schema("add_int"),
+            R"({"type":"ffi.Function","args":[{"type":"int"},{"type":"int"}]})");
+  EXPECT_EQ(
+      method_schema("append_int"),
+      R"({"type":"ffi.Function","args":[{"type":"ffi.Array","args":[{"type":"int"}]},{"type":"ffi.Array","args":[{"type":"int"}]},{"type":"int"}]})");
+  EXPECT_EQ(
+      method_schema("maybe_concat"),
+      R"({"type":"ffi.Function","args":[{"type":"Optional","args":[{"type":"ffi.String"}]},{"type":"Optional","args":[{"type":"ffi.String"}]},{"type":"Optional","args":[{"type":"ffi.String"}]}]})");
+  EXPECT_EQ(
+      method_schema("merge_map"),
+      R"({"type":"ffi.Function","args":[{"type":"ffi.Map","args":[{"type":"ffi.String"},{"type":"ffi.Array","args":[{"type":"int"}]}]},{"type":"ffi.Map","args":[{"type":"ffi.String"},{"type":"ffi.Array","args":[{"type":"int"}]}]},{"type":"ffi.Map","args":[{"type":"ffi.String"},{"type":"ffi.Array","args":[{"type":"int"}]}]}]})");
+
+  // Static method make_with: return type is the object type itself.
+  // Build expected JSON as ffi.Function with return type = type_key and args = (int, float, str)
+  EXPECT_EQ(
+      method_schema("make_with"),
+      R"({"type":"ffi.Function","args":[{"type":"testing.SchemaAllTypes"},{"type":"int"},{"type":"float"},{"type":"ffi.String"}]})");
+}
+
+}  // namespace

--- a/tests/python/test_metadata.py
+++ b/tests/python/test_metadata.py
@@ -1,0 +1,157 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Any
+
+import pytest
+from tvm_ffi import get_global_func_metadata
+from tvm_ffi.core import TypeInfo, TypeSchema
+from tvm_ffi.testing import _SchemaAllTypes
+
+
+@pytest.mark.parametrize(
+    "func_name,expected",
+    [
+        ("testing.schema_id_int", "Callable[[int], int]"),
+        ("testing.schema_id_float", "Callable[[float], float]"),
+        ("testing.schema_id_bool", "Callable[[bool], bool]"),
+        ("testing.schema_id_device", "Callable[[Device], Device]"),
+        ("testing.schema_id_dtype", "Callable[[DataType], DataType]"),
+        ("testing.schema_id_string", "Callable[[str], str]"),
+        ("testing.schema_id_bytes", "Callable[[bytes], bytes]"),
+        ("testing.schema_id_func", "Callable[[Callable[..., Any]], Callable[..., Any]]"),
+        ("testing.schema_id_any", "Callable[[Any], Any]"),
+        ("testing.schema_id_object", "Callable[[Object], Object]"),
+        ("testing.schema_id_dltensor", "Callable[[Tensor], Tensor]"),
+        ("testing.schema_id_tensor", "Callable[[Tensor], Tensor]"),
+        ("testing.schema_tensor_view_input", "Callable[[Tensor], None]"),
+        ("testing.schema_id_opt_int", "Callable[[int | None], int | None]"),
+        ("testing.schema_id_opt_str", "Callable[[str | None], str | None]"),
+        ("testing.schema_id_opt_obj", "Callable[[Object | None], Object | None]"),
+        ("testing.schema_id_arr_int", "Callable[[list[int]], list[int]]"),
+        ("testing.schema_id_arr_str", "Callable[[list[str]], list[str]]"),
+        ("testing.schema_id_arr_obj", "Callable[[list[Object]], list[Object]]"),
+        ("testing.schema_id_map_str_int", "Callable[[dict[str, int]], dict[str, int]]"),
+        ("testing.schema_id_map_str_str", "Callable[[dict[str, str]], dict[str, str]]"),
+        ("testing.schema_id_map_str_obj", "Callable[[dict[str, Object]], dict[str, Object]]"),
+        ("testing.schema_id_variant_int_str", "Callable[[int | str], int | str]"),
+        ("testing.schema_packed", "Callable[..., Any]"),
+        (
+            "testing.schema_arr_map_opt",
+            "Callable[[list[int | None], dict[str, list[int]], str | None], dict[str, list[int]]]",
+        ),
+        ("testing.schema_variant_mix", "Callable[[int | str | list[int]], int | str | list[int]]"),
+        ("testing.schema_no_args", "Callable[[], int]"),
+        ("testing.schema_no_return", "Callable[[int], None]"),
+        ("testing.schema_no_args_no_return", "Callable[[], None]"),
+    ],
+)
+def test_schema_global_func(func_name: str, expected: str) -> None:
+    metadata: dict[str, Any] = get_global_func_metadata(func_name)
+    actual: TypeSchema = TypeSchema.from_json_str(metadata["type_schema"])
+    assert str(actual) == expected, f"{func_name}: {actual}"
+
+
+@pytest.mark.parametrize(
+    "field_name,expected",
+    [
+        ("v_bool", "bool"),
+        ("v_int", "int"),
+        ("v_float", "float"),
+        ("v_device", "Device"),
+        ("v_dtype", "DataType"),
+        ("v_string", "str"),
+        ("v_bytes", "bytes"),
+        ("v_opt_int", "int | None"),
+        ("v_opt_str", "str | None"),
+        ("v_arr_int", "list[int]"),
+        ("v_arr_str", "list[str]"),
+        ("v_map_str_int", "dict[str, int]"),
+        ("v_map_str_arr_int", "dict[str, list[int]]"),
+        ("v_variant", "str | list[int] | dict[str, int]"),
+        ("v_opt_arr_variant", "list[int | str] | None"),
+    ],
+)
+def test_schema_field(field_name: str, expected: str) -> None:
+    type_info: TypeInfo = getattr(_SchemaAllTypes, "__tvm_ffi_type_info__")
+    for field in type_info.fields:
+        if field.name == field_name:
+            actual: TypeSchema = TypeSchema.from_json_str(field.metadata["type_schema"])
+            assert str(actual) == expected, f"{field_name}: {actual}"
+            break
+    else:
+        raise ValueError(f"Field not found: {field_name}")
+
+
+@pytest.mark.parametrize(
+    "method_name,expected",
+    [
+        ("add_int", "Callable[[int], int]"),
+        ("append_int", "Callable[[list[int], int], list[int]]"),
+        ("maybe_concat", "Callable[[str | None, str | None], str | None]"),
+        (
+            "merge_map",
+            "Callable[[dict[str, list[int]], dict[str, list[int]]], dict[str, list[int]]]",
+        ),
+        ("make_with", "Callable[[int, float, str], testing.SchemaAllTypes]"),
+    ],
+)
+def test_schema_member_method(method_name: str, expected: str) -> None:
+    type_info: TypeInfo = getattr(_SchemaAllTypes, "__tvm_ffi_type_info__")
+    for method in type_info.methods:
+        if method.name == method_name:
+            actual: TypeSchema = TypeSchema.from_json_str(method.metadata["type_schema"])
+            assert str(actual) == expected, f"{method_name}: {actual}"
+            break
+    else:
+        raise ValueError(f"Method not found: {method_name}")
+
+
+def test_metadata_global_func() -> None:
+    metadata: dict[str, Any] = get_global_func_metadata("testing.schema_id_int")
+    assert len(metadata) == 4
+    assert "type_schema" in metadata
+    assert metadata["bool_attr"] is True
+    assert metadata["int_attr"] == 1
+    assert metadata["str_attr"] == "hello"
+
+
+def test_metadata_field() -> None:
+    type_info: TypeInfo = getattr(_SchemaAllTypes, "__tvm_ffi_type_info__")
+    for field in type_info.fields:
+        if field.name == "v_bool":
+            assert len(field.metadata) == 4
+            assert "type_schema" in field.metadata
+            assert field.metadata["bool_attr"] is True
+            assert field.metadata["int_attr"] == 1
+            assert field.metadata["str_attr"] == "hello"
+            break
+    else:
+        raise ValueError("Field not found: v_bool")
+
+
+def test_metadata_member_method() -> None:
+    type_info: TypeInfo = getattr(_SchemaAllTypes, "__tvm_ffi_type_info__")
+    for method in type_info.methods:
+        if method.name == "add_int":
+            assert len(method.metadata) == 4
+            assert "type_schema" in method.metadata
+            assert method.metadata["bool_attr"] is True
+            assert method.metadata["int_attr"] == 1
+            assert method.metadata["str_attr"] == "hello"
+            break
+    else:
+        raise ValueError("Method not found: add_int")


### PR DESCRIPTION
This PR introduces to TVM-FFI's registry a metadata mechanism, which allows to expose metadata attached to global functions, object fields and object member functions. As part of metadata, this PR generates a JSON-based type schema exposed in both C++ and Python APIs.

This enhancement provides richer, machine-readable type information, which can be invaluable for tooling, static analysis, and dynamic dispatch mechanisms built on top of the TVM FFI.

**Key Changes:**

[C++] JSON-based schema generation `tvm::ffi::details::TypeSchema<T>`, which supports:
- Fundamental types, e.g., `int`, `float`, `bool`, `String`, `Bytes`, `DLDataType`, `DLDevice`
- Complex container types, e.g., `Array<T>`, `Map<K, V>`, `Optional<T>`, `Tuple<Args...>`, `Variant<Args...>`
- Typed and type-erased functions, e.g. `Callable`, `Callable[[Args...], Ret]`.

[C++] Trait class `tvm::ffi::reflection::Metadata` is introduced, allowing arbitrary key-value pairs to be attached to fields and methods during registration. Example:
 
```C++
TVM_FFI_STATIC_INIT_BLOCK() {
  GlobalDef()
      .def("my_add", my_add_func,
           Metadata{{"description", "Adds two integers"}, {"version", 1}});
}
```

[Python] `tvm_ffi.core.TypeField` and `tvm_ffi.core.TypeMethod` now include a `metadata: dict[str, Any]` dictionary, making the attached JSON metadata accessible from Python.

[Python] A new `tvm_ffi.core.TypeSchema` class is added, capable of parsing the JSON schema strings into a structured Python object, providing a more convenient way to inspect type information.

```python
schema_str: str = "{\"type\":\"ffi.Function\",\"args\":[{\"type\":\"int\"},{\"type\":\"int\"}]}"
schema_obj: TypeSchema = TypeSchema.from_json_str(schema_str)
print(schema_obj)
# Callable[[int], int]
```

[Python] A new Python function `tvm_ffi.get_global_func_metadata(name: str)` is exposed to retrieve the full metadata (including `type_schema`) for any registered global function.

```python
# (Assuming 'testing.schema_id_int' is registered in C++ as in src/ffi/extra/testing.cc)
metadata: dict[str, Any] = get_global_func_metadata("testing.schema_id_int")
# metadata will contain:
# {
#   "type_schema": "{\"type\":\"ffi.Function\",\"args\":[{\"type\":\"int\"},{\"type\":\"int\"}]}",
#   "bool_attr": True,
#   "int_attr": 1,
#   "str_attr": "hello"
# }
```

Internal Utilities
- A new `tvm::ffi::EscapeString` utility is added for proper string escaping.
- `FieldInfoBuilder` and `MethodInfoBuilder` are added to temporarily hold this metadata before it's serialized into the `TVMFFIFieldInfo` and `TVMFFIMethodInfo` C structs.
