### PR TITLE
fix(Map): `Map.get` should never throw when element is missing

### DIFF
--- a/include/tvm/ffi/container/map.h
+++ b/include/tvm/ffi/container/map.h
@@ -691,7 +691,7 @@ class DenseMapObj : public MapObj {
   mapped_type& At(const key_type& key) const {
     ListNode iter = Search(key);
     if (iter.IsNone()) {
-      TVM_FFI_THROW(IndexError) << "key is not in Map";
+      TVM_FFI_THROW(KeyError) << "key is not in Map";
     }
     return iter.Val();
   }

--- a/tests/python/test_container.py
+++ b/tests/python/test_container.py
@@ -124,3 +124,9 @@ def test_serialization() -> None:
     a = tvm_ffi.convert([1, 2, 3])
     b = pickle.loads(pickle.dumps(a))
     assert str(b) == "[1, 2, 3]"
+
+
+def test_large_map_get() -> None:
+    amap = tvm_ffi.convert({k: k**2 for k in range(100)})
+    assert amap.get(101) is None
+    assert amap.get(3) == 9


### PR DESCRIPTION
This PR fixes missing element handling within `Map` by correcting the exception type thrown from `IndexError` to `KeyError`. Additionally, it introduces a new test to confirm that the `Map.get` method behaves as expected, i.e. returning `None` for absent keys.