### PR TITLE
[FEAT] Introduce TensorView for non-owning view

### DIFF
--- a/docs/get_started/quick_start.md
+++ b/docs/get_started/quick_start.md
@@ -103,7 +103,7 @@ namespace tvm_ffi_example {
 
 namespace ffi = tvm::ffi;
 
-void AddOne(ffi::Tensor x, ffi::Tensor y) {
+void AddOne(ffi::TensorView x, ffi::TensorView y) {
   // Validate inputs
   TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
   DLDataType f32_dtype{kDLFloat, 32, 1};
@@ -131,7 +131,7 @@ TVM_FFI_DLL_EXPORT_TYPED_FUNC(add_one_cpu, tvm_ffi_example::AddOne);
 ### CUDA Implementation
 
 ```cpp
-void AddOneCUDA(ffi::Tensor x, ffi::Tensor y) {
+void AddOneCUDA(ffi::TensorView x, ffi::TensorView y) {
   // Validation (same as CPU version)
   // ...
 
@@ -216,7 +216,7 @@ shows how to run the example exported function in C++.
 
 namespace ffi = tvm::ffi;
 
-void CallAddOne(ffi::Tensor x, ffi::Tensor y) {
+void CallAddOne(ffi::TensorView x, ffi::TensorView y) {
   ffi::Module mod = ffi::Module::LoadFromFile("build/add_one_cpu.so");
   ffi::Function add_one_cpu = mod->GetFunction("add_one_cpu").value();
   add_one_cpu(x, y);

--- a/docs/guides/packaging.md
+++ b/docs/guides/packaging.md
@@ -149,7 +149,7 @@ which can later be accessed via `tvm_ffi.load_module`.
 Here's a basic example of the function implementation:
 
 ```c++
-void AddOne(ffi::Tensor x, ffi::Tensor y) {
+void AddOne(ffi::TensorView x, ffi::TensorView y) {
   // ... implementation omitted ...
 }
 

--- a/docs/guides/python_guide.md
+++ b/docs/guides/python_guide.md
@@ -151,7 +151,7 @@ import tvm_ffi.cpp
 
 # define the cpp source code
 cpp_source = '''
-     void add_one_cpu(tvm::ffi::Tensor x, tvm::ffi::Tensor y) {
+     void add_one_cpu(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
        // implementation of a library function
        TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
        DLDataType f32_dtype{kDLFloat, 32, 1};

--- a/examples/inline_module/main.py
+++ b/examples/inline_module/main.py
@@ -26,7 +26,7 @@ def main() -> None:
     mod: Module = tvm_ffi.cpp.load_inline(
         name="hello",
         cpp_sources=r"""
-            void add_one_cpu(tvm::ffi::Tensor x, tvm::ffi::Tensor y) {
+            void add_one_cpu(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
               // implementation of a library function
               TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
               DLDataType f32_dtype{kDLFloat, 32, 1};
@@ -39,7 +39,7 @@ def main() -> None:
               }
             }
 
-            void add_one_cuda(tvm::ffi::Tensor x, tvm::ffi::Tensor y);
+            void add_one_cuda(tvm::ffi::TensorView x, tvm::ffi::TensorView y);
         """,
         cuda_sources=r"""
             __global__ void AddOneKernel(float* x, float* y, int n) {
@@ -49,7 +49,7 @@ def main() -> None:
               }
             }
 
-            void add_one_cuda(tvm::ffi::Tensor x, tvm::ffi::Tensor y) {
+            void add_one_cuda(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
               // implementation of a library function
               TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
               DLDataType f32_dtype{kDLFloat, 32, 1};

--- a/examples/packaging/src/extension.cc
+++ b/examples/packaging/src/extension.cc
@@ -44,7 +44,7 @@ namespace ffi = tvm::ffi;
  */
 void RaiseError(ffi::String msg) { TVM_FFI_THROW(RuntimeError) << msg; }
 
-void AddOne(ffi::Tensor x, ffi::Tensor y) {
+void AddOne(ffi::TensorView x, ffi::TensorView y) {
   // implementation of a library function
   TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
   DLDataType f32_dtype{kDLFloat, 32, 1};

--- a/examples/quick_start/run_example.py
+++ b/examples/quick_start/run_example.py
@@ -28,7 +28,7 @@ def run_add_one_cpu() -> None:
     x = numpy.array([1, 2, 3, 4, 5], dtype=numpy.float32)
     y = numpy.empty_like(x)
     # tvm-ffi automatically handles DLPack compatible tensors
-    # torch tensors can be viewed as ffi::Tensor or DLTensor*
+    # torch tensors can be viewed as ffi::TensorView
     # in the background
     mod.add_one_cpu(x, y)
     print("numpy.result after add_one(x, y)")
@@ -37,7 +37,7 @@ def run_add_one_cpu() -> None:
     x = torch.tensor([1, 2, 3, 4, 5], dtype=torch.float32)
     y = torch.empty_like(x)
     # tvm-ffi automatically handles DLPack compatible tensors
-    # torch tensors can be viewed as ffi::Tensor or DLTensor*
+    # torch tensors can be viewed as ffi::TensorView
     # in the background
     mod.add_one_cpu(x, y)
     print("torch.result after add_one(x, y)")

--- a/examples/quick_start/src/add_one_cpu.cc
+++ b/examples/quick_start/src/add_one_cpu.cc
@@ -23,7 +23,7 @@
 
 namespace tvm_ffi_example {
 
-void AddOne(tvm::ffi::Tensor x, tvm::ffi::Tensor y) {
+void AddOne(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
   // implementation of a library function
   TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
   DLDataType f32_dtype{kDLFloat, 32, 1};

--- a/examples/quick_start/src/add_one_cuda.cu
+++ b/examples/quick_start/src/add_one_cuda.cu
@@ -31,7 +31,7 @@ __global__ void AddOneKernel(float* x, float* y, int n) {
   }
 }
 
-void AddOneCUDA(tvm::ffi::Tensor x, tvm::ffi::Tensor y) {
+void AddOneCUDA(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
   // implementation of a library function
   TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
   DLDataType f32_dtype{kDLFloat, 32, 1};

--- a/include/tvm/ffi/object.h
+++ b/include/tvm/ffi/object.h
@@ -82,6 +82,8 @@ struct StaticTypeKey {
   static constexpr const char* kTVMFFIDataType = "DataType";
   /*! \brief The type key for Device */
   static constexpr const char* kTVMFFIDevice = "Device";
+  /*! \brief The type key for DLTensor* */
+  static constexpr const char* kTVMFFIDLTensorPtr = "DLTensor*";
   /*! \brief The type key for const char* */
   static constexpr const char* kTVMFFIRawStr = "const char*";
   /*! \brief The type key for TVMFFIByteArray* */

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@
 
 [project]
 name = "apache-tvm-ffi"
-version = "0.1.0b12"
+version = "0.1.0b13"
 description = "tvm ffi"
 
 authors = [{ name = "TVM FFI team" }]

--- a/python/tvm_ffi/__init__.py
+++ b/python/tvm_ffi/__init__.py
@@ -17,7 +17,7 @@
 """TVM FFI Python package."""
 
 # version
-__version__ = "0.1.0b12"
+__version__ = "0.1.0b13"
 
 # order matters here so we need to skip isort here
 # isort: skip_file

--- a/python/tvm_ffi/cpp/load_inline.py
+++ b/python/tvm_ffi/cpp/load_inline.py
@@ -453,7 +453,7 @@ def build_inline(  # noqa: PLR0915, PLR0912
 
         # define the cpp source code
         cpp_source = '''
-             void add_one_cpu(tvm::ffi::Tensor x, tvm::ffi::Tensor y) {
+             void add_one_cpu(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
                // implementation of a library function
                TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
                DLDataType f32_dtype{kDLFloat, 32, 1};
@@ -661,7 +661,7 @@ def load_inline(
 
         # define the cpp source code
         cpp_source = '''
-             void add_one_cpu(tvm::ffi::Tensor x, tvm::ffi::Tensor y) {
+             void add_one_cpu(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
                // implementation of a library function
                TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
                DLDataType f32_dtype{kDLFloat, 32, 1};

--- a/rust/tvm-ffi/scripts/generate_example_lib.py
+++ b/rust/tvm-ffi/scripts/generate_example_lib.py
@@ -32,7 +32,7 @@ def main() -> None:
     output_lib_path = tvm_ffi.cpp.build_inline(
         name="hello",
         cpp_sources=r"""
-            void add_one_cpu(tvm::ffi::Tensor x, tvm::ffi::Tensor y) {
+            void add_one_cpu(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
               // implementation of a library function
               TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
               DLDataType f32_dtype{kDLFloat, 32, 1};

--- a/tests/cpp/test_tensor.cc
+++ b/tests/cpp/test_tensor.cc
@@ -163,4 +163,28 @@ TEST(Tensor, DLPackAllocError) {
       tvm::ffi::Error);
 }
 
+TEST(Tensor, TensorView) {
+  Tensor tensor = Empty({1, 2, 3}, DLDataType({kDLFloat, 32, 1}), DLDevice({kDLCPU, 0}));
+  TensorView tensor_view = tensor;
+
+  EXPECT_EQ(tensor_view.shape().size(), 3);
+  EXPECT_EQ(tensor_view.shape()[0], 1);
+  EXPECT_EQ(tensor_view.shape()[1], 2);
+  EXPECT_EQ(tensor_view.shape()[2], 3);
+  EXPECT_EQ(tensor_view.dtype().code, kDLFloat);
+  EXPECT_EQ(tensor_view.dtype().bits, 32);
+  EXPECT_EQ(tensor_view.dtype().lanes, 1);
+
+  AnyView result = tensor_view;
+  EXPECT_EQ(result.type_index(), TypeIndex::kTVMFFIDLTensorPtr);
+  TensorView tensor_view2 = result.as<TensorView>().value();
+  EXPECT_EQ(tensor_view2.shape().size(), 3);
+  EXPECT_EQ(tensor_view2.shape()[0], 1);
+  EXPECT_EQ(tensor_view2.shape()[1], 2);
+  EXPECT_EQ(tensor_view2.shape()[2], 3);
+  EXPECT_EQ(tensor_view2.dtype().code, kDLFloat);
+  EXPECT_EQ(tensor_view2.dtype().bits, 32);
+  EXPECT_EQ(tensor_view2.dtype().lanes, 1);
+}
+
 }  // namespace

--- a/tests/python/test_build_inline.py
+++ b/tests/python/test_build_inline.py
@@ -24,7 +24,7 @@ def test_build_inline_cpp() -> None:
     output_lib_path = tvm_ffi.cpp.build_inline(
         name="hello",
         cpp_sources=r"""
-            void add_one_cpu(tvm::ffi::Tensor x, tvm::ffi::Tensor y) {
+            void add_one_cpu(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
               // implementation of a library function
               TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
               DLDataType f32_dtype{kDLFloat, 32, 1};

--- a/tests/python/test_load_inline.py
+++ b/tests/python/test_load_inline.py
@@ -36,7 +36,7 @@ def test_load_inline_cpp() -> None:
     mod: Module = tvm_ffi.cpp.load_inline(
         name="hello",
         cpp_sources=r"""
-            void add_one_cpu(tvm::ffi::Tensor x, tvm::ffi::Tensor y) {
+            void add_one_cpu(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
               // implementation of a library function
               TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
               DLDataType f32_dtype{kDLFloat, 32, 1};
@@ -62,7 +62,7 @@ def test_load_inline_cpp_with_docstrings() -> None:
     mod: Module = tvm_ffi.cpp.load_inline(
         name="hello",
         cpp_sources=r"""
-            void add_one_cpu(tvm::ffi::Tensor x, tvm::ffi::Tensor y) {
+            void add_one_cpu(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
               // implementation of a library function
               TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
               DLDataType f32_dtype{kDLFloat, 32, 1};
@@ -89,7 +89,7 @@ def test_load_inline_cpp_multiple_sources() -> None:
         name="hello",
         cpp_sources=[
             r"""
-            void add_one_cpu(tvm::ffi::Tensor x, tvm::ffi::Tensor y) {
+            void add_one_cpu(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
               // implementation of a library function
               TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
               DLDataType f32_dtype{kDLFloat, 32, 1};
@@ -103,7 +103,7 @@ def test_load_inline_cpp_multiple_sources() -> None:
             }
         """,
             r"""
-            void add_two_cpu(tvm::ffi::Tensor x, tvm::ffi::Tensor y) {
+            void add_two_cpu(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
               // implementation of a library function
               TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
               DLDataType f32_dtype{kDLFloat, 32, 1};
@@ -130,7 +130,7 @@ def test_load_inline_cpp_build_dir() -> None:
     mod: Module = tvm_ffi.cpp.load_inline(
         name="hello",
         cpp_sources=r"""
-            void add_one_cpu(tvm::ffi::Tensor x, tvm::ffi::Tensor y) {
+            void add_one_cpu(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
               // implementation of a library function
               TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
               DLDataType f32_dtype{kDLFloat, 32, 1};
@@ -167,7 +167,7 @@ def test_load_inline_cuda() -> None:
               }
             }
 
-            void add_one_cuda(tvm::ffi::Tensor x, tvm::ffi::Tensor y, int64_t raw_stream) {
+            void add_one_cuda(tvm::ffi::TensorView x, tvm::ffi::TensorView y, int64_t raw_stream) {
               // implementation of a library function
               TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
               DLDataType f32_dtype{kDLFloat, 32, 1};
@@ -261,7 +261,7 @@ def test_load_inline_both() -> None:
     mod: Module = tvm_ffi.cpp.load_inline(
         name="hello",
         cpp_sources=r"""
-            void add_one_cpu(tvm::ffi::Tensor x, tvm::ffi::Tensor y) {
+            void add_one_cpu(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
               // implementation of a library function
               TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
               DLDataType f32_dtype{kDLFloat, 32, 1};
@@ -274,7 +274,7 @@ def test_load_inline_both() -> None:
               }
             }
 
-            void add_one_cuda(tvm::ffi::Tensor x, tvm::ffi::Tensor y);
+            void add_one_cuda(tvm::ffi::TensorView x, tvm::ffi::TensorView y);
         """,
         cuda_sources=r"""
             __global__ void AddOneKernel(float* x, float* y, int n) {
@@ -284,7 +284,7 @@ def test_load_inline_both() -> None:
               }
             }
 
-            void add_one_cuda(tvm::ffi::Tensor x, tvm::ffi::Tensor y) {
+            void add_one_cuda(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
               // implementation of a library function
               TVM_FFI_ICHECK(x->ndim == 1) << "x must be a 1D tensor";
               DLDataType f32_dtype{kDLFloat, 32, 1};


### PR DESCRIPTION
When exposing an FFI function, sometimes it is not always possible to pass in an owning reference of a Tensor, in such case, it is better to interface with the Tensor using non-owning view.

This PR adds a ffi::TensorView class to represent in-memory non-owning DLTensor view. It can be converted from DLTensorPtr* in the ffi argument but cannot be promoted to an owning Tensor.

We recommend kernel ops to make use of TensorView when possible so the exposed ops can support broad range of inputs including non-owning ones.