### PR TITLE
feat: Address warnings from clang-tidy 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,29 @@
+# -clang-analyzer-unix.Malloc is disabled due to false positives
+Checks: >
+  clang-diagnostic-*,
+  clang-analyzer-*,
+  modernize-*,
+  bugprone-*,
+  performance-*,
+  portability-*,
+  google-*,
+  -modernize-use-trailing-return-type,
+  -modernize-concat-nested-namespaces,
+  -modernize-use-auto,
+  -modernize-use-nodiscard,
+  -modernize-return-braced-init-list,
+  -modernize-avoid-c-arrays,
+  -bugprone-easily-swappable-parameters,
+  -google-build-using-namespace,
+  -performance-enum-size,
+  -clang-analyzer-unix.Malloc,
+  -performance-avoid-endl
+WarningsAsErrors: '*'
+HeaderFilterRegex: '.*(include/tvm/ffi|src/ffi)/.*\.h$'
+HeaderFileExtensions: ['h']
+ImplementationFileExtensions: ['cc']
+CheckOptions:
+  - key: misc-include-cleaner.UnusedIncludes
+    value: 'true'
+  - key: misc-include-cleaner.MissingIncludes
+    value: 'true'

--- a/cmake/Utils/AddLibbacktrace.cmake
+++ b/cmake/Utils/AddLibbacktrace.cmake
@@ -62,8 +62,9 @@ function (_libbacktrace_compile)
   add_library(libbacktrace STATIC IMPORTED)
   add_dependencies(libbacktrace project_libbacktrace)
   set_target_properties(
-    libbacktrace PROPERTIES IMPORTED_LOCATION ${libbacktrace_prefix}/lib/libbacktrace.a
-                            INTERFACE_INCLUDE_DIRECTORIES ${libbacktrace_prefix}/include
+    libbacktrace
+    PROPERTIES IMPORTED_LOCATION ${libbacktrace_prefix}/lib/libbacktrace.a
+               INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_LIST_DIR}/../../3rdparty/libbacktrace/
   )
 endfunction ()
 

