### PR TITLE
[VERSION] Expose version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,16 @@ repos:
         language_version: python3
         pass_filenames: false
         verbose: false
+  - repo: local
+    hooks:
+      - id: check-version
+        name: check version
+        entry: python tests/lint/check_version.py
+        language: python
+        language_version: python3
+        pass_filenames: false
+        verbose: false
+        additional_dependencies: [tomli]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@
 
 [project]
 name = "apache-tvm-ffi"
-version = "0.1.0b8"
+version = "0.1.0b9"
 description = "tvm ffi"
 
 authors = [{ name = "TVM FFI team" }]

--- a/python/tvm_ffi/__init__.py
+++ b/python/tvm_ffi/__init__.py
@@ -16,6 +16,9 @@
 # under the License.
 """TVM FFI Python package."""
 
+# version
+__version__ = "0.1.0b9"
+
 # order matters here so we need to skip isort here
 # isort: skip_file
 # base always go first to load the libtvm_ffi
@@ -60,6 +63,7 @@ __all__ = [
     "ObjectConvertible",
     "Shape",
     "Tensor",
+    "__version__",
     "access_path",
     "convert",
     "dataclasses",

--- a/tests/lint/check_version.py
+++ b/tests/lint/check_version.py
@@ -1,0 +1,89 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Helper tool to check version consistency between pyproject.toml and __init__.py."""
+
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+import tomli
+
+
+def read_pyproject_version(pyproject_path: Path) -> Optional[str]:
+    """Read version from pyproject.toml."""
+    with pyproject_path.open("rb") as f:
+        data = tomli.load(f)
+
+    return data.get("project", {}).get("version")
+
+
+def read_init_version(init_path: Path) -> Optional[str]:
+    """Read __version__ from __init__.py."""
+    with init_path.open(encoding="utf-8") as f:
+        content = f.read()
+
+    # Look for __version__ = "..." pattern
+    match = re.search(r'__version__\s*=\s*["\']([^"\']+)["\']', content)
+    if match:
+        return match.group(1)
+    return None
+
+
+def update_init_version(init_path: Path, new_version: str) -> bool:
+    """Update __version__ in __init__.py."""
+    with init_path.open(encoding="utf-8") as f:
+        content = f.read()
+
+    # Replace the version line
+    new_content = re.sub(
+        r'__version__\s*=\s*["\'][^"\']+["\']', f'__version__ = "{new_version}"', content
+    )
+
+    with init_path.open("w", encoding="utf-8") as f:
+        f.write(new_content)
+
+    return True
+
+
+def main() -> int:
+    """Execute the main function."""
+    # Hardcoded paths
+    pyproject_path = Path("pyproject.toml")
+    init_path = Path("python/tvm_ffi/__init__.py")
+
+    # Read versions
+    pyproject_version = read_pyproject_version(pyproject_path)
+    init_version = read_init_version(init_path)
+
+    if pyproject_version is None or init_version is None:
+        return 1
+
+    if pyproject_version == init_version:
+        print("Version check passed!")
+        return 0
+    else:
+        print("Version check failed!")
+        print(f"pyproject.toml version: {pyproject_version}")
+        print(f"__init__.py version: {init_version}")
+        print("Run precommit locally to fix the version.")
+        update_init_version(init_path, pyproject_version)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR exposes the version. Because we need version to communicate changes, so we still rely on manual management for now based on pyproject.toml

Added a precheck hook so the version stays synced and use pyproject.toml as source of truth.