### PR TITLE
fix: Only attach docstring when it's defined

### DIFF
--- a/src/ffi/extra/testing.cc
+++ b/src/ffi/extra/testing.cc
@@ -58,8 +58,8 @@ class TestIntPair : public tvm::ffi::ObjectRef {
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   refl::ObjectDef<TestIntPairObj>()
-      .def_ro("a", &TestIntPairObj::a)
-      .def_ro("b", &TestIntPairObj::b)
+      .def_ro("a", &TestIntPairObj::a, "Field `a`")
+      .def_ro("b", &TestIntPairObj::b, "Field `b`")
       .def_static("__ffi_init__", refl::init<TestIntPairObj, int64_t, int64_t>);
 }
 

--- a/tests/python/test_object.py
+++ b/tests/python/test_object.py
@@ -45,6 +45,14 @@ def test_method() -> None:
     assert type(obj0).v_i64.__doc__ == "i64 field"  # type: ignore[attr-defined]
 
 
+def test_attribute() -> None:
+    obj = tvm_ffi.testing.TestIntPair(3, 4)
+    assert obj.a == 3
+    assert obj.b == 4
+    assert type(obj).a.__doc__ == "Field `a`"
+    assert type(obj).b.__doc__ == "Field `b`"
+
+
 def test_setter() -> None:
     # test setter
     obj0 = tvm_ffi.testing.create_object("testing.TestObjectBase", v_i64=10, v_str="hello")


### PR DESCRIPTION
PR #49 introduced a behavior that generates a default docstring if it's not available. However, it seems to conflict with upstream Sphinx doc generation. This PR reverts such behavior.