### PR TITLE
[MEMORY] Explicitly set padding to 0

### DIFF
--- a/include/tvm/ffi/memory.h
+++ b/include/tvm/ffi/memory.h
@@ -115,6 +115,7 @@ class ObjAllocatorBase {
     TVMFFIObject* ffi_ptr = details::ObjectUnsafe::GetHeader(ptr);
     ffi_ptr->combined_ref_count = kCombinedRefCountBothOne;
     ffi_ptr->type_index = T::RuntimeTypeIndex();
+    ffi_ptr->__padding = 0;
     ffi_ptr->deleter = Handler::Deleter();
     return details::ObjectUnsafe::ObjectPtrFromOwned<T>(ptr);
   }
@@ -136,6 +137,7 @@ class ObjAllocatorBase {
     TVMFFIObject* ffi_ptr = details::ObjectUnsafe::GetHeader(ptr);
     ffi_ptr->combined_ref_count = kCombinedRefCountBothOne;
     ffi_ptr->type_index = ArrayType::RuntimeTypeIndex();
+    ffi_ptr->__padding = 0;
     ffi_ptr->deleter = Handler::Deleter();
     return details::ObjectUnsafe::ObjectPtrFromOwned<ArrayType>(ptr);
   }


### PR DESCRIPTION
This PR updates the memory module to explicitly set padding to 0. Although this part is unused, it is good to have determininstic memory.