--- a/include/tvm/ffi/any.h
+++ b/include/tvm/ffi/any.h
@@ -83,12 +83,12 @@ class AnyView {
   /*! \brief Copy assignment operator */
   AnyView& operator=(const AnyView&) = default;
   /*! \brief Move constructor */
-  AnyView(AnyView&& other) : data_(other.data_) {
+  AnyView(AnyView&& other) noexcept : data_(other.data_) {
     other.data_.type_index = TypeIndex::kTVMFFINone;
     other.data_.zero_padding = 0;
     other.data_.v_int64 = 0;
   }
-  TVM_FFI_INLINE AnyView& operator=(AnyView&& other) {
+  TVM_FFI_INLINE AnyView& operator=(AnyView&& other) noexcept {
     // copy-and-swap idiom
     AnyView(std::move(other)).swap(*this);  // NOLINT(*)
     return *this;
@@ -286,7 +286,7 @@ class Any {
    * \brief Move constructor from another Any
    * \param other The other Any
    */
-  Any(Any&& other) : data_(other.data_) {
+  Any(Any&& other) noexcept : data_(other.data_) {
     other.data_.type_index = TypeIndex::kTVMFFINone;
     other.data_.zero_padding = 0;
     other.data_.v_int64 = 0;
@@ -304,7 +304,7 @@ class Any {
    * \brief Move assign from another Any
    * \param other The other Any
    */
-  TVM_FFI_INLINE Any& operator=(Any&& other) {
+  TVM_FFI_INLINE Any& operator=(Any&& other) noexcept {
     // copy-and-swap idiom
     Any(std::move(other)).swap(*this);  // NOLINT(*)
     return *this;
@@ -326,7 +326,9 @@ class Any {
     return *this;
   }
   /*! \brief Any can be converted to AnyView in zero cost. */
-  operator AnyView() const { return AnyView::CopyFromTVMFFIAny(data_); }
+  operator AnyView() const {  // NOLINT(google-explicit-constructor)
+    return AnyView::CopyFromTVMFFIAny(data_);
+  }
   /*!
    * \brief Constructor from a general type
    * \tparam T The value type of the other
@@ -540,12 +542,12 @@ struct AnyUnsafe : public ObjectUnsafe {
     return result;
   }
 
-  TVM_FFI_INLINE static Any MoveTVMFFIAnyToAny(TVMFFIAny&& data) {
+  TVM_FFI_INLINE static Any MoveTVMFFIAnyToAny(TVMFFIAny* data) {
     Any any;
-    any.data_ = data;
-    data.type_index = TypeIndex::kTVMFFINone;
-    data.zero_padding = 0;
-    data.v_int64 = 0;
+    any.data_ = *data;
+    data->type_index = TypeIndex::kTVMFFINone;
+    data->zero_padding = 0;
+    data->v_int64 = 0;
     return any;
   }
 

--- a/include/tvm/ffi/c_api.h
+++ b/include/tvm/ffi/c_api.h
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
+// NOLINTBEGIN(modernize-use-using,bugprone-reserved-identifier,modernize-deprecated-headers)
 /*
  * \file tvm/ffi/c_api.h
  * \brief This file defines the C convention of the FFI convention
@@ -1183,3 +1183,4 @@ inline DLDevice TVMFFIDLDeviceFromIntPair(int32_t device_type, int32_t device_id
 }
 #endif  // __cplusplus
 #endif  // TVM_FFI_C_API_H_
+// NOLINTEND(modernize-use-using,bugprone-reserved-identifier,modernize-deprecated-headers)

--- a/include/tvm/ffi/cast.h
+++ b/include/tvm/ffi/cast.h
@@ -70,7 +70,7 @@ inline RefType GetRef(const ObjectType* ptr) {
  */
 template <typename BaseType, typename ObjectType>
 inline ObjectPtr<BaseType> GetObjectPtr(ObjectType* ptr) {
-  static_assert(std::is_base_of<BaseType, ObjectType>::value,
+  static_assert(std::is_base_of_v<BaseType, ObjectType>,
                 "Can only cast to the ref of same container type");
   return details::ObjectUnsafe::ObjectPtrFromUnowned<BaseType>(ptr);
 }

--- a/include/tvm/ffi/container/container_details.h
+++ b/include/tvm/ffi/container/container_details.h
@@ -24,6 +24,7 @@
 #ifndef TVM_FFI_CONTAINER_CONTAINER_DETAILS_H_
 #define TVM_FFI_CONTAINER_CONTAINER_DETAILS_H_
 
+#include <tvm/ffi/any.h>
 #include <tvm/ffi/memory.h>
 #include <tvm/ffi/object.h>
 
@@ -107,7 +108,7 @@ class InplaceArrayBase {
    * \brief Destroy the Inplace Array Base object
    */
   ~InplaceArrayBase() {
-    if constexpr (!(std::is_standard_layout<ElemType>::value && std::is_trivial<ElemType>::value)) {
+    if constexpr (!(std::is_standard_layout_v<ElemType> && std::is_trivial_v<ElemType>)) {
       size_t size = Self()->GetSize();
       for (size_t i = 0; i < size; ++i) {
         ElemType* fp = reinterpret_cast<ElemType*>(AddressOf(i));
@@ -115,6 +116,10 @@ class InplaceArrayBase {
       }
     }
   }
+
+ private:
+  InplaceArrayBase() = default;
+  friend ArrayType;
 
  protected:
   /*!
@@ -210,8 +215,8 @@ class IterAdapter {
   }
 
   template <typename T = IterAdapter>
-  typename std::enable_if<std::is_same<iterator_category, std::random_access_iterator_tag>::value,
-                          typename T::difference_type>::type inline
+  inline std::enable_if_t<std::is_same_v<iterator_category, std::random_access_iterator_tag>,
+                          typename T::difference_type>
   operator-(const IterAdapter& rhs) const {
     return iter_ - rhs.iter_;
   }
@@ -262,8 +267,8 @@ class ReverseIterAdapter {
   }
 
   template <typename T = ReverseIterAdapter>
-  typename std::enable_if<std::is_same<iterator_category, std::random_access_iterator_tag>::value,
-                          typename T::difference_type>::type inline
+  inline std::enable_if_t<std::is_same_v<iterator_category, std::random_access_iterator_tag>,
+                          typename T::difference_type>
   operator-(const ReverseIterAdapter& rhs) const {
     return rhs.iter_ - iter_;
   }

--- a/include/tvm/ffi/container/shape.h
+++ b/include/tvm/ffi/container/shape.h
@@ -124,7 +124,7 @@ namespace details {
 
 class ShapeObjStdImpl : public ShapeObj {
  public:
-  explicit ShapeObjStdImpl(std::vector<int64_t> other) : data_{other} {
+  explicit ShapeObjStdImpl(std::vector<int64_t> other) : data_{std::move(other)} {
     this->data = data_.data();
     this->size = static_cast<size_t>(data_.size());
   }
@@ -309,7 +309,7 @@ class Shape : public ObjectRef {
   /// \endcond
 
  private:
-  explicit Shape(ObjectPtr<ShapeObj> ptr) : ObjectRef(ptr) {}
+  explicit Shape(ObjectPtr<ShapeObj> ptr) : ObjectRef(std::move(ptr)) {}
 };
 
 inline std::ostream& operator<<(std::ostream& os, const Shape& shape) {
@@ -332,7 +332,9 @@ inline constexpr bool use_default_type_traits_v<Shape> = false;
 template <>
 struct TypeTraits<Shape> : public ObjectRefWithFallbackTraitsBase<Shape, Array<int64_t>> {
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFIShape;
-  TVM_FFI_INLINE static Shape ConvertFallbackValue(Array<int64_t> src) { return Shape(src); }
+  TVM_FFI_INLINE static Shape ConvertFallbackValue(Array<int64_t> src) {
+    return Shape(std::move(src));
+  }
 };
 
 }  // namespace ffi

--- a/include/tvm/ffi/container/tensor.h
+++ b/include/tvm/ffi/container/tensor.h
@@ -95,7 +95,7 @@ inline bool IsAligned(const DLTensor& arr, size_t alignment) {
  * \param dtype the data type of the array
  * \return the total number of bytes needed to store packed data
  */
-inline size_t GetDataSize(int64_t numel, DLDataType dtype) {
+inline size_t GetDataSize(size_t numel, DLDataType dtype) {
   // compatible handling sub-byte uint1(bool), which usually stored as uint8_t
   // TODO(tqchen): revisit and switch to kDLBool
   if (dtype.code == kDLUInt && dtype.bits == 1 && dtype.lanes == 1) {
@@ -335,8 +335,8 @@ class Tensor : public ObjectRef {
    * \param device The device of the Tensor.
    * \return The created Tensor.
    */
-  static Tensor FromDLPackAlloc(DLPackTensorAllocator allocator, ffi::Shape shape, DLDataType dtype,
-                                DLDevice device) {
+  static Tensor FromDLPackAlloc(DLPackTensorAllocator allocator, ffi::ShapeView shape,
+                                DLDataType dtype, DLDevice device) {
     if (allocator == nullptr) {
       TVM_FFI_THROW(RuntimeError)
           << "FromDLPackAlloc: allocator is nullptr, "
@@ -616,7 +616,7 @@ struct TypeTraits<TensorView> : public TypeTraitsBase {
 
   TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIDLTensorPtr; }
   TVM_FFI_INLINE static std::string TypeSchema() {
-    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIDLTensorPtr) + "\"}";
+    return R"({"type":")" + std::string(StaticTypeKey::kTVMFFIDLTensorPtr) + R"("})";
   }
 };
 

--- a/include/tvm/ffi/container/tuple.h
+++ b/include/tvm/ffi/container/tuple.h
@@ -54,7 +54,7 @@ class Tuple : public ObjectRef {
   /*! \brief Copy constructor */
   Tuple(const Tuple<Types...>& other) : ObjectRef(other) {}
   /*! \brief Move constructor */
-  Tuple(Tuple<Types...>&& other) : ObjectRef(std::move(other)) {}
+  Tuple(Tuple<Types...>&& other) noexcept : ObjectRef(std::move(other)) {}
   /*!
    * \brief Constructor from another tuple
    * \param other The other tuple
@@ -63,7 +63,7 @@ class Tuple : public ObjectRef {
    */
   template <typename... UTypes,
             typename = std::enable_if_t<(details::type_contains_v<Types, UTypes> && ...), int>>
-  Tuple(const Tuple<UTypes...>& other) : ObjectRef(other) {}
+  Tuple(const Tuple<UTypes...>& other) : ObjectRef(other) {}  // NOLINT(google-explicit-constructor)
 
   /*!
    * \brief Constructor from another tuple
@@ -73,7 +73,8 @@ class Tuple : public ObjectRef {
    */
   template <typename... UTypes,
             typename = std::enable_if_t<(details::type_contains_v<Types, UTypes> && ...), int>>
-  Tuple(Tuple<UTypes...>&& other) : ObjectRef(std::move(other)) {}
+  Tuple(Tuple<UTypes...>&& other)  // NOLINT(google-explicit-constructor)
+      : ObjectRef(std::move(other)) {}
 
   /*!
    * \brief Constructor from arguments
@@ -101,7 +102,7 @@ class Tuple : public ObjectRef {
    * \param other The other tuple
    * \tparam The enable_if_t type
    */
-  TVM_FFI_INLINE Tuple& operator=(Tuple<Types...>&& other) {
+  TVM_FFI_INLINE Tuple& operator=(Tuple<Types...>&& other) noexcept {
     data_ = std::move(other.data_);
     return *this;
   }
@@ -306,7 +307,7 @@ struct TypeTraits<Tuple<Types...>> : public ObjectRefTypeTraitsBase<Tuple<Types.
   }
   TVM_FFI_INLINE static std::string TypeSchema() {
     std::ostringstream oss;
-    oss << "{\"type\":\"Tuple\",\"args\":[";
+    oss << R"({"type":"Tuple","args":[)";
     const char* sep = "";
     ((oss << sep << details::TypeSchema<Types>::v(), sep = ","), ...);
     oss << "]}";

--- a/include/tvm/ffi/dtype.h
+++ b/include/tvm/ffi/dtype.h
@@ -30,6 +30,7 @@
 #include <tvm/ffi/string.h>
 #include <tvm/ffi/type_traits.h>
 
+#include <cstdint>
 #include <string>
 
 namespace tvm {
@@ -179,7 +180,7 @@ struct TypeTraits<DLDataType> : public TypeTraitsBase {
 
   TVM_FFI_INLINE static std::string TypeStr() { return ffi::StaticTypeKey::kTVMFFIDataType; }
   TVM_FFI_INLINE static std::string TypeSchema() {
-    return "{\"type\":\"" + std::string(ffi::StaticTypeKey::kTVMFFIDataType) + "\"}";
+    return R"({"type":")" + std::string(ffi::StaticTypeKey::kTVMFFIDataType) + R"("})";
   }
 };
 }  // namespace ffi

--- a/include/tvm/ffi/extra/base64.h
+++ b/include/tvm/ffi/extra/base64.h
@@ -44,23 +44,23 @@ inline String Base64Encode(TVMFFIByteArray bytes) {
 
   for (size_t i = 0; i < (bytes.size / 3) * 3; i += 3) {
     int32_t buf[3];
-    buf[0] = static_cast<int32_t>(bytes.data[i]);
-    buf[1] = static_cast<int32_t>(bytes.data[i + 1]);
-    buf[2] = static_cast<int32_t>(bytes.data[i + 2]);
+    buf[0] = static_cast<int32_t>(static_cast<unsigned char>(bytes.data[i]));
+    buf[1] = static_cast<int32_t>(static_cast<unsigned char>(bytes.data[i + 1]));
+    buf[2] = static_cast<int32_t>(static_cast<unsigned char>(bytes.data[i + 2]));
     encoded.push_back(kEncodeTable[buf[0] >> 2]);
     encoded.push_back(kEncodeTable[((buf[0] << 4) | (buf[1] >> 4)) & 0x3F]);
     encoded.push_back(kEncodeTable[((buf[1] << 2) | (buf[2] >> 6)) & 0x3F]);
     encoded.push_back(kEncodeTable[buf[2] & 0x3F]);
   }
   if (bytes.size % 3 == 1) {
-    int32_t buf[1] = {static_cast<int32_t>(bytes.data[bytes.size - 1])};
+    int32_t buf[1] = {static_cast<int32_t>(static_cast<unsigned char>(bytes.data[bytes.size - 1]))};
     encoded.push_back(kEncodeTable[buf[0] >> 2]);
     encoded.push_back(kEncodeTable[(buf[0] << 4) & 0x3F]);
     encoded.push_back('=');
     encoded.push_back('=');
   } else if (bytes.size % 3 == 2) {
-    int32_t buf[2] = {static_cast<int32_t>(bytes.data[bytes.size - 2]),
-                      static_cast<int32_t>(bytes.data[bytes.size - 1])};
+    int32_t buf[2] = {static_cast<int32_t>(static_cast<unsigned char>(bytes.data[bytes.size - 2])),
+                      static_cast<int32_t>(static_cast<unsigned char>(bytes.data[bytes.size - 1]))};
     encoded.push_back(kEncodeTable[buf[0] >> 2]);
     encoded.push_back(kEncodeTable[((buf[0] << 4) | (buf[1] >> 4)) & 0x3F]);
     encoded.push_back(kEncodeTable[(buf[1] << 2) & 0x3F]);
@@ -107,10 +107,10 @@ inline Bytes Base64Decode(TVMFFIByteArray bytes) {
     // decode every 4 characters into 24bits, each character contains 6 bits
     // note that = is also decoded as 0, which is safe to skip
     int32_t buf[4] = {
-        static_cast<int32_t>(bytes.data[i]),
-        static_cast<int32_t>(bytes.data[i + 1]),
-        static_cast<int32_t>(bytes.data[i + 2]),
-        static_cast<int32_t>(bytes.data[i + 3]),
+        static_cast<int32_t>(static_cast<unsigned char>(bytes.data[i])),
+        static_cast<int32_t>(static_cast<unsigned char>(bytes.data[i + 1])),
+        static_cast<int32_t>(static_cast<unsigned char>(bytes.data[i + 2])),
+        static_cast<int32_t>(static_cast<unsigned char>(bytes.data[i + 3])),
     };
     int32_t value_i24 = (static_cast<int32_t>(kDecodeTable[buf[0]]) << 18) |
                         (static_cast<int32_t>(kDecodeTable[buf[1]]) << 12) |

--- a/include/tvm/ffi/extra/c_env_api.h
+++ b/include/tvm/ffi/extra/c_env_api.h
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+// NOLINTBEGIN(modernize-use-using)
 /*!
  * \file tvm/ffi/extra/c_env_api.h
  * \brief Extra environment API.
@@ -140,3 +141,4 @@ TVM_FFI_DLL int TVMFFIEnvModRegisterSystemLibSymbol(const char* name, void* symb
 }  // extern "C"
 #endif
 #endif  // TVM_FFI_EXTRA_C_ENV_API_H_
+// NOLINTEND(modernize-use-using)

--- a/include/tvm/ffi/extra/module.h
+++ b/include/tvm/ffi/extra/module.h
@@ -28,6 +28,8 @@
 #include <tvm/ffi/extra/base.h>
 #include <tvm/ffi/function.h>
 
+#include <cstdint>
+
 namespace tvm {
 namespace ffi {
 
@@ -113,7 +115,7 @@ class TVM_FFI_EXTRA_CXX_API ModuleObj : public Object {
    * \param format Format of the source code, can be empty by default.
    * \return Possible source code when available, or empty string if not available.
    */
-  virtual String InspectSource(const String& format = "") const { return String(); }
+  virtual String InspectSource(const String& format) const { return String(); }
   /*!
    * \brief Import another module.
    * \param other The module to import.
@@ -233,7 +235,9 @@ class Module : public ObjectRef {
    * \brief Constructor from ObjectPtr<ModuleObj>.
    * \param ptr The object pointer.
    */
-  explicit Module(ObjectPtr<ModuleObj> ptr) : ObjectRef(ptr) { TVM_FFI_ICHECK(ptr != nullptr); }
+  explicit Module(const ObjectPtr<ModuleObj>& ptr) : ObjectRef(ptr) {
+    TVM_FFI_ICHECK(ptr != nullptr);
+  }
   /*!
    * \brief Load a module from file.
    * \param file_name The name of the host function module.

--- a/include/tvm/ffi/function_details.h
+++ b/include/tvm/ffi/function_details.h
@@ -86,7 +86,7 @@ struct FuncFunctorImpl {
   }
   TVM_FFI_INLINE static std::string TypeSchema() {
     std::ostringstream oss;
-    oss << "{\"type\":\"" << StaticTypeKey::kTVMFFIFunction << "\",\"args\":[";
+    oss << R"({"type":")" << StaticTypeKey::kTVMFFIFunction << R"(","args":[)";
     oss << details::TypeSchema<R>::v();
     ((oss << "," << details::TypeSchema<Args>::v()), ...);
     oss << "]}";
@@ -120,7 +120,7 @@ template <typename Class, typename R, typename... Args>
 struct FunctionInfo<R (Class::*)(Args...) const> : FuncFunctorImpl<R, Args...> {};
 
 /*! \brief Using static function to output typed function signature */
-typedef std::string (*FGetFuncSignature)();
+using FGetFuncSignature = std::string (*)();
 
 /*!
  * \brief Auxilary argument value with context for error reporting
@@ -140,7 +140,7 @@ class ArgValueWithContext {
       : args_(args), arg_index_(arg_index), optional_name_(optional_name), f_sig_(f_sig) {}
 
   template <typename Type>
-  TVM_FFI_INLINE operator Type() {
+  TVM_FFI_INLINE operator Type() {  // NOLINT(google-explicit-constructor)
     using TypeWithoutCR = std::remove_const_t<std::remove_reference_t<Type>>;
 
     if constexpr (std::is_same_v<TypeWithoutCR, AnyView>) {
@@ -227,18 +227,22 @@ struct TypeSchemaImpl {
 template <>
 struct TypeSchemaImpl<void> {
   static std::string v() {
-    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFINone) + "\"}";
+    return R"({"type":")" + std::string(StaticTypeKey::kTVMFFINone) + R"("})";
   }
 };
 
 template <>
 struct TypeSchemaImpl<Any> {
-  static std::string v() { return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIAny) + "\"}"; }
+  static std::string v() {
+    return R"({"type":")" + std::string(StaticTypeKey::kTVMFFIAny) + R"("})";
+  }
 };
 
 template <>
 struct TypeSchemaImpl<AnyView> {
-  static std::string v() { return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIAny) + "\"}"; }
+  static std::string v() {
+    return R"({"type":")" + std::string(StaticTypeKey::kTVMFFIAny) + R"("})";
+  }
 };
 
 }  // namespace details

--- a/include/tvm/ffi/memory.h
+++ b/include/tvm/ffi/memory.h
@@ -33,7 +33,7 @@
 namespace tvm {
 namespace ffi {
 /*! \brief Deleter function for obeject */
-typedef void (*FObjectDeleter)(void* obj, int flags);
+using FObjectDeleter = void (*)(void* obj, int flags);
 
 // Detail implementations after this
 //
@@ -110,7 +110,7 @@ class ObjAllocatorBase {
   template <typename T, typename... Args>
   ObjectPtr<T> make_object(Args&&... args) {
     using Handler = typename Derived::template Handler<T>;
-    static_assert(std::is_base_of<Object, T>::value, "make can only be used to create Object");
+    static_assert(std::is_base_of_v<Object, T>, "make can only be used to create Object");
     T* ptr = Handler::New(static_cast<Derived*>(this), std::forward<Args>(args)...);
     TVMFFIObject* ffi_ptr = details::ObjectUnsafe::GetHeader(ptr);
     ffi_ptr->combined_ref_count = kCombinedRefCountBothOne;
@@ -130,7 +130,7 @@ class ObjAllocatorBase {
   template <typename ArrayType, typename ElemType, typename... Args>
   ObjectPtr<ArrayType> make_inplace_array(size_t num_elems, Args&&... args) {
     using Handler = typename Derived::template ArrayHandler<ArrayType, ElemType>;
-    static_assert(std::is_base_of<Object, ArrayType>::value,
+    static_assert(std::is_base_of_v<Object, ArrayType>,
                   "make_inplace_array can only be used to create Object");
     ArrayType* ptr =
         Handler::New(static_cast<Derived*>(this), num_elems, std::forward<Args>(args)...);
@@ -141,6 +141,10 @@ class ObjAllocatorBase {
     ffi_ptr->deleter = Handler::Deleter();
     return details::ObjectUnsafe::ObjectPtrFromOwned<ArrayType>(ptr);
   }
+
+ private:
+  ObjAllocatorBase() = default;
+  friend Derived;
 };
 
 // Simple allocator that uses new/delete.

--- a/include/tvm/ffi/optional.h
+++ b/include/tvm/ffi/optional.h
@@ -60,20 +60,20 @@ class Optional<T, std::enable_if_t<!use_ptr_based_optional_v<T> && !std::is_same
  public:
   // default constructors.
   Optional() = default;
+  // NOLINTBEGIN(google-explicit-constructor)
   Optional(const Optional<T>& other) : data_(other.data_) {}
-  Optional(Optional<T>&& other) : data_(std::move(other.data_)) {}
-  Optional(std::optional<T> other) : data_(std::move(other)) {}  // NOLINT(*)
-  Optional(std::nullopt_t) {}                                    // NOLINT(*)
-  // normal value handling.
-  Optional(T other)  // NOLINT(*)
-      : data_(std::move(other)) {}
+  Optional(Optional<T>&& other) noexcept : data_(std::move(other.data_)) {}
+  Optional(std::optional<T> other) : data_(std::move(other)) {}
+  Optional(std::nullopt_t) {}
+  Optional(T other) : data_(std::move(other)) {}
+  // NOLINTEND(google-explicit-constructor)
 
   TVM_FFI_INLINE Optional<T>& operator=(const Optional<T>& other) {
     data_ = other.data_;
     return *this;
   }
 
-  TVM_FFI_INLINE Optional<T>& operator=(Optional<T>&& other) {
+  TVM_FFI_INLINE Optional<T>& operator=(Optional<T>&& other) noexcept {
     data_ = std::move(other.data_);
     return *this;
   }
@@ -124,6 +124,7 @@ class Optional<T, std::enable_if_t<!use_ptr_based_optional_v<T> && !std::is_same
     return data_ != other;
   }
 
+  // NOLINTBEGIN(bugprone-unchecked-optional-access)
   /*!
    * \brief Direct access to the value.
    * \return the xvalue reference to the stored value.
@@ -136,6 +137,7 @@ class Optional<T, std::enable_if_t<!use_ptr_based_optional_v<T> && !std::is_same
    * \note only use this function  after checking has_value()
    */
   TVM_FFI_INLINE const T& operator*() const& noexcept { return *data_; }
+  // NOLINTEND(bugprone-unchecked-optional-access)
 
  private:
   std::optional<T> data_;
@@ -147,12 +149,12 @@ class Optional<T, std::enable_if_t<std::is_same_v<T, String> || std::is_same_v<T
  public:
   // default constructors.
   Optional() = default;
+  // NOLINTBEGIN(google-explicit-constructor)
   Optional(const Optional<T>& other) : data_(other.data_) {}
   Optional(Optional<T>&& other) : data_(std::move(other.data_)) {}
-  Optional(std::nullopt_t) {}  // NOLINT(*)
-  // normal value handling.
-  Optional(T other)  // NOLINT(*)
-      : data_(std::move(other)) {}
+  Optional(std::nullopt_t) {}
+  Optional(T other) : data_(std::move(other)) {}
+  // NOLINTEND(google-explicit-constructor)
 
   TVM_FFI_INLINE Optional<T>& operator=(const Optional<T>& other) {
     data_ = other.data_;
@@ -260,21 +262,18 @@ class Optional<T, std::enable_if_t<use_ptr_based_optional_v<T>>> : public Object
  public:
   using ContainerType = typename T::ContainerType;
   Optional() = default;
-  Optional(const Optional<T>& other) : ObjectRef(other.data_) {}
-  Optional(Optional<T>&& other) : ObjectRef(std::move(other.data_)) {}
+  // NOLINTBEGIN(google-explicit-constructor)
+  Optional(const Optional<T>& other) : ObjectRef(other) {}
+  Optional(Optional<T>&& other) noexcept : ObjectRef(std::move(other)) {}
   explicit Optional(ffi::UnsafeInit tag) : ObjectRef(tag) {}
-  // nullopt hanlding
-  Optional(std::nullopt_t) {}  // NOLINT(*)
-
-  // handle conversion from std::optional<T>
-  Optional(std::optional<T> other) {  // NOLINT(*)
+  Optional(std::nullopt_t) {}
+  Optional(std::optional<T> other) {
     if (other.has_value()) {
       *this = *std::move(other);
     }
   }
-  // normal value handling.
-  Optional(T other)  // NOLINT(*)
-      : ObjectRef(std::move(other)) {}
+  Optional(T other) : ObjectRef(std::move(other)) {}
+  // NOLINTEND(google-explicit-constructor)
 
   TVM_FFI_INLINE Optional<T>& operator=(T other) {
     ObjectRef::operator=(std::move(other));

--- a/include/tvm/ffi/reflection/registry.h
+++ b/include/tvm/ffi/reflection/registry.h
@@ -47,7 +47,7 @@ namespace reflection {
  * \brief Types of temporary metadata hold in FieldInfoBuilder and MethodInfoBuilder,
  * before they are filled into final C metadata
  */
-using _MetadataType = std::vector<std::pair<String, Any>>;
+using _MetadataType = std::vector<std::pair<String, Any>>;  // NOLINT(bugprone-reserved-identifier)
 /*!
  * \brief Builder for TVMFFIFieldInfo
  * \sa TVMFFIFieldInfo
@@ -78,7 +78,7 @@ class Metadata : public InfoTrait {
    * \brief Constructor
    * \param dict The initial dictionary
    */
-  explicit Metadata(std::initializer_list<std::pair<String, Any>> dict) : dict_(dict) {}
+  Metadata(std::initializer_list<std::pair<String, Any>> dict) : dict_(dict) {}
   /*!
    * \brief Move metadata into `FieldInfoBuilder`
    * \param info The field info builder.
@@ -141,7 +141,7 @@ class DefaultValue : public InfoTrait {
    * \brief Constructor
    * \param value The value to be set
    */
-  explicit DefaultValue(Any value) : value_(value) {}
+  explicit DefaultValue(Any value) : value_(std::move(value)) {}
 
   /*!
    * \brief Apply the default value to the field info
@@ -279,7 +279,7 @@ class ReflectionDefBase {
         // call method pointer
         return (target.*func)(std::forward<Args>(params)...);
       };
-      return ffi::Function::FromTyped(fwrap, name);
+      return ffi::Function::FromTyped(fwrap, std::move(name));
     }
 
     if constexpr (std::is_base_of_v<Object, Class>) {
@@ -287,7 +287,7 @@ class ReflectionDefBase {
         // call method pointer
         return (const_cast<Class*>(target)->*func)(std::forward<Args>(params)...);
       };
-      return ffi::Function::FromTyped(fwrap, name);
+      return ffi::Function::FromTyped(fwrap, std::move(name));
     }
   }
 
@@ -300,7 +300,7 @@ class ReflectionDefBase {
         // call method pointer
         return (target.*func)(std::forward<Args>(params)...);
       };
-      return ffi::Function::FromTyped(fwrap, name);
+      return ffi::Function::FromTyped(fwrap, std::move(name));
     }
 
     if constexpr (std::is_base_of_v<Object, Class>) {
@@ -308,13 +308,13 @@ class ReflectionDefBase {
         // call method pointer
         return (target->*func)(std::forward<Args>(params)...);
       };
-      return ffi::Function::FromTyped(fwrap, name);
+      return ffi::Function::FromTyped(fwrap, std::move(name));
     }
   }
 
   template <typename Func>
   TVM_FFI_INLINE static Function GetMethod(std::string name, Func&& func) {
-    return ffi::Function::FromTyped(std::forward<Func>(func), name);
+    return ffi::Function::FromTyped(std::forward<Func>(func), std::move(name));
   }
 };
 /// \endcond
@@ -391,7 +391,7 @@ class GlobalDef : public ReflectionDefBase {
   }
 
  private:
-  template <typename... Extra>
+  template <typename... Extra>  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   void RegisterFunc(const char* name, ffi::Function func, String type_schema, Extra&&... extra) {
     MethodInfoBuilder info;
     info.name = TVMFFIByteArray{name, std::char_traits<char>::length(name)};

--- a/include/tvm/ffi/rvalue_ref.h
+++ b/include/tvm/ffi/rvalue_ref.h
@@ -151,7 +151,7 @@ struct TypeTraits<RValueRef<TObjRef>> : public TypeTraitsBase {
 
   TVM_FFI_INLINE static std::string TypeSchema() {
     std::ostringstream oss;
-    oss << "{\"type\":\"" << StaticTypeKey::kTVMFFIObjectRValueRef << "\",\"args\":[";
+    oss << R"({"type":")" << StaticTypeKey::kTVMFFIObjectRValueRef << R"(","args":[)";
     oss << TypeTraits<TObjRef>::TypeSchema();
     oss << "]}";
     return oss.str();

--- a/include/tvm/ffi/string.h
+++ b/include/tvm/ffi/string.h
@@ -931,11 +931,13 @@ struct TypeTraits<std::string>
     return std::string(src->data, src->size);
   }
 
-  TVM_FFI_INLINE static std::string ConvertFallbackValue(const Bytes& src) {
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
+  TVM_FFI_INLINE static std::string ConvertFallbackValue(Bytes src) {
     return src.operator std::string();
   }
 
-  TVM_FFI_INLINE static std::string ConvertFallbackValue(const String& src) {
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
+  TVM_FFI_INLINE static std::string ConvertFallbackValue(String src) {
     return src.operator std::string();
   }
 };

--- a/include/tvm/ffi/string.h
+++ b/include/tvm/ffi/string.h
@@ -89,7 +89,7 @@ class StringObj : public BytesObjBase {
 template <typename Base>
 class BytesObjStdImpl : public Base {
  public:
-  explicit BytesObjStdImpl(std::string other) : data_{other} {
+  explicit BytesObjStdImpl(std::string other) : data_{std::move(other)} {
     this->data = data_.data();
     this->size = data_.size();
   }
@@ -132,7 +132,7 @@ class BytesBaseCell {
     return *this;
   }
 
-  BytesBaseCell& operator=(BytesBaseCell&& other) {
+  BytesBaseCell& operator=(BytesBaseCell&& other) noexcept {
     BytesBaseCell(std::move(other)).swap(*this);  // NOLINT(*)
     return *this;
   }
@@ -167,6 +167,7 @@ class BytesBaseCell {
     if (data_.type_index < TypeIndex::kTVMFFIStaticObjectBegin) {
       return data_.v_bytes;
     } else {
+      // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
       return TVMFFIBytesGetByteArrayPtr(data_.v_obj)->data;
     }
   }
@@ -175,6 +176,7 @@ class BytesBaseCell {
     if (data_.type_index < TypeIndex::kTVMFFIStaticObjectBegin) {
       return data_.small_str_len;
     } else {
+      // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
       return TVMFFIBytesGetByteArrayPtr(data_.v_obj)->size;
     }
   }
@@ -325,7 +327,9 @@ class Bytes {
    *
    * \return std::string
    */
-  operator std::string() const { return std::string{data(), size()}; }
+  operator std::string() const {  // NOLINT(google-explicit-constructor)
+    return std::string{data(), size()};
+  }
 
   /*!
    * \brief Compare two char sequence
@@ -374,7 +378,7 @@ class Bytes {
   // internal backing cell
   details::BytesBaseCell data_;
   // create a new String from TVMFFIAny, must keep private
-  explicit Bytes(details::BytesBaseCell data) : data_(data) {}
+  explicit Bytes(details::BytesBaseCell data) : data_(std::move(data)) {}
   char* InitSpaceForSize(size_t size) {
     return data_.InitSpaceForSize<details::BytesObj>(size, TypeIndex::kTVMFFISmallBytes,
                                                      TypeIndex::kTVMFFIBytes);
@@ -612,7 +616,9 @@ class String {
    *
    * \return std::string
    */
-  operator std::string() const { return std::string{data(), size()}; }
+  operator std::string() const {  // NOLINT(google-explicit-constructor)
+    return std::string{data(), size()};
+  }
 
  private:
   template <typename, typename>
@@ -622,7 +628,7 @@ class String {
   // internal backing cell
   details::BytesBaseCell data_;
   // create a new String from TVMFFIAny, must keep private
-  explicit String(details::BytesBaseCell data) : data_(data) {}
+  explicit String(details::BytesBaseCell data) : data_(std::move(data)) {}
   /*!
    * \brief Create a new empty space for a string
    * \param size The size of the string
@@ -661,6 +667,7 @@ class String {
     char* dest_data = ret.InitSpaceForSize(lhs_size + rhs_size);
     std::memcpy(dest_data, lhs, lhs_size);
     std::memcpy(dest_data + lhs_size, rhs, rhs_size);
+    // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
     dest_data[lhs_size + rhs_size] = '\0';
 #if (__GNUC__) && !(__clang__)
 #pragma GCC diagnostic pop
@@ -690,7 +697,7 @@ inline String EscapeString(const String& value) {
 /// \cond Doxygen_Suppress
 #define TVM_FFI_ESCAPE_CHAR(pattern, val) \
   case pattern:                           \
-    oss << val;                           \
+    oss << (val);                         \
     break
       TVM_FFI_ESCAPE_CHAR('\"', "\\\"");
       TVM_FFI_ESCAPE_CHAR('\\', "\\\\");
@@ -770,7 +777,7 @@ struct TypeTraits<Bytes> : public TypeTraitsBase {
 
   TVM_FFI_INLINE static std::string TypeStr() { return "bytes"; }
   TVM_FFI_INLINE static std::string TypeSchema() {
-    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIBytes) + "\"}";
+    return R"({"type":")" + std::string(StaticTypeKey::kTVMFFIBytes) + R"("})";
   }
 };
 
@@ -816,7 +823,7 @@ struct TypeTraits<String> : public TypeTraitsBase {
 
   TVM_FFI_INLINE static std::string TypeStr() { return "str"; }
   TVM_FFI_INLINE static std::string TypeSchema() {
-    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIStr) + "\"}";
+    return R"({"type":")" + std::string(StaticTypeKey::kTVMFFIStr) + R"("})";
   }
 };
 
@@ -862,7 +869,7 @@ struct TypeTraits<const char*> : public TypeTraitsBase {
   }
 
   TVM_FFI_INLINE static std::string TypeStr() { return "const char*"; }
-  TVM_FFI_INLINE static std::string TypeSchema() { return "{\"type\":\"const char*\"}"; }
+  TVM_FFI_INLINE static std::string TypeSchema() { return R"({"type":"const char*"})"; }
 };
 
 // TVMFFIByteArray, requirement: not nullable, do not retain ownership
@@ -892,7 +899,7 @@ struct TypeTraits<TVMFFIByteArray*> : public TypeTraitsBase {
 
   TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIByteArrayPtr; }
   TVM_FFI_INLINE static std::string TypeSchema() {
-    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIByteArrayPtr) + "\"}";
+    return R"({"type":")" + std::string(StaticTypeKey::kTVMFFIByteArrayPtr) + R"("})";
   }
 };
 
@@ -914,7 +921,7 @@ struct TypeTraits<std::string>
   }
 
   TVM_FFI_INLINE static std::string TypeStr() { return "std::string"; }
-  TVM_FFI_INLINE static std::string TypeSchema() { return "{\"type\":\"std::string\"}"; }
+  TVM_FFI_INLINE static std::string TypeSchema() { return R"({"type":"std::string"})"; }
 
   TVM_FFI_INLINE static std::string ConvertFallbackValue(const char* src) {
     return std::string(src);
@@ -924,11 +931,11 @@ struct TypeTraits<std::string>
     return std::string(src->data, src->size);
   }
 
-  TVM_FFI_INLINE static std::string ConvertFallbackValue(Bytes src) {
+  TVM_FFI_INLINE static std::string ConvertFallbackValue(const Bytes& src) {
     return src.operator std::string();
   }
 
-  TVM_FFI_INLINE static std::string ConvertFallbackValue(String src) {
+  TVM_FFI_INLINE static std::string ConvertFallbackValue(const String& src) {
     return src.operator std::string();
   }
 };
@@ -1054,7 +1061,7 @@ inline bool operator!=(const String& lhs, const char* rhs) { return lhs.compare(
 inline bool operator!=(const char* lhs, const String& rhs) { return rhs.compare(lhs) != 0; }
 
 inline std::ostream& operator<<(std::ostream& out, const String& input) {
-  out.write(input.data(), input.size());
+  out.write(input.data(), static_cast<std::streamsize>(input.size()));
   return out;
 }
 /// \endcond

--- a/include/tvm/ffi/type_traits.h
+++ b/include/tvm/ffi/type_traits.h
@@ -168,7 +168,7 @@ struct TypeTraits<std::nullptr_t> : public TypeTraitsBase {
 
   TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFINone; }
   TVM_FFI_INLINE static std::string TypeSchema() {
-    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFINone) + "\"}";
+    return R"({"type":")" + std::string(StaticTypeKey::kTVMFFINone) + R"("})";
   }
 };
 
@@ -183,12 +183,12 @@ class StrictBool {
    * \brief Constructor
    * \param value The value of the strict bool.
    */
-  StrictBool(bool value) : value_(value) {}  // NOLINT(*)
+  StrictBool(bool value) : value_(value) {}  // NOLINT(google-explicit-constructor)
   /*!
    *\brief Convert the strict bool to bool.
    * \return The value of the strict bool.
    */
-  operator bool() const { return value_; }
+  operator bool() const { return value_; }  // NOLINT(google-explicit-constructor)
 
  private:
   bool value_;
@@ -230,7 +230,7 @@ struct TypeTraits<StrictBool> : public TypeTraitsBase {
 
   TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIBool; }
   TVM_FFI_INLINE static std::string TypeSchema() {
-    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIBool) + "\"}";
+    return R"({"type":")" + std::string(StaticTypeKey::kTVMFFIBool) + R"("})";
   }
 };
 
@@ -269,7 +269,7 @@ struct TypeTraits<bool> : public TypeTraitsBase {
 
   TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIBool; }
   TVM_FFI_INLINE static std::string TypeSchema() {
-    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIBool) + "\"}";
+    return R"({"type":")" + std::string(StaticTypeKey::kTVMFFIBool) + R"("})";
   }
 };
 
@@ -309,7 +309,7 @@ struct TypeTraits<Int, std::enable_if_t<std::is_integral_v<Int>>> : public TypeT
 
   TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIInt; }
   TVM_FFI_INLINE static std::string TypeSchema() {
-    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIInt) + "\"}";
+    return R"({"type":")" + std::string(StaticTypeKey::kTVMFFIInt) + R"("})";
   }
 };
 
@@ -364,7 +364,7 @@ struct TypeTraits<IntEnum, std::enable_if_t<is_integeral_enum_v<IntEnum>>> : pub
 
   TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIInt; }
   TVM_FFI_INLINE static std::string TypeSchema() {
-    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIInt) + "\"}";
+    return R"({"type":")" + std::string(StaticTypeKey::kTVMFFIInt) + R"("})";
   }
 };
 
@@ -408,7 +408,7 @@ struct TypeTraits<Float, std::enable_if_t<std::is_floating_point_v<Float>>>
 
   TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIFloat; }
   TVM_FFI_INLINE static std::string TypeSchema() {
-    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIFloat) + "\"}";
+    return R"({"type":")" + std::string(StaticTypeKey::kTVMFFIFloat) + R"("})";
   }
 };
 
@@ -450,7 +450,7 @@ struct TypeTraits<void*> : public TypeTraitsBase {
 
   TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIOpaquePtr; }
   TVM_FFI_INLINE static std::string TypeSchema() {
-    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIOpaquePtr) + "\"}";
+    return R"({"type":")" + std::string(StaticTypeKey::kTVMFFIOpaquePtr) + R"("})";
   }
 };
 
@@ -493,7 +493,7 @@ struct TypeTraits<DLDevice> : public TypeTraitsBase {
 
   TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIDevice; }
   TVM_FFI_INLINE static std::string TypeSchema() {
-    return "{\"type\":\"" + std::string(StaticTypeKey::kTVMFFIDevice) + "\"}";
+    return R"({"type":")" + std::string(StaticTypeKey::kTVMFFIDevice) + R"("})";
   }
 };
 
@@ -538,7 +538,7 @@ struct TypeTraits<DLTensor*> : public TypeTraitsBase {
   }
 
   TVM_FFI_INLINE static std::string TypeStr() { return "DLTensor*"; }
-  TVM_FFI_INLINE static std::string TypeSchema() { return "{\"type\":\"DLTensor*\"}"; }
+  TVM_FFI_INLINE static std::string TypeSchema() { return R"({"type":"DLTensor*"})"; }
 };
 
 // Traits for ObjectRef, None to ObjectRef will always fail.
@@ -625,7 +625,7 @@ struct ObjectRefTypeTraitsBase : public TypeTraitsBase {
 
   TVM_FFI_INLINE static std::string TypeStr() { return ContainerType::_type_key; }
   TVM_FFI_INLINE static std::string TypeSchema() {
-    return "{\"type\":\"" + std::string(ContainerType::_type_key) + "\"}";
+    return R"({"type":")" + std::string(ContainerType::_type_key) + R"("})";
   }
 };
 
@@ -686,7 +686,7 @@ struct ObjectRefWithFallbackTraitsBase : public ObjectRefTypeTraitsBase<ObjectRe
   /// \cond Doxygen_Suppress
   TVM_FFI_INLINE static std::optional<ObjectRefType> TryCastFromAnyView(const TVMFFIAny* src) {
     if (auto opt_obj = ObjectRefTypeTraitsBase<ObjectRefType>::TryCastFromAnyView(src)) {
-      return *opt_obj;
+      return opt_obj;
     }
     // apply fallback types in TryCastFromAnyView
     return TryFallbackTypes<FallbackTypes...>(src);
@@ -754,7 +754,7 @@ struct TypeTraits<TObject*, std::enable_if_t<std::is_base_of_v<Object, TObject>>
 
   TVM_FFI_INLINE static std::string TypeStr() { return TObject::_type_key; }
   TVM_FFI_INLINE static std::string TypeSchema() {
-    return "{\"type\":\"" + std::string(TObject::_type_key) + "\"}";
+    return R"({"type":")" + std::string(TObject::_type_key) + R"("})";
   }
 };
 
@@ -818,7 +818,7 @@ struct TypeTraits<Optional<T>> : public TypeTraitsBase {
     return "Optional<" + TypeTraits<T>::TypeStr() + ">";
   }
   TVM_FFI_INLINE static std::string TypeSchema() {
-    return "{\"type\":\"Optional\",\"args\":[" + details::TypeSchema<T>::v() + "]}";
+    return R"({"type":"Optional","args":[)" + details::TypeSchema<T>::v() + "]}";
   }
 };
 }  // namespace ffi

--- a/src/ffi/container.cc
+++ b/src/ffi/container.cc
@@ -79,7 +79,9 @@ TVM_FFI_STATIC_INIT_BLOCK() {
            [](const ffi::MapObj* n) -> int64_t { return static_cast<int64_t>(n->size()); })
       .def("ffi.MapGetItem", [](const ffi::MapObj* n, const Any& k) -> Any { return n->at(k); })
       .def("ffi.MapCount",
-           [](const ffi::MapObj* n, const Any& k) -> int64_t { return n->count(k); })
+           [](const ffi::MapObj* n, const Any& k) -> int64_t {
+             return static_cast<int64_t>(n->count(k));
+           })
       .def("ffi.MapForwardIterFunctor", [](const ffi::MapObj* n) -> ffi::Function {
         return ffi::Function::FromTyped(MapForwardIterFunctor(n->begin(), n->end()));
       });

--- a/src/ffi/dtype.cc
+++ b/src/ffi/dtype.cc
@@ -44,8 +44,9 @@ inline int ParseCustomDataTypeCode(const std::string_view& str, const char** sca
   TVM_FFI_ICHECK(str.data() == tmp);
   *scan = str.data() + 6;
   TVM_FFI_ICHECK(str.data() == tmp);
-  if (**scan != '[')
+  if (**scan != '[') {
     TVM_FFI_THROW(ValueError) << "expected opening brace after 'custom' type in" << str;
+  }
   TVM_FFI_ICHECK(str.data() == tmp);
   *scan += 1;
   TVM_FFI_ICHECK(str.data() == tmp);

--- a/src/ffi/extra/buffer_stream.h
+++ b/src/ffi/extra/buffer_stream.h
@@ -24,6 +24,8 @@
 #ifndef TVM_FFI_EXTRA_BUFFER_STREAM_H_
 #define TVM_FFI_EXTRA_BUFFER_STREAM_H_
 
+#include <tvm/ffi/endian.h>
+
 #include <algorithm>
 #include <cstring>
 #include <string>
@@ -67,7 +69,7 @@ class BufferInStream {
   bool Read(T* data) {
     bool ret = Read(static_cast<void*>(data), sizeof(T)) == sizeof(T);  // NOLINT(*)
     if (!TVM_FFI_IO_NO_ENDIAN_SWAP) {
-      ByteSwap(&data, sizeof(T), 1);
+      ByteSwap(static_cast<void*>(data), sizeof(T), 1);
     }
     return ret;
   }

--- a/src/ffi/extra/env_c_api.cc
+++ b/src/ffi/extra/env_c_api.cc
@@ -49,10 +49,10 @@ class EnvCAPIRegistry {
    *
    * \return 0 if no error happens, -1 if error happens.
    */
-  typedef int (*F_PyErr_CheckSignals)();
+  using F_PyErr_CheckSignals = int (*)();
 
   /*! \brief Callback to increment/decrement the python ref count */
-  typedef void (*F_Py_IncDefRef)(void*);
+  using F_Py_IncDefRef = void (*)(void*);
 
   /*!
    * \brief PyErr_CheckSignal function

--- a/src/ffi/extra/json_parser.cc
+++ b/src/ffi/extra/json_parser.cc
@@ -31,6 +31,7 @@
 
 #include <cinttypes>
 #include <limits>
+#include <utility>
 
 namespace tvm {
 namespace ffi {
@@ -432,37 +433,37 @@ class JSONParserContext {
             // 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx    | 0x10000 - end
             // ------------------------------------------------------------
             if (code_point < 0x80) {
-              out_str.push_back(code_point);
+              out_str.push_back(static_cast<char>(code_point));
             } else if (code_point < 0x800) {
               // first byte: 110xxxxx (5 effective bits)
               // second byte: 10xxxxxx (6 effecive bits)
               // shift by 6 bits to get the first bytes
-              out_str.push_back(0xC0 | (code_point >> 6));
+              out_str.push_back(static_cast<char>(0xC0 | (code_point >> 6)));
               // mask by 6 effective bits
-              out_str.push_back(0x80 | (code_point & 0x3F));
+              out_str.push_back(static_cast<char>(0x80 | (code_point & 0x3F)));
             } else if (code_point < 0x10000) {
               // first byte: 1110xxxx (4 effective bits)
               // second byte: 10xxxxxx (6 effecive bits)
               // third byte: 10xxxxxx (6 effecive bits)
               // shift by 12 bits to get the first bytes
-              out_str.push_back(0xE0 | (code_point >> 12));
+              out_str.push_back(static_cast<char>(0xE0 | (code_point >> 12)));
               // shift by 6 bits to get the second bytes, mask by 6 effective bits
-              out_str.push_back(0x80 | ((code_point >> 6) & 0x3F));
+              out_str.push_back(static_cast<char>(0x80 | ((code_point >> 6) & 0x3F)));
               // mask by 6 effective bits
-              out_str.push_back(0x80 | (code_point & 0x3F));
+              out_str.push_back(static_cast<char>(0x80 | (code_point & 0x3F)));
             } else {
               // first byte: 11110xxx (3 effective bits)
               // second byte: 10xxxxxx (6 effecive bits)
               // third byte: 10xxxxxx (6 effecive bits)
               // fourth byte: 10xxxxxx (6 effecive bits)
               // shift by 18 bits to get the first bytes
-              out_str.push_back(0xF0 | (code_point >> 18));
+              out_str.push_back(static_cast<char>(0xF0 | (code_point >> 18)));
               // shift by 12 bits to get the second bytes, mask by 6 effective bits
-              out_str.push_back(0x80 | ((code_point >> 12) & 0x3F));
+              out_str.push_back(static_cast<char>(0x80 | ((code_point >> 12) & 0x3F)));
               // shift by 6 bits to get the third bytes, mask by 6 effective bits
-              out_str.push_back(0x80 | ((code_point >> 6) & 0x3F));
+              out_str.push_back(static_cast<char>(0x80 | ((code_point >> 6) & 0x3F)));
               // mask by 6 effective bits
-              out_str.push_back(0x80 | (code_point & 0x3F));
+              out_str.push_back(static_cast<char>(0x80 | (code_point & 0x3F)));
             }
             break;
           }
@@ -541,7 +542,8 @@ class JSONParser {
   }
 
  private:
-  explicit JSONParser(String json_str) : ctx_(json_str.data(), json_str.data() + json_str.size()) {}
+  explicit JSONParser(String json_str)
+      : storage_(std::move(json_str)), ctx_(storage_.data(), storage_.data() + storage_.size()) {}
 
   bool ParseTail() {
     ctx_.SkipSpaces();
@@ -650,7 +652,8 @@ class JSONParser {
       ctx_.SkipSpaces();
       if (ctx_.Peek() == '}') {
         ctx_.SkipNextAssumeNoSpace();
-        *out = json::Object(object_temp_stack_.begin() + stack_top, object_temp_stack_.end());
+        *out = json::Object(object_temp_stack_.begin() + static_cast<std::ptrdiff_t>(stack_top),
+                            object_temp_stack_.end());
         // recover the stack to original state
         object_temp_stack_.resize(stack_top);
         return true;
@@ -682,7 +685,7 @@ class JSONParser {
       return true;
     }
     // non-empty array
-    while ((next_char = ctx_.Peek()) != -1) {
+    while ((next_char = ctx_.Peek()) != -1) {  // NOLINT(clang-analyzer-deadcode.DeadStores)
       json::Value value;
       // no need to skip space here because we already skipped space
       // at the beginning or in previous iteration
@@ -696,7 +699,8 @@ class JSONParser {
         ctx_.SkipSpaces();
       } else if (next_char == ']') {
         ctx_.SkipNextAssumeNoSpace();
-        *out = json::Array(array_temp_stack_.begin() + stack_top, array_temp_stack_.end());
+        *out = json::Array(array_temp_stack_.begin() + static_cast<std::ptrdiff_t>(stack_top),
+                           array_temp_stack_.end());
         // recover the stack
         array_temp_stack_.resize(stack_top);
         return true;
@@ -708,6 +712,7 @@ class JSONParser {
     return false;
   }
 
+  String storage_;
   JSONParserContext ctx_;
   // Temp stack for intermediate values
   // we first create a persistent stack to store the parsed values

--- a/src/ffi/extra/json_writer.cc
+++ b/src/ffi/extra/json_writer.cc
@@ -34,6 +34,7 @@
 #include <cstdint>
 #include <limits>
 #include <string>
+#include <utility>
 
 namespace tvm {
 namespace ffi {
@@ -41,6 +42,7 @@ namespace json {
 
 class JSONWriter {
  public:
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   static String Stringify(const json::Value& value, Optional<int> indent) {
     JSONWriter writer(indent.value_or(0));
     writer.WriteValue(value);
@@ -194,7 +196,7 @@ class JSONWriter {
       if (indent_ != 0) {
         WriteIndent();
       }
-      WriteValue(value[i]);
+      WriteValue(value[static_cast<int64_t>(i)]);
     }
     if (indent_ != 0) {
       total_indent_ -= indent_;
@@ -249,7 +251,7 @@ class JSONWriter {
 };
 
 String Stringify(const json::Value& value, Optional<int> indent) {
-  return JSONWriter::Stringify(value, indent);
+  return JSONWriter::Stringify(value, indent);  // NOLINT(performance-unnecessary-value-param)
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() {

--- a/src/ffi/extra/library_module_dynamic_lib.cc
+++ b/src/ffi/extra/library_module_dynamic_lib.cc
@@ -45,7 +45,7 @@ namespace ffi {
 class DSOLibrary final : public Library {
  public:
   explicit DSOLibrary(const String& name) { Load(name); }
-  ~DSOLibrary() {
+  ~DSOLibrary() final {
     if (lib_handle_) Unload();
   }
 
@@ -110,9 +110,10 @@ void DSOLibrary::Unload() {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
-  refl::GlobalDef().def("ffi.Module.load_from_file.so", [](String library_path, String) {
-    return CreateLibraryModule(make_object<DSOLibrary>(library_path));
-  });
+  refl::GlobalDef().def("ffi.Module.load_from_file.so",
+                        [](const String& library_path, const String&) {
+                          return CreateLibraryModule(make_object<DSOLibrary>(library_path));
+                        });
 }
 }  // namespace ffi
 }  // namespace tvm

--- a/src/ffi/extra/library_module_system_lib.cc
+++ b/src/ffi/extra/library_module_system_lib.cc
@@ -28,6 +28,7 @@
 #include <tvm/ffi/string.h>
 
 #include <mutex>
+#include <utility>
 
 #include "module_internal.h"
 
@@ -66,7 +67,7 @@ class SystemLibSymbolRegistry {
 
 class SystemLibrary final : public Library {
  public:
-  explicit SystemLibrary(const String& symbol_prefix) : symbol_prefix_(symbol_prefix) {}
+  explicit SystemLibrary(String symbol_prefix) : symbol_prefix_(std::move(symbol_prefix)) {}
 
   void* GetSymbol(const String& name) final {
     // The `name` might or might not already contain the symbol prefix.
@@ -98,8 +99,8 @@ class SystemLibrary final : public Library {
 
 class SystemLibModuleRegistry {
  public:
-  Module GetOrCreateModule(String symbol_prefix) {
-    std::lock_guard<std::mutex> lock(mutex_);
+  Module GetOrCreateModule(const String& symbol_prefix) {
+    std::scoped_lock<std::mutex> lock(mutex_);
     auto it = lib_map_.find(symbol_prefix);
     if (it != lib_map_.end()) {
       return (*it).second;

--- a/src/ffi/extra/module.cc
+++ b/src/ffi/extra/module.cc
@@ -140,19 +140,19 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   refl::GlobalDef()
       .def("ffi.ModuleLoadFromFile", &Module::LoadFromFile)
       .def_method("ffi.ModuleImplementsFunction",
-                  [](Module mod, String name, bool query_imports) {
+                  [](const Module& mod, const String& name, bool query_imports) {
                     return mod->ImplementsFunction(name, query_imports);
                   })
       .def_method("ffi.ModuleGetFunctionMetadata",
-                  [](Module mod, String name, bool query_imports) {
+                  [](const Module& mod, const String& name, bool query_imports) {
                     return mod->GetFunctionMetadata(name, query_imports);
                   })
       .def_method("ffi.ModuleGetFunctionDoc",
-                  [](Module mod, String name, bool query_imports) {
+                  [](const Module& mod, const String& name, bool query_imports) {
                     return mod->GetFunctionDoc(name, query_imports);
                   })
       .def_method("ffi.ModuleGetFunction",
-                  [](Module mod, String name, bool query_imports) {
+                  [](const Module& mod, const String& name, bool query_imports) {
                     return mod->GetFunction(name, query_imports);
                   })
       .def_method("ffi.ModuleGetPropertyMask", &ModuleObj::GetPropertyMask)

--- a/src/ffi/extra/module_internal.h
+++ b/src/ffi/extra/module_internal.h
@@ -42,7 +42,7 @@ namespace ffi {
 class Library : public Object {
  public:
   // destructor.
-  virtual ~Library() {}
+  virtual ~Library() = default;
   /*!
    * \brief Get the symbol address for a given name.
    * \param name The name of the symbol.
@@ -69,7 +69,7 @@ struct ModuleObj::InternalUnsafe {
   static void* GetFunctionFromImports(ModuleObj* module, const char* name) {
     // backend implementation for TVMFFIEnvModLookupFromImports
     static std::mutex mutex_;
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::scoped_lock<std::mutex> lock(mutex_);
     String s_name(name);
     auto it = module->import_lookup_cache_.find(s_name);
     if (it != module->import_lookup_cache_.end()) {

--- a/src/ffi/extra/reflection_extra.cc
+++ b/src/ffi/extra/reflection_extra.cc
@@ -74,7 +74,7 @@ void MakeObjectFromPackedArgs(ffi::PackedArgs args, Any* ret) {
       size_t arg_index = search_field(field_info->name);
       void* field_addr = reinterpret_cast<char*>(ptr.get()) + field_info->offset;
       if (arg_index < keys.size()) {
-        AnyView field_value = args[arg_index * 2 + 2];
+        AnyView field_value = args[static_cast<int>(arg_index * 2 + 2)];
         field_info->setter(field_addr, reinterpret_cast<const TVMFFIAny*>(&field_value));
         keys_found[arg_index] = true;
       } else if (field_info->flags & kTVMFFIFieldFlagBitMaskHasDefault) {

--- a/src/ffi/extra/structural_equal.cc
+++ b/src/ffi/extra/structural_equal.cc
@@ -255,6 +255,7 @@ class StructEqualHandler {
     }
   }
 
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   bool CompareMap(Map<Any, Any> lhs, Map<Any, Any> rhs) {
     if (lhs.size() != rhs.size()) {
       // size mismatch, and there is no path tracing
@@ -299,13 +300,14 @@ class StructEqualHandler {
     return false;
   }
 
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   bool CompareArray(ffi::Array<Any> lhs, ffi::Array<Any> rhs) {
     if (lhs.size() != rhs.size()) {
       // fast path, size mismatch, and there is no path tracing
       // return false since we don't need informative error message
       if (mismatch_lhs_reverse_path_ == nullptr) return false;
     }
-    for (size_t i = 0; i < std::min(lhs.size(), rhs.size()); ++i) {
+    for (int64_t i = 0, n = static_cast<int64_t>(std::min(lhs.size(), rhs.size())); i < n; ++i) {
       if (!CompareAny(lhs[i], rhs[i])) {
         if (mismatch_lhs_reverse_path_ != nullptr) {
           mismatch_lhs_reverse_path_->emplace_back(reflection::AccessStep::ArrayItem(i));
@@ -317,23 +319,26 @@ class StructEqualHandler {
     if (lhs.size() == rhs.size()) return true;
     if (mismatch_lhs_reverse_path_ != nullptr) {
       if (lhs.size() > rhs.size()) {
-        mismatch_lhs_reverse_path_->emplace_back(reflection::AccessStep::ArrayItem(rhs.size()));
+        mismatch_lhs_reverse_path_->emplace_back(
+            reflection::AccessStep::ArrayItem(static_cast<int64_t>(rhs.size())));
         mismatch_rhs_reverse_path_->emplace_back(
-            reflection::AccessStep::ArrayItemMissing(rhs.size()));
+            reflection::AccessStep::ArrayItemMissing(static_cast<int64_t>(rhs.size())));
       } else {
         mismatch_lhs_reverse_path_->emplace_back(
-            reflection::AccessStep::ArrayItemMissing(lhs.size()));
-        mismatch_rhs_reverse_path_->emplace_back(reflection::AccessStep::ArrayItem(lhs.size()));
+            reflection::AccessStep::ArrayItemMissing(static_cast<int64_t>(lhs.size())));
+        mismatch_rhs_reverse_path_->emplace_back(
+            reflection::AccessStep::ArrayItem(static_cast<int64_t>(lhs.size())));
       }
     }
     return false;
   }
 
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   bool CompareShape(Shape lhs, Shape rhs) {
     if (lhs.size() != rhs.size()) {
       return false;
     }
-    for (size_t i = 0; i < lhs.size(); ++i) {
+    for (int64_t i = 0, n = static_cast<int64_t>(lhs.size()); i < n; ++i) {
       if (lhs[i] != rhs[i]) {
         return false;
       }
@@ -341,6 +346,7 @@ class StructEqualHandler {
     return true;
   }
 
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   bool CompareTensor(Tensor lhs, Tensor rhs) {
     if (lhs.same_as(rhs)) return true;
     if (lhs->ndim != rhs->ndim) return false;

--- a/src/ffi/extra/structural_equal.cc
+++ b/src/ffi/extra/structural_equal.cc
@@ -338,7 +338,7 @@ class StructEqualHandler {
     if (lhs.size() != rhs.size()) {
       return false;
     }
-    for (int64_t i = 0, n = static_cast<int64_t>(lhs.size()); i < n; ++i) {
+    for (size_t i = 0; i < lhs.size(); ++i) {
       if (lhs[i] != rhs[i]) {
         return false;
       }

--- a/src/ffi/extra/structural_hash.cc
+++ b/src/ffi/extra/structural_hash.cc
@@ -180,10 +180,11 @@ class StructuralHashHandler {
     return hash_value;
   }
 
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   uint64_t HashArray(Array<Any> arr) {
     uint64_t hash_value = details::StableHashCombine(arr->GetTypeKeyHash(), arr.size());
-    for (size_t i = 0; i < arr.size(); ++i) {
-      hash_value = details::StableHashCombine(hash_value, HashAny(arr[i]));
+    for (const auto& elem : arr) {
+      hash_value = details::StableHashCombine(hash_value, HashAny(elem));
     }
     return hash_value;
   }
@@ -192,7 +193,7 @@ class StructuralHashHandler {
   // Order independent hash value means the hash value will remain stable independent
   // of the order we hash the content at the current context.
   // This property is needed to support stable hash for map.
-  std::optional<uint64_t> FindOrderIndependentHash(Any src) {
+  std::optional<uint64_t> FindOrderIndependentHash(const Any& src) {
     using ffi::details::AnyUnsafe;
     const TVMFFIAny* src_data = AnyUnsafe::TVMFFIAnyPtrFromAny(src);
 
@@ -225,6 +226,7 @@ class StructuralHashHandler {
     }
   }
 
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   uint64_t HashMap(Map<Any, Any> map) {
     // Compute a deterministic hash value for the map.
     uint64_t hash_value = details::StableHashCombine(map->GetTypeKeyHash(), map.size());
@@ -259,14 +261,16 @@ class StructuralHashHandler {
     return hash_value;
   }
 
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   uint64_t HashShape(Shape shape) {
     uint64_t hash_value = details::StableHashCombine(shape->GetTypeKeyHash(), shape.size());
-    for (size_t i = 0; i < shape.size(); ++i) {
-      hash_value = details::StableHashCombine(hash_value, shape[i]);
+    for (int64_t i : shape) {
+      hash_value = details::StableHashCombine(hash_value, i);
     }
     return hash_value;
   }
 
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   uint64_t HashTensor(Tensor tensor) {
     uint64_t hash_value = details::StableHashCombine(tensor->GetTypeKeyHash(), tensor->ndim);
     for (int i = 0; i < tensor->ndim; ++i) {

--- a/src/ffi/extra/testing.cc
+++ b/src/ffi/extra/testing.cc
@@ -32,6 +32,7 @@
 #include <chrono>
 #include <iostream>
 #include <thread>
+#include <utility>
 
 namespace tvm {
 namespace ffi {
@@ -121,7 +122,7 @@ class TestCxxClassDerivedDerived : public TestCxxClassDerived {
 
   TestCxxClassDerivedDerived(int64_t v_i64, int32_t v_i32, double v_f64, float v_f32, String v_str,
                              bool v_bool)
-      : TestCxxClassDerived(v_i64, v_i32, v_f64, v_f32), v_str(v_str), v_bool(v_bool) {}
+      : TestCxxClassDerived(v_i64, v_i32, v_f64, v_f32), v_str(std::move(v_str)), v_bool(v_bool) {}
 
   TVM_FFI_DECLARE_OBJECT_INFO("testing.TestCxxClassDerivedDerived", TestCxxClassDerivedDerived,
                               TestCxxClassDerived);
@@ -130,11 +131,11 @@ class TestCxxClassDerivedDerived : public TestCxxClassDerived {
 class TestCxxInitSubsetObj : public Object {
  public:
   int64_t required_field;
-  int64_t optional_field;
+  int64_t optional_field = -1;
   String note;
 
   explicit TestCxxInitSubsetObj(int64_t value, String note)
-      : required_field(value), optional_field(-1), note(note) {}
+      : required_field(value), note(std::move(note)) {}
 
   static constexpr bool _type_mutable = true;
   TVM_FFI_DECLARE_OBJECT_INFO("testing.TestCxxInitSubset", TestCxxInitSubsetObj, Object);
@@ -159,6 +160,7 @@ class TestUnregisteredObject : public TestUnregisteredBaseObject {
                               TestUnregisteredBaseObject);
 };
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 TVM_FFI_NO_INLINE void TestRaiseError(String kind, String msg) {
   // keep name and no liner for testing backtrace
   throw ffi::Error(kind, msg, TVMFFIBacktrace(__FILE__, __LINE__, TVM_FFI_FUNC_SIG, 0));
@@ -255,7 +257,7 @@ namespace ffi {
 class SchemaAllTypesObj : public Object {
  public:
   // POD and builtin types
-  bool v_bool;
+  bool v_bool{true};
   int64_t v_int;
   double v_float;
   DLDevice v_device;
@@ -277,8 +279,7 @@ class SchemaAllTypesObj : public Object {
 
   // Constructor used by refl::init in make_with
   SchemaAllTypesObj(int64_t vi, double vf, String s)  // NOLINT(*): explicit not necessary here
-      : v_bool(true),
-        v_int(vi),
+      : v_int(vi),
         v_float(vf),
         v_device(TVMFFIDLDeviceFromIntPair(kDLCPU, 0)),
         v_dtype(StringToDLDataType("float32")),
@@ -298,6 +299,7 @@ class SchemaAllTypesObj : public Object {
     return Optional<String>(std::nullopt);
   }
   Map<String, Array<int64_t>> MergeMap(Map<String, Array<int64_t>> lhs,
+                                       // NOLINTNEXTLINE(performance-unnecessary-value-param)
                                        Map<String, Array<int64_t>> rhs) const {
     for (const auto& kv : rhs) {
       if (!lhs.count(kv.first)) {
@@ -390,13 +392,15 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def("testing.schema_id_variant_int_str", [](Variant<int64_t, String> v) { return v; })
       .def_packed("testing.schema_packed", [](PackedArgs args, Any* ret) {})
       .def("testing.schema_arr_map_opt",
+           // NOLINTNEXTLINE(performance-unnecessary-value-param)
            [](Array<Optional<int64_t>> arr, Map<String, Array<int64_t>> mp,
+              // NOLINTNEXTLINE(performance-unnecessary-value-param)
               Optional<String> os) -> Map<String, Array<int64_t>> {
              // no-op combine
              if (os.has_value()) {
                Array<int64_t> extra;
-               for (size_t i = 0; i < arr.size(); ++i) {
-                 if (arr[i].has_value()) extra.push_back(arr[i].value());
+               for (const auto& i : arr) {
+                 if (i.has_value()) extra.push_back(i.value());
                }
                mp.Set(os.value(), extra);
              }

--- a/src/ffi/object.cc
+++ b/src/ffi/object.cc
@@ -148,7 +148,7 @@ class TypeTable {
       TVM_FFI_ICHECK(parent->child_slots_can_overflow)
           << "Reach maximum number of sub-classes for " << ToStringView(parent->type_key);
       // allocate new entries.
-      int32_t allocated_tindex = type_counter_;
+      int32_t allocated_tindex = static_cast<int32_t>(type_counter_);
       type_counter_ += num_slots;
       TVM_FFI_ICHECK_LE(type_table_.size(), type_counter_);
       type_table_.reserve(type_counter_);
@@ -246,13 +246,13 @@ class TypeTable {
     if (it == type_attr_name_to_column_index_.end()) {
       column_index = type_attr_columns_.size();
       type_attr_columns_.emplace_back(std::make_unique<TypeAttrColumnData>());
-      type_attr_name_to_column_index_.Set(name_str, column_index);
+      type_attr_name_to_column_index_.Set(name_str, static_cast<int64_t>(column_index));
     } else {
       column_index = (*it).second;
     }
     TypeAttrColumnData* column = type_attr_columns_[column_index].get();
-    if (column->data_.size() < static_cast<size_t>(type_index + 1)) {
-      column->data_.resize(type_index + 1, Any(nullptr));
+    if (column->data_.size() < static_cast<size_t>(type_index) + 1) {
+      column->data_.resize(static_cast<size_t>(type_index) + 1, Any(nullptr));
       column->data = reinterpret_cast<const TVMFFIAny*>(column->data_.data());
       column->size = column->data_.size();
     }

--- a/tests/cpp/extra/test_json_parser.cc
+++ b/tests/cpp/extra/test_json_parser.cc
@@ -207,7 +207,7 @@ TEST(JSONParser, Object) {
 }
 
 TEST(JSONParser, ObjectOrderPreserving) {
-  auto obj = json::Parse("{\"c\": 1, \"a\": 2, \"b\": 3}   ");
+  auto obj = json::Parse(R"({"c": 1, "a": 2, "b": 3}   )");
   json::Array keys;
   for (auto& [key, value] : obj.cast<json::Object>()) {
     keys.push_back(key);

--- a/tests/cpp/test_any.cc
+++ b/tests/cpp/test_any.cc
@@ -256,7 +256,7 @@ TEST(Any, Object) {
   // convert to raw opaque ptr
   void* raw_v1_ptr = const_cast<TIntObj*>(v1_ptr);
   any2 = raw_v1_ptr;
-  EXPECT_TRUE(any2.as<void*>().value() == v1_ptr);
+  EXPECT_TRUE(any2.as<void*>().value() == v1_ptr);  // NOLINT(bugprone-unchecked-optional-access)
 
   // convert to ObjectRef
   {
@@ -308,7 +308,7 @@ TEST(Any, ObjectRefWithFallbackTraits) {
   EXPECT_EQ(v1->value, 1);
   EXPECT_EQ(v1->dtype, "bool");
 
-  any1 = int64_t(42);
+  any1 = static_cast<int64_t>(42);
   auto v2 = any1.cast<TPrimExpr>();
   EXPECT_EQ(v2->value, 42);
   EXPECT_EQ(v2->dtype, "int64");
@@ -330,7 +330,7 @@ TEST(Any, ObjectRefWithFallbackTraits) {
   EXPECT_EQ(v5->value, 1);
   EXPECT_EQ(v5->dtype, "bool");
 
-  view1 = int64_t(42);
+  view1 = static_cast<int64_t>(42);
   auto v6 = view1.cast<TPrimExpr>();
   EXPECT_EQ(v6->value, 42);
   EXPECT_EQ(v6->dtype, "int64");
@@ -358,7 +358,7 @@ TEST(Any, CastVsAs) {
   // as only runs strict check
   auto opt_v0 = view0.as<int64_t>();
   EXPECT_TRUE(opt_v0.has_value());
-  EXPECT_EQ(opt_v0.value(), 1);
+  EXPECT_EQ(opt_v0.value(), 1);  // NOLINT(bugprone-unchecked-optional-access)
 
   auto opt_v1 = view0.as<bool>();
   EXPECT_TRUE(!opt_v1.has_value());
@@ -368,19 +368,19 @@ TEST(Any, CastVsAs) {
   // try_cast will try run the conversion.
   auto opt_v3 = view0.try_cast<bool>();
   EXPECT_TRUE(opt_v3.has_value());
-  EXPECT_EQ(opt_v3.value(), 1);
+  EXPECT_EQ(opt_v3.value(), 1);  // NOLINT(bugprone-unchecked-optional-access)
   auto opt_v4 = view0.try_cast<double>();
   EXPECT_TRUE(opt_v4.has_value());
-  EXPECT_EQ(opt_v4.value(), 1);
+  EXPECT_EQ(opt_v4.value(), 1);  // NOLINT(bugprone-unchecked-optional-access)
 
   Any any1 = true;
   auto opt_v5 = any1.as<bool>();
   EXPECT_TRUE(opt_v5.has_value());
-  EXPECT_EQ(opt_v5.value(), 1);
+  EXPECT_EQ(opt_v5.value(), 1);  // NOLINT(bugprone-unchecked-optional-access)
 
   auto opt_v6 = any1.try_cast<int>();
   EXPECT_TRUE(opt_v6.has_value());
-  EXPECT_EQ(opt_v6.value(), 1);
+  EXPECT_EQ(opt_v6.value(), 1);  // NOLINT(bugprone-unchecked-optional-access)
 
   auto opt_v7 = any1.try_cast<double>();
   EXPECT_TRUE(opt_v7.has_value());
@@ -391,7 +391,7 @@ TEST(Any, ObjectMove) {
   auto v0 = std::move(any1).cast<TPrimExpr>();
   EXPECT_EQ(v0->value, 3.14);
   EXPECT_EQ(v0.use_count(), 1);
-  EXPECT_TRUE(any1 == nullptr);
+  EXPECT_TRUE(any1 == nullptr);  // NOLINT(bugprone-use-after-move)
 }
 
 TEST(Any, AnyEqualHash) {

--- a/tests/cpp/test_array.cc
+++ b/tests/cpp/test_array.cc
@@ -51,6 +51,7 @@ TEST(Array, MutateInPlaceForUniqueReference) {
   EXPECT_TRUE(arr.unique());
   auto* before = arr.get();
 
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   arr.MutateByApply([](TInt) { return TInt(2); });
   auto* after = arr.get();
   EXPECT_EQ(before, after);
@@ -64,6 +65,7 @@ TEST(Array, CopyWhenMutatingNonUniqueReference) {
   EXPECT_TRUE(!arr.unique());
   auto* before = arr.get();
 
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   arr.MutateByApply([](TInt) { return TInt(2); });
   auto* after = arr.get();
   EXPECT_NE(before, after);
@@ -73,8 +75,11 @@ TEST(Array, Map) {
   // Basic functionality
   TInt x(1), y(1);
   Array<TInt> var_arr{x, y};
+
   Array<TNumber> expr_arr =
-      var_arr.Map([](TInt var) -> TNumber { return TFloat(static_cast<double>(var->value + 1)); });
+      var_arr.Map([](TInt var) -> TNumber {  // NOLINT(performance-unnecessary-value-param)
+        return TFloat(static_cast<double>(var->value + 1));
+      });
 
   EXPECT_NE(var_arr.get(), expr_arr.get());
   EXPECT_TRUE(expr_arr[0]->IsInstance<TFloatObj>());
@@ -119,8 +124,8 @@ TEST(Array, ResizeReserveClear) {
   for (size_t n = 0; n < 10; ++n) {
     Array<int> a;
     Array<int> b;
-    a.resize(n);
-    b.reserve(n);
+    a.resize(static_cast<int64_t>(n));
+    b.reserve(static_cast<int64_t>(n));
     ASSERT_EQ(a.size(), n);
     ASSERT_GE(a.capacity(), n);
     a.clear();
@@ -166,8 +171,8 @@ TEST(Array, InsertEraseRange) {
     a.insert(a.end(), static_cast<int>(n));
     b.insert(b.end(), static_cast<int>(n));
     for (size_t pos = 0; pos <= n; ++pos) {
-      a.insert(a.begin() + pos, range_a.begin(), range_a.end());
-      b.insert(b.begin() + pos, range_b.begin(), range_b.end());
+      a.insert(a.begin() + static_cast<std::ptrdiff_t>(pos), range_a.begin(), range_a.end());
+      b.insert(b.begin() + static_cast<std::ptrdiff_t>(pos), range_b.begin(), range_b.end());
       ASSERT_EQ(a.front(), b.front());
       ASSERT_EQ(a.back(), b.back());
       ASSERT_EQ(a.size(), n + range_a.size());
@@ -176,8 +181,10 @@ TEST(Array, InsertEraseRange) {
       for (size_t k = 0; k < m; ++k) {
         ASSERT_EQ(a[k], b[k]);
       }
-      a.erase(a.begin() + pos, a.begin() + pos + range_a.size());
-      b.erase(b.begin() + pos, b.begin() + pos + range_b.size());
+      a.erase(a.begin() + static_cast<std::ptrdiff_t>(pos),
+              a.begin() + static_cast<std::ptrdiff_t>(pos + range_a.size()));
+      b.erase(b.begin() + static_cast<std::ptrdiff_t>(pos),
+              b.begin() + static_cast<std::ptrdiff_t>(pos + range_b.size()));
     }
     ASSERT_EQ(a.front(), b.front());
     ASSERT_EQ(a.back(), b.back());
@@ -186,6 +193,7 @@ TEST(Array, InsertEraseRange) {
 }
 
 TEST(Array, FuncArrayAnyArg) {
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   Function fadd_one = Function::FromTyped([](Array<Any> a) -> Any { return a[0].cast<int>() + 1; });
   EXPECT_EQ(fadd_one(Array<Any>{1}).cast<int>(), 2);
 }
@@ -193,6 +201,7 @@ TEST(Array, FuncArrayAnyArg) {
 TEST(Array, MapUniquePropogation) {
   // Basic functionality
   Array<TInt> var_arr{TInt(1), TInt(2)};
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   var_arr.MutateByApply([](TInt x) -> TInt {
     EXPECT_TRUE(x.unique());
     return x;

--- a/tests/cpp/test_example.cc
+++ b/tests/cpp/test_example.cc
@@ -83,6 +83,7 @@ void ExampleFunctionPassFunction() {
   namespace ffi = tvm::ffi;
   // Create a function from a typed lambda
   ffi::Function fapply = ffi::Function::FromTyped(
+      // NOLINTNEXTLINE(performance-unnecessary-value-param)
       [](const ffi::Function f, ffi::Any param) { return f(param.cast<int>()); });
   ffi::Function fadd1 = ffi::Function::FromTyped(  //
       [](const int a) -> int { return a + 1; });
@@ -168,6 +169,7 @@ void ExampleArray() {
   EXPECT_EQ(numbers.size(), 3);
   EXPECT_EQ(numbers[0], 1);
 
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   ffi::Function head = ffi::Function::FromTyped([](const ffi::Array<int> a) { return a[0]; });
   EXPECT_EQ(head(numbers).cast<int>(), 1);
 
@@ -225,7 +227,7 @@ void ExampleVariant() {
 
   var0 = ffi::String("hello");
   std::optional<ffi::String> maybe_str = var0.as<ffi::String>();
-  EXPECT_EQ(maybe_str.value(), "hello");
+  EXPECT_EQ(maybe_str.value(), "hello");  // NOLINT(bugprone-unchecked-optional-access)
 
   std::optional<int> maybe_int2 = var0.as<int>();
   EXPECT_EQ(maybe_int2.has_value(), false);

--- a/tests/cpp/test_function.cc
+++ b/tests/cpp/test_function.cc
@@ -110,6 +110,7 @@ TEST(Func, FromTyped) {
 
   // try decution
   Function fpass_and_return = Function::FromTyped(
+      // NOLINTNEXTLINE(performance-unnecessary-value-param)
       [](TInt x, int value, AnyView z) -> Function {
         EXPECT_EQ(x.use_count(), 2);
         EXPECT_EQ(x->value, value);
@@ -144,6 +145,7 @@ TEST(Func, FromTyped) {
 }
 
 TEST(Func, PassReturnAny) {
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   Function fadd_one = Function::FromTyped([](Any a) -> Any { return a.cast<int>() + 1; });
   EXPECT_EQ(fadd_one(1).cast<int>(), 2);
 }
@@ -157,7 +159,7 @@ TEST(Func, Global) {
   auto fnot_exist = Function::GetGlobal("testing.not_existing_func");
   EXPECT_TRUE(!fnot_exist);
 
-  auto fname_functor =
+  auto fname_functor =  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
       Function::GetGlobal("ffi.FunctionListGlobalNamesFunctor").value()().cast<Function>();
   Array<String> names;
   int len = fname_functor(-1).cast<int>();
@@ -184,7 +186,7 @@ TEST(Func, TypedFunction) {
 TEST(Func, TypedFunctionAsAny) {
   TypedFunction<int(int)> fadd1 = [](int a) -> int { return a + 1; };
   Any fany(std::move(fadd1));
-  EXPECT_TRUE(fadd1 == nullptr);
+  EXPECT_TRUE(fadd1 == nullptr);  // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   auto fadd1_dup = fany.cast<TypedFunction<int(int)>>();
   EXPECT_EQ(fadd1_dup(1), 2);
 }

--- a/tests/cpp/test_map.cc
+++ b/tests/cpp/test_map.cc
@@ -285,6 +285,7 @@ TEST(Map, MapInsertOrder) {
     return reverse_order;
   };
 
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   auto check_map = [&](Map<String, int> m0, size_t size, const std::vector<int>& order) {
     auto lhs = m0.begin();
     auto rhs = order.begin();
@@ -295,7 +296,7 @@ TEST(Map, MapInsertOrder) {
       ++rhs;
     }
     lhs = m0.end();
-    rhs = order.begin() + size;
+    rhs = order.begin() + static_cast<std::ptrdiff_t>(size);
     do {
       --lhs;
       --rhs;

--- a/tests/cpp/test_object.cc
+++ b/tests/cpp/test_object.cc
@@ -45,7 +45,7 @@ TEST(Object, RefCounter) {
 
   ObjectPtr<TIntObj> c = std::move(a);
   EXPECT_EQ(c.use_count(), 1);
-  EXPECT_TRUE(a == nullptr);
+  EXPECT_TRUE(a == nullptr);  // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
 
   EXPECT_EQ(c->value, 11);
 }
@@ -152,6 +152,7 @@ TEST(Object, WeakObjectPtrAssignment) {
 
   // Test move construction
   WeakObjectPtr<TIntObj> weak3(std::move(weak1));
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_TRUE(weak1.expired());  // weak1 should be moved from
   EXPECT_FALSE(weak3.expired());
   EXPECT_EQ(weak3.use_count(), 1);
@@ -167,6 +168,7 @@ TEST(Object, WeakObjectPtrAssignment) {
   // Test move assignment
   WeakObjectPtr<TIntObj> weak5;
   weak5 = std::move(weak2);
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_TRUE(weak2.expired());  // weak2 should be moved from
   EXPECT_FALSE(weak5.expired());
   EXPECT_EQ(weak5.use_count(), 1);
@@ -234,7 +236,7 @@ TEST(Object, OpaqueObject) {
   thread_local int deleter_trigger_counter = 0;
   struct DummyOpaqueObject {
     int value;
-    DummyOpaqueObject(int value) : value(value) {}
+    explicit DummyOpaqueObject(int value) : value(value) {}
 
     static void Deleter(void* handle) {
       deleter_trigger_counter++;

--- a/tests/cpp/test_optional.cc
+++ b/tests/cpp/test_optional.cc
@@ -43,6 +43,7 @@ TEST(Optional, TInt) {
   Any z_any = std::move(y);
   EXPECT_TRUE(z_any != nullptr);
   EXPECT_EQ((z_any.cast<TInt>())->value, 11);
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_TRUE(!y.has_value());
 
   // move from any to optional
@@ -67,7 +68,7 @@ TEST(Optional, double) {
   EXPECT_TRUE(y != 12);
 }
 
-TEST(Optional, AnyConvert_int) {
+TEST(Optional, AnyConvertInt) {
   Optional<int> opt_v0 = 1;
   EXPECT_EQ(opt_v0.value(), 1);
   EXPECT_TRUE(opt_v0.has_value());
@@ -83,7 +84,7 @@ TEST(Optional, AnyConvert_int) {
   EXPECT_EQ(any2.cast<int>(), 11);
 }
 
-TEST(Optional, AnyConvert_Array) {
+TEST(Optional, AnyConvertArray) {
   AnyView view0;
   Array<Array<TNumber>> arr_nested = {{}, {TInt(1), TFloat(2)}};
   view0 = arr_nested;
@@ -142,6 +143,7 @@ TEST(Optional, OptionalOfOptional) {
 TEST(Optional, ValueMove) {
   Optional<TInt> y = TInt(11);
   TInt x = std::move(y).value();
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_TRUE(!y.has_value());
   EXPECT_EQ(x->value, 11);
 
@@ -151,6 +153,7 @@ TEST(Optional, ValueMove) {
 
   TInt moved_tint = *std::move(opt_tint);
   EXPECT_EQ(moved_tint->value, 21);
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_TRUE(!opt_tint.has_value());
 }
 

--- a/tests/cpp/test_reflection.cc
+++ b/tests/cpp/test_reflection.cc
@@ -142,7 +142,7 @@ TEST(Reflection, CallMethod) {
   EXPECT_EQ(prim_expr_sub(TPrimExpr("float", 1), 2.0).cast<double>(), -1.0);
 }
 
-TEST(Reflection, InitFunction_Base) {
+TEST(Reflection, InitFunctionBase) {
   Function int_init = reflection::GetMethod("test.TestObjA", "__ffi_init__");
   Any obj_a = int_init(1, 2);
   EXPECT_TRUE(obj_a.as<TestObjA>() != nullptr);
@@ -150,7 +150,7 @@ TEST(Reflection, InitFunction_Base) {
   EXPECT_EQ(obj_a.as<TestObjA>()->y, 2);
 }
 
-TEST(Reflection, InitFunction_Derived) {
+TEST(Reflection, InitFunctionDerived) {
   Function derived_init = reflection::GetMethod("test.TestObjADerived", "__ffi_init__");
   Any obj_derived = derived_init(1, 2, 3);
   EXPECT_TRUE(obj_derived.as<TestObjADerived>() != nullptr);
@@ -163,7 +163,7 @@ TEST(Reflection, ForEachFieldInfo) {
   const TypeInfo* info = TVMFFIGetTypeInfo(TestObjADerived::RuntimeTypeIndex());
   Map<String, int> field_name_to_offset;
   reflection::ForEachFieldInfo(info, [&](const TVMFFIFieldInfo* field_info) {
-    field_name_to_offset.Set(String(field_info->name), field_info->offset);
+    field_name_to_offset.Set(String(field_info->name), static_cast<int>(field_info->offset));
   });
   EXPECT_EQ(field_name_to_offset["x"], sizeof(TVMFFIObject));
   EXPECT_EQ(field_name_to_offset["y"], 8 + sizeof(TVMFFIObject));

--- a/tests/cpp/test_rvalue_ref.cc
+++ b/tests/cpp/test_rvalue_ref.cc
@@ -48,6 +48,7 @@ TEST(RValueRef, Basic) {
 
 TEST(RValueRef, ParamChecking) {
   // try decution
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   Function fadd1 = Function::FromTyped([](TInt a) -> int64_t { return a->value + 1; });
 
   // convert that triggers error

--- a/tests/cpp/test_string.cc
+++ b/tests/cpp/test_string.cc
@@ -29,17 +29,17 @@ TEST(String, MoveFromStd) {
   string source = "this is a string";
   string expect = source;
   String s(std::move(source));
-  string copy = (string)s;
+  string copy = string(s);
   EXPECT_EQ(copy, expect);
-  EXPECT_EQ(source.size(), 0);
+  EXPECT_EQ(source.size(), 0);  // NOLINT(bugprone-use-after-move)
 }
 
 TEST(String, CopyFromStd) {
   using namespace std;
   string source = "this is a string";
-  string expect = source;
+  string expect = source;  // NOLINT(performance-unnecessary-copy-initialization)
   String s{source};
-  string copy = (string)s;
+  string copy = string(s);
   EXPECT_EQ(copy, expect);
   EXPECT_EQ(source.size(), expect.size());
 }
@@ -113,7 +113,7 @@ TEST(String, Compare) {
 }
 
 // Check '\0' handling
-TEST(String, null_byte_handling) {
+TEST(String, NullByteHandling) {
   using namespace std;
   // Ensure string still compares equal if it contains '\0'.
   string v1 = "hello world";
@@ -154,7 +154,7 @@ TEST(String, null_byte_handling) {
   EXPECT_GT(v4.compare(v5), 0);
 }
 
-TEST(String, compare_same_memory_region_different_size) {
+TEST(String, CompareSameMemoryRegionDifferentSize) {
   using namespace std;
   string source = "a string";
   String str_source{source};
@@ -232,7 +232,7 @@ TEST(String, compare) {
   EXPECT_TRUE(str_source < str_mismatch4);
 }
 
-TEST(String, c_str) {
+TEST(String, CString) {
   using namespace std;
   string source = "this is a string";
   string mismatch = "mismatch";
@@ -296,23 +296,30 @@ TEST(String, Any) {
 
   Any b = view;
   EXPECT_EQ(b.type_index(), TypeIndex::kTVMFFISmallStr);
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
   EXPECT_EQ(b.as<String>().value(), "hello");
   EXPECT_TRUE(b.as<String>().has_value());
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
   EXPECT_EQ(b.try_cast<std::string>().value(), "hello");
 
   std::string s_world = "world";
   view = s_world;
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
   EXPECT_EQ(view.try_cast<std::string>().value(), "world");
 
   String s{"hello"};
   Any a = s;
   EXPECT_EQ(a.type_index(), TypeIndex::kTVMFFISmallStr);
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
   EXPECT_EQ(a.as<String>().value(), "hello");
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
   EXPECT_EQ(a.try_cast<std::string>().value(), "hello");
 
   Any c = "long string very long";
   EXPECT_EQ(c.type_index(), TypeIndex::kTVMFFIStr);
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
   EXPECT_EQ(c.as<String>().value(), "long string very long");
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
   EXPECT_EQ(c.try_cast<std::string>().value(), "long string very long");
 }
 
@@ -339,11 +346,13 @@ TEST(String, BytesAny) {
 
   AnyView view = &arr;
   EXPECT_EQ(view.type_index(), TypeIndex::kTVMFFIByteArrayPtr);
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
   EXPECT_EQ(view.try_cast<Bytes>().value().operator std::string(), s);
 
   Any b = view;
   EXPECT_EQ(b.type_index(), TypeIndex::kTVMFFISmallBytes);
 
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
   EXPECT_EQ(b.try_cast<Bytes>().value().operator std::string(), s);
   EXPECT_EQ(b.cast<std::string>(), s);
 
@@ -351,7 +360,8 @@ TEST(String, BytesAny) {
   s2[0] = '\0';
   Any b2 = Bytes(s2);
   EXPECT_EQ(b2.type_index(), TypeIndex::kTVMFFIBytes);
-  EXPECT_EQ(b2.try_cast<std::string>().value(), s2);
+  EXPECT_EQ(b2.try_cast<std::string>().value(),  // NOLINT(bugprone-unchecked-optional-access)
+            s2);
   EXPECT_EQ(b2.cast<std::string>(), s2);
 }
 
@@ -359,39 +369,47 @@ TEST(String, StdString) {
   std::string s1 = "test_string";
   AnyView view1 = s1;
   EXPECT_EQ(view1.type_index(), TypeIndex::kTVMFFIRawStr);
-  EXPECT_EQ(view1.try_cast<std::string>().value(), s1);
+  EXPECT_EQ(view1.try_cast<std::string>().value(),  // NOLINT(bugprone-unchecked-optional-access)
+            s1);
 
   TVMFFIByteArray arr1{s1.data(), static_cast<size_t>(s1.size())};
   AnyView view2 = &arr1;
   EXPECT_EQ(view2.type_index(), TypeIndex::kTVMFFIByteArrayPtr);
-  EXPECT_EQ(view2.try_cast<std::string>().value(), s1);
+  EXPECT_EQ(view2.try_cast<std::string>().value(),  // NOLINT(bugprone-unchecked-optional-access)
+            s1);
 
   Bytes bytes1 = s1;
   AnyView view3 = bytes1;
   EXPECT_EQ(view3.type_index(), TypeIndex::kTVMFFIBytes);
-  EXPECT_EQ(view3.try_cast<std::string>().value(), s1);
+  EXPECT_EQ(view3.try_cast<std::string>().value(),  // NOLINT(bugprone-unchecked-optional-access)
+            s1);
 
   String string1 = s1;
   AnyView view4 = string1;
   EXPECT_EQ(view4.type_index(), TypeIndex::kTVMFFIStr);
-  EXPECT_EQ(view4.try_cast<std::string>().value(), s1);
+  EXPECT_EQ(view4.try_cast<std::string>().value(),  // NOLINT(bugprone-unchecked-optional-access)
+            s1);
 
   // Test with Any
   Any any1 = s1;
   EXPECT_EQ(any1.type_index(), TypeIndex::kTVMFFIStr);
-  EXPECT_EQ(any1.try_cast<std::string>().value(), s1);
+  EXPECT_EQ(any1.try_cast<std::string>().value(),  // NOLINT(bugprone-unchecked-optional-access)
+            s1);
 
   Any any2 = &arr1;
   EXPECT_EQ(any2.type_index(), TypeIndex::kTVMFFIBytes);
-  EXPECT_EQ(any2.try_cast<std::string>().value(), s1);
+  EXPECT_EQ(any2.try_cast<std::string>().value(),  // NOLINT(bugprone-unchecked-optional-access)
+            s1);
 
   Any any3 = bytes1;
   EXPECT_EQ(any3.type_index(), TypeIndex::kTVMFFIBytes);
-  EXPECT_EQ(any3.try_cast<std::string>().value(), s1);
+  EXPECT_EQ(any3.try_cast<std::string>().value(),  // NOLINT(bugprone-unchecked-optional-access)
+            s1);
 
   Any any4 = string1;
   EXPECT_EQ(any4.type_index(), TypeIndex::kTVMFFIStr);
-  EXPECT_EQ(any4.try_cast<std::string>().value(), s1);
+  EXPECT_EQ(any4.try_cast<std::string>().value(),  // NOLINT(bugprone-unchecked-optional-access)
+            s1);
 }
 
 TEST(String, CAPIAccessor) {
@@ -406,7 +424,7 @@ TEST(String, BytesHash) {
   std::vector<int64_t> data1(10);
   std::vector<int64_t> data2(11);
   for (size_t i = 0; i < data1.size(); ++i) {
-    data1[i] = i;
+    data1[i] = static_cast<int64_t>(i);
   }
   char* data1_ptr = reinterpret_cast<char*>(data1.data());
   char* data2_ptr = reinterpret_cast<char*>(data2.data()) + 1;

--- a/tests/cpp/test_tensor.cc
+++ b/tests/cpp/test_tensor.cc
@@ -28,7 +28,7 @@ struct CPUNDAlloc {
   void FreeData(DLTensor* tensor) { free(tensor->data); }
 };
 
-inline Tensor Empty(Shape shape, DLDataType dtype, DLDevice device) {
+inline Tensor Empty(const Shape& shape, DLDataType dtype, DLDevice device) {
   return Tensor::FromNDAlloc(CPUNDAlloc(), shape, dtype, device);
 }
 
@@ -71,7 +71,7 @@ TEST(Tensor, Basic) {
   EXPECT_EQ(nd.data_ptr(), nd->data);
 
   Any any0 = nd;
-  Tensor nd2 = any0.as<Tensor>().value();
+  Tensor nd2 = any0.as<Tensor>().value();  // NOLINT(bugprone-unchecked-optional-access)
   EXPECT_EQ(nd2.dtype(), DLDataType({kDLFloat, 32, 1}));
   for (int64_t i = 0; i < shape.Product(); ++i) {
     EXPECT_EQ(reinterpret_cast<float*>(nd2->data)[i], i);
@@ -177,6 +177,7 @@ TEST(Tensor, TensorView) {
 
   AnyView result = tensor_view;
   EXPECT_EQ(result.type_index(), TypeIndex::kTVMFFIDLTensorPtr);
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
   TensorView tensor_view2 = result.as<TensorView>().value();
   EXPECT_EQ(tensor_view2.shape().size(), 3);
   EXPECT_EQ(tensor_view2.shape()[0], 1);

--- a/tests/cpp/test_tuple.cc
+++ b/tests/cpp/test_tuple.cc
@@ -68,9 +68,12 @@ TEST(Tuple, Basic) {
 TEST(Tuple, AnyConvert) {
   Tuple<int, TInt> tuple0(1, 2);
   AnyView view0 = tuple0;
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
   Array<Any> arr0 = view0.as<Array<Any>>().value();
   EXPECT_EQ(arr0.size(), 2);
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
   EXPECT_EQ(arr0[0].as<int>().value(), 1);
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
   EXPECT_EQ(arr0[1].as<TInt>().value()->value, 2);
 
   // directly reuse the underlying storage.

--- a/tests/cpp/test_variant.cc
+++ b/tests/cpp/test_variant.cc
@@ -43,6 +43,7 @@ TEST(Variant, Basic) {
 TEST(Variant, AnyConvert) {
   Variant<int, TInt> v = 1;
   AnyView view0 = v;
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
   EXPECT_EQ(view0.as<int>().value(), 1);
 
   // implicit convert to variant
@@ -65,7 +66,7 @@ TEST(Variant, ObjectPtrHashEqual) {
 
   Variant<TFloat, TInt> v0 = x;
   Variant<TFloat, TInt> v1 = y;
-  Variant<TFloat, TInt> v2 = v1;
+  Variant<TFloat, TInt> v2 = v1;  // NOLINT(performance-unnecessary-copy-initialization)
 
   EXPECT_EQ(ObjectPtrHash()(v0), ObjectPtrHash()(x));
   EXPECT_TRUE(!ObjectPtrEqual()(v0, v1));

--- a/tests/lint/check_file_type.py
+++ b/tests/lint/check_file_type.py
@@ -109,6 +109,7 @@ ALLOW_FILE_NAME = {
     "Doxyfile",
     "pylintrc",
     ".clang-format",
+    ".clang-tidy",
     ".gitmodules",
     "CODEOWNERSHIP",
     "Dockerfile",

--- a/tests/lint/clang_tidy_precommit.py
+++ b/tests/lint/clang_tidy_precommit.py
@@ -1,0 +1,162 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import subprocess
+import sys
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, Namespace
+from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+DEFAULT_SOURCE_EXTS = (".c", ".cc", ".cpp", ".cxx", ".m", ".mm")
+
+
+def parse_args(argv: Sequence[str]) -> Namespace:
+    p = ArgumentParser(
+        prog="clang-tidy-precommit",
+        description=(
+            "Run clang-tidy on changed files using a compile_commands.json "
+            "generated in a dedicated build directory."
+        ),
+        formatter_class=ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--build-dir",
+        "-B",
+        default="build-pre-commit",
+        help="CMake build directory containing compile_commands.json.",
+    )
+    p.add_argument(
+        "--jobs",
+        "-j",
+        type=int,
+        default=max(1, os.cpu_count() or 1),
+        help="Maximum parallel clang-tidy processes.",
+    )
+    p.add_argument(
+        "--fix",
+        action="store_true",
+        help="Enable clang-tidy in-place fixes (-fix).",
+    )
+    p.add_argument(
+        "files",
+        nargs="*",
+        help="Files passed by pre-commit (will be filtered by extension).",
+    )
+    return p.parse_args(list(argv))
+
+
+def filter_files(files: Sequence[str]) -> list[str]:
+    kept: list[str] = []
+    for f in files:
+        if not f:
+            continue
+        p = Path(f)
+        if p.is_dir():
+            for child in p.rglob("*"):
+                if child.is_file() and child.suffix.lower() in DEFAULT_SOURCE_EXTS:
+                    kept.append(str(child))
+            continue
+        if p.suffix.lower() in DEFAULT_SOURCE_EXTS:
+            kept.append(str(p))
+    return kept
+
+
+def ensure_compile_commands(build_dir: Path) -> Path:
+    cc_path = build_dir / "compile_commands.json"
+    if cc_path.exists():
+        return cc_path
+    build_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "cmake",
+        "-S",
+        ".",
+        "-B",
+        str(build_dir),
+        "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DTVM_FFI_BUILD_TESTS=ON",
+    ]
+    ret = subprocess.run(cmd, check=False)
+    if ret.returncode != 0:
+        print(
+            "[clang-tidy-precommit] Failed to generate compile_commands.json via CMake.",
+            file=sys.stderr,
+        )
+        sys.exit(ret.returncode)
+    if not cc_path.exists():
+        print(
+            f"[clang-tidy-precommit] Missing {cc_path}. Ensure CMake config succeeded.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return cc_path
+
+
+def build_base_cmd(p_arg: Path, fix: bool) -> list[str]:
+    cmd: list[str] = ["clang-tidy", f"-p={p_arg!s}", "-quiet"]
+    if fix:
+        cmd.append("-fix")
+    return cmd
+
+
+def run_parallel(cmd: list[str], files: list[str], jobs: int) -> int:
+    def one(f: str) -> tuple[int, str, list[str]]:
+        full_cmd = [*cmd, f]
+        print(f"[RUNNING] {' '.join(full_cmd)}", file=sys.stderr)
+        proc = subprocess.run(full_cmd, check=False, capture_output=True, text=True)
+        out = (proc.stdout or "") + (proc.stderr or "")
+        return proc.returncode, out, " ".join(full_cmd)
+
+    jobs = max(1, int(jobs or 1))
+    rc = 0
+    with ThreadPoolExecutor(max_workers=jobs) as ex:
+        futs = [ex.submit(one, f) for f in files]
+        for fut in as_completed(futs):
+            code, output, full_cmd = fut.result()
+            output = output.strip()
+            if code != 0:
+                print(f"[FAILED] {full_cmd}\n{output}")
+                rc = 1
+    return rc
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    files = filter_files(args.files)
+    if not files:
+        print("[clang-tidy-precommit] No relevant files to lint.")
+        return 0
+
+    build_dir = Path(args.build_dir).resolve()
+    cc_path = ensure_compile_commands(build_dir)
+    base_cmd = build_base_cmd(p_arg=cc_path.parent, fix=args.fix)
+    if sys.platform == "darwin":
+        base_cmd = ["xcrun", *base_cmd]
+    rc = run_parallel(base_cmd, files, args.jobs)
+    if rc != 0 and args.fix:
+        print(
+            "[clang-tidy-precommit] clang-tidy reported issues and applied fixes. "
+            "Re-stage your changes if files were modified.",
+            file=sys.stderr,
+        )
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR introduces `clang-tidy` and applies a large number of fixes it suggested.

The changes include:
- style modernizations, e.g., using `_v` and `_t` suffixes, `using` instead of `typedef`, range-based for loops
- perf improvements, e.g., using `std::move`
- and correctness fixes, e.g., adding `noexcept`, explicit casts, fixing dangling pointers

Note that `clang-tidy` is not added to CI in this PR, and to manually trigger trigger clang-tidy in this codebase, we will have to run:

```
uv run --with "clang-tidy==21.1.1"          \
  python tests/lint/clang_tidy_precommit.py \
    --build-dir=build-pre-commit            \
    --jobs=16                               \
    ./src/ ./include ./tests
```