### PR TITLE
[ERROR] Place ErrorKind second in error handling

### DIFF
--- a/include/tvm/ffi/error.h
+++ b/include/tvm/ffi/error.h
@@ -362,7 +362,7 @@ TVM_FFI_CHECK_FUNC(_NE, !=)
 #define TVM_FFI_ICHECK(x) \
   if (!(x)) TVM_FFI_THROW(InternalError) << "Check failed: (" #x << ") is false: "
 
-#define TVM_FFI_CHECK(ErrorKind, cond) \
+#define TVM_FFI_CHECK(cond, ErrorKind) \
   if (!(cond)) TVM_FFI_THROW(ErrorKind) << "Check failed: (" #cond << ") is false: "
 
 #define TVM_FFI_ICHECK_LT(x, y) TVM_FFI_ICHECK_BINARY_OP(_LT, <, x, y)

--- a/tests/cpp/test_error.cc
+++ b/tests/cpp/test_error.cc
@@ -66,7 +66,7 @@ TEST(CheckError, ValueError) {
   EXPECT_THROW(
       {
         try {
-          TVM_FFI_CHECK(ValueError, value >= 0) << "Value must be non-negative, got " << value;
+          TVM_FFI_CHECK(value >= 0, ValueError) << "Value must be non-negative, got " << value;
         } catch (const Error& error) {
           EXPECT_EQ(error.kind(), "ValueError");
           std::string what = error.what();
@@ -85,7 +85,7 @@ TEST(CheckError, IndexError) {
   EXPECT_THROW(
       {
         try {
-          TVM_FFI_CHECK(IndexError, index < array_size)
+          TVM_FFI_CHECK(index < array_size, IndexError)
               << "Index " << index << " out of bounds for array of size " << array_size;
         } catch (const Error& error) {
           EXPECT_EQ(error.kind(), "IndexError");
@@ -101,8 +101,8 @@ TEST(CheckError, IndexError) {
 
 TEST(CheckError, PassingCondition) {
   // This should not throw
-  EXPECT_NO_THROW(TVM_FFI_CHECK(ValueError, true));
-  EXPECT_NO_THROW(TVM_FFI_CHECK(IndexError, 5 < 10));
+  EXPECT_NO_THROW(TVM_FFI_CHECK(true, ValueError));
+  EXPECT_NO_THROW(TVM_FFI_CHECK(5 < 10, IndexError));
 }
 
 TEST(Error, AnyConvert) {


### PR DESCRIPTION
This PR updates TVM_FFI_CHECK to place error kind after cond.