### PR TITLE
[COMPILE] Fixed error compile when using compiler gcc 8.x

### DIFF
--- a/include/tvm/ffi/type_traits.h
+++ b/include/tvm/ffi/type_traits.h
@@ -301,6 +301,8 @@ struct TypeTraits<Int, std::enable_if_t<std::is_integral_v<Int>>> : public TypeT
   TVM_FFI_INLINE static std::string TypeStr() { return StaticTypeKey::kTVMFFIInt; }
 };
 
+/// \cond Doxygen_Suppress
+
 // trait to check if a type is an integeral enum
 // note that we need this trait so we can confirm underlying_type_t is an integral type
 // to avoid potential undefined behavior
@@ -309,6 +311,8 @@ constexpr bool is_integeral_enum_v = false;
 
 template <typename T>
 constexpr bool is_integeral_enum_v<T, true> = std::is_integral_v<std::underlying_type_t<T>>;
+
+/// \endcond
 
 // Enum Integer POD values
 template <typename IntEnum>


### PR DESCRIPTION
<img width="1903" height="592" alt="Screenshot 2025-10-03 153819" src="https://github.com/user-attachments/assets/118e2233-ab47-4690-a5be-ef75c28bdd17" />

Resolved: Add safe_underlying_type_t: check enum before using std::underlying_type