### PR TITLE
fix(c_class): Fix mypy warnings on `dataclasses.field(...)`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 keywords = ["machine learning", "inference"]
 requires-python = ">=3.9"
-dependencies = []
+dependencies = ["typing-extensions"]
 
 [project.urls]
 Homepage = "https://github.com/apache/tvm-ffi"

--- a/python/tvm_ffi/testing.py
+++ b/python/tvm_ffi/testing.py
@@ -103,5 +103,5 @@ class _TestCxxClassDerived(_TestCxxClassBase):
 
 @c_class("testing.TestCxxClassDerivedDerived")
 class _TestCxxClassDerivedDerived(_TestCxxClassDerived):
-    v_str: str = field(default_factory=lambda: "default")  # type: ignore[assignment]
-    v_bool: bool  # type: ignore[misc]
+    v_str: str = field(default_factory=lambda: "default")
+    v_bool: bool  # type: ignore[misc]  # Suppress: Attributes without a default cannot follow attributes with one


### PR DESCRIPTION
Previously when defining a `c_class`, when RHS invokes a `dataclasses.field(...)`, as exemplified below:

```python
v_str: str = field(default_factory=lambda: "default") 
```

we will get a warning saying

```
error: Incompatible types in assignment (expression has type "Field", variable has type "str")  [assignment]
```

This PR fixes this issue