### PR TITLE
[MEMORY] Use raw alloc for allocator

### DIFF
--- a/include/tvm/ffi/memory.h
+++ b/include/tvm/ffi/memory.h
@@ -26,12 +26,12 @@
 #include <tvm/ffi/object.h>
 
 #include <cstdlib>
+#include <cstddef>
 #include <type_traits>
 #include <utility>
 
 namespace tvm {
 namespace ffi {
-
 /*! \brief Deleter function for obeject */
 typedef void (*FObjectDeleter)(void* obj, int flags);
 
@@ -45,6 +45,47 @@ typedef void (*FObjectDeleter)(void* obj, int flags);
 // - Thread-local object pools: one pool per size and alignment requirement.
 // - Can specialize by type of object to give the specific allocator to each object.
 namespace details {
+
+/*!
+ * \brief Allocate aligned memory.
+ * \param size The size.
+ * \tparam align The alignment.
+ * \return The pointer to the allocated memory.
+ */
+template <size_t align>
+TVM_FFI_INLINE void* AlignedAlloc(size_t size) {
+#ifdef _MSC_VER
+  // MSVC have to use _aligned_malloc
+  return _aligned_malloc(size, align);
+#else
+  if constexpr (align <= alignof(std::max_align_t)) {
+    // malloc guarantees alignment of std::max_align_t
+    return std::malloc(size);
+  } else {
+    // for other alignments, use posix_memalign
+    void* ptr;
+    int ret = posix_memalign(&ptr, align, size);
+    if (ret != 0) {
+      throw std::bad_alloc();
+    }
+    return ptr;
+  }
+#endif
+}
+
+/*!
+ * \brief Free aligned memory.
+ * \param data The pointer to the memory to free.
+ */
+TVM_FFI_INLINE void AlignedFree(void* data) {
+#ifdef _MSC_VER
+  // MSVC have to use _aligned_free
+  _aligned_free(data);
+#else
+  std::free(data);
+#endif
+}
+
 /*!
  * \brief Base class of object allocators that implements make.
  *  Use curiously recurring template pattern.
@@ -100,10 +141,6 @@ class SimpleObjAllocator : public ObjAllocatorBase<SimpleObjAllocator> {
   template <typename T>
   class Handler {
    public:
-    struct alignas(T) StorageType {
-      char data[sizeof(T)];
-    };
-
     template <typename... Args>
     static T* New(SimpleObjAllocator*, Args&&... args) {
       // NOTE: the first argument is not needed for SimpleObjAllocator
@@ -119,7 +156,7 @@ class SimpleObjAllocator : public ObjAllocatorBase<SimpleObjAllocator> {
       // class with non-virtual destructor.
       // We are fine here as we captured the right deleter during construction.
       // This is also the right way to get storage type for an object pool.
-      StorageType* data = new StorageType();
+      void* data = AlignedAlloc<alignof(T)>(sizeof(T));
       new (data) T(std::forward<Args>(args)...);
       return reinterpret_cast<T*>(data);
     }
@@ -138,7 +175,7 @@ class SimpleObjAllocator : public ObjAllocatorBase<SimpleObjAllocator> {
         tptr->T::~T();
       }
       if (flags & kTVMFFIObjectDeleterFlagBitMaskWeak) {
-        delete reinterpret_cast<StorageType*>(tptr);
+        AlignedFree(static_cast<void*>(tptr));
       }
     }
   };
@@ -147,12 +184,6 @@ class SimpleObjAllocator : public ObjAllocatorBase<SimpleObjAllocator> {
   template <typename ArrayType, typename ElemType>
   class ArrayHandler {
    public:
-    using StorageType = typename std::aligned_storage<sizeof(ArrayType), alignof(ArrayType)>::type;
-    // for now only support elements that aligns with array header.
-    static_assert(alignof(ArrayType) % alignof(ElemType) == 0 &&
-                      sizeof(ArrayType) % alignof(ElemType) == 0,
-                  "element alignment constraint");
-
     template <typename... Args>
     static ArrayType* New(SimpleObjAllocator*, size_t num_elems, Args&&... args) {
       // NOTE: the first argument is not needed for ArrayObjAllocator
@@ -167,10 +198,17 @@ class SimpleObjAllocator : public ObjAllocatorBase<SimpleObjAllocator> {
       // class with non-virtual destructor.
       // We are fine here as we captured the right deleter during construction.
       // This is also the right way to get storage type for an object pool.
-      size_t unit = sizeof(StorageType);
-      size_t requested_size = num_elems * sizeof(ElemType) + sizeof(ArrayType);
-      size_t num_storage_slots = (requested_size + unit - 1) / unit;
-      StorageType* data = new StorageType[num_storage_slots];
+
+      // for now only support elements that aligns with array header.
+      static_assert(
+          alignof(ArrayType) % alignof(ElemType) == 0 && sizeof(ArrayType) % alignof(ElemType) == 0,
+          "element alignment constraint");
+      size_t size = sizeof(ArrayType) + sizeof(ElemType) * num_elems;
+      // round up to the nearest multiple of align
+      constexpr size_t align = alignof(ArrayType);
+      static_assert(align != 0 && (align & (align - 1)) == 0, "align must be a power of 2");
+      size_t aligned_size = (size + (align - 1)) & ~(align - 1);
+      void* data = AlignedAlloc<align>(aligned_size);
       new (data) ArrayType(std::forward<Args>(args)...);
       return reinterpret_cast<ArrayType*>(data);
     }
@@ -189,8 +227,7 @@ class SimpleObjAllocator : public ObjAllocatorBase<SimpleObjAllocator> {
         tptr->ArrayType::~ArrayType();
       }
       if (flags & kTVMFFIObjectDeleterFlagBitMaskWeak) {
-        StorageType* p = reinterpret_cast<StorageType*>(tptr);
-        delete[] p;
+        AlignedFree(static_cast<void*>(tptr));
       }
     }
   };


### PR DESCRIPTION
This PR updates the memory allocator to use raw aligned alloc for allocation. The change likely can help to improve the total size allocated in inplace array where previously it needs to be multiple of ArrayType, it now only have to multiple of align type.