### PR TITLE
fix: Type mismatch aborts on OpaquePyObject

### DIFF
--- a/include/tvm/ffi/object.h
+++ b/include/tvm/ffi/object.h
@@ -110,6 +110,8 @@ struct StaticTypeKey {
   static constexpr const char* kTVMFFIMap = "ffi.Map";
   /*! \brief The type key for Module */
   static constexpr const char* kTVMFFIModule = "ffi.Module";
+  /*! \brief The type key for OpaquePyObject */
+  static constexpr const char* kTVMFFIOpaquePyObject = "ffi.OpaquePyObject";
 };
 
 /*!

--- a/python/tvm_ffi/testing.py
+++ b/python/tvm_ffi/testing.py
@@ -89,6 +89,11 @@ def make_unregistered_object() -> Object:
     return get_global_func("testing.make_unregistered_object")()
 
 
+def add_one(x: int) -> int:
+    """Add one to the input integer."""
+    return get_global_func("testing.add_one")(x)
+
+
 @c_class("testing.TestCxxClassBase")
 class _TestCxxClassBase:
     v_i64: int

--- a/src/ffi/extra/testing.cc
+++ b/src/ffi/extra/testing.cc
@@ -191,6 +191,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 
   refl::GlobalDef()
       .def("testing.test_raise_error", TestRaiseError)
+      .def("testing.add_one", [](int x) { return x + 1; })
       .def_packed("testing.nop", [](PackedArgs args, Any* ret) {})
       .def_packed("testing.echo", [](PackedArgs args, Any* ret) { *ret = args[0]; })
       .def_packed("testing.apply", TestApply)

--- a/src/ffi/object.cc
+++ b/src/ffi/object.cc
@@ -29,7 +29,6 @@
 #include <tvm/ffi/string.h>
 
 #include <memory>
-#include <string>
 #include <utility>
 #include <vector>
 
@@ -340,6 +339,7 @@ class TypeTable {
                             TypeIndex::kTVMFFIObjectRValueRef);
     ReserveBuiltinTypeIndex(StaticTypeKey::kTVMFFISmallStr, TypeIndex::kTVMFFISmallStr);
     ReserveBuiltinTypeIndex(StaticTypeKey::kTVMFFISmallBytes, TypeIndex::kTVMFFISmallBytes);
+    ReserveBuiltinTypeIndex(StaticTypeKey::kTVMFFIOpaquePyObject, TypeIndex::kTVMFFIOpaquePyObject);
     // no need to reserve for object types as they will be registered
   }
 

--- a/tests/python/test_object.py
+++ b/tests/python/test_object.py
@@ -102,6 +102,16 @@ def test_opaque_object() -> None:
     assert sys.getrefcount(obj0) == 2
 
 
+def test_opaque_type_error() -> None:
+    obj0 = MyObject("hello")
+    with pytest.raises(TypeError) as e:
+        tvm_ffi.testing.add_one(obj0)  # type: ignore[arg-type]
+    assert (
+        "Mismatched type on argument #0 when calling: `testing.add_one(0: int) -> int`. Expected `int` but got `ffi.OpaquePyObject`"
+        in str(e.value)
+    )
+
+
 def test_unregistered_object_fallback() -> None:
     with pytest.warns(
         UserWarning,


### PR DESCRIPTION
In [#49](https://github.com/apache/tvm-ffi/pull/49#issuecomment-3331042097), We noticed an issue with `OpaquePyObject`:

```
Exception caught during TVMFFIGetTypeInfo:
Traceback (most recent call last):
  File "include/tvm/ffi/type_traits.h", line 92, in tvm::ffi::TypeTraitsBase::GetMismatchTypeInfo[abi:cxx11](TVMFFIAny const*)
  File "include/tvm/ffi/object.h", line 121, in tvm::ffi::TypeIndexToTypeKey[abi:cxx11](int)
  File "src/ffi/object.cc", line 493, in TVMFFIGetTypeInfo
  File "src/ffi/object.cc", line 193, in tvm::ffi::TypeTable::Entry* tvm::ffi::TypeTable::GetTypeEntry(int32_t)
InternalError: Check failed: (entry != nullptr) is false: Cannot find type info for type_index=74
```

where when an `OpaquePyObject` is fed into a TVM-FFI function, which expects a different type (e.g. `int`), the entire program aborts without proper error message inside `TVMFFIGetTypeInfo`, which uses `exit(1)` instead of C error code.

This PR fixes this issue by registering `TypeIndex::kTVMFFIOpaquePyObject` as a builtin type index. 

