### PR TITLE
fix: Cython Memory Corruption Reported by ASan

### DIFF
--- a/python/tvm_ffi/cython/object.pxi
+++ b/python/tvm_ffi/cython/object.pxi
@@ -303,8 +303,9 @@ def _type_info_create_from_type_key(object type_cls, str type_key):
     cdef object methods = []
     cdef FieldGetter getter
     cdef FieldSetter setter
+    cdef ByteArrayArg type_key_arg = ByteArrayArg(c_str(type_key))
 
-    if TVMFFITypeKeyToIndex(ByteArrayArg(c_str(type_key)).cptr(), &type_index) != 0:
+    if TVMFFITypeKeyToIndex(type_key_arg.cptr(), &type_index) != 0:
         raise ValueError(f"Cannot find type key: {type_key}")
     info = TVMFFIGetTypeInfo(type_index)
     for i in range(info.num_fields):


### PR DESCRIPTION
This PR addresses a memory corruption issue in Cython. The fix involves ensuring that the `ByteArrayArg` object, which holds the type key, is properly destructed after being passed to the `TVMFFITypeKeyToIndex` function. This prevents a potential read-after-free scenario, as reported by ASan.

## ASan Report

```
READ of size 9 at 0x604000420a30 thread T0
    ...
    #5 0x7fdb57299506 in __pyx_f_4core__type_info_create_from_type_key /home/dolores/Projects/tvm-ffi/build/core.cpp:17732
    ...

0x604000420a30 is located 32 bytes inside of 42-byte region [0x604000420a10,0x604000420a3a)
freed by thread T0 here:
    ...
    #4 0x7fdb572994e2 in __pyx_f_4core__type_info_create_from_type_key /home/dolores/Projects/tvm-ffi/build/core.cpp:17731
   ...

previously allocated by thread T0 here:
    ...
    #8 0x7fdb57299366 in __pyx_f_4core__type_info_create_from_type_key /home/dolores/Projects/tvm-ffi/build/core.cpp:17718
```

<img width="1444" height="904" alt="image" src="https://github.com/user-attachments/assets/7a80d33d-dedf-41ca-ac77-108e63b8e57b" />

## Recommended ASan Options

One will need to preload `libasan` to properly work with CPython, and `libstdc++` to properly intercept `__cxa_throw`. The path to those two files can be found using:

```
ASAN="$(gcc -print-file-name=libasan.so)"
STDCXX="$(g++ -print-file-name=libstdc++.so.6)"
LD_PRELOAD="$ASAN $STDCXX"
```

Additionally, it might be helpful to tweak 

```
PYTHONMALLOC=malloc
```

and run with ASan options

```
ASAN_OPTIONS="detect_leaks=0:abort_on_error=1:symbolize=1:fast_unwind_on_malloc=0"
```

Notably, turning on `detect_leaks=1` will lead to bunch of irrelevant noisy reports. Better turning it off.