### PR TITLE
[CYTHON] Fix memory leak when tensor alloc returns to python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@
 
 [project]
 name = "apache-tvm-ffi"
-version = "0.1.0b14"
+version = "0.1.0b15"
 description = "tvm ffi"
 
 authors = [{ name = "TVM FFI team" }]

--- a/python/tvm_ffi/__init__.py
+++ b/python/tvm_ffi/__init__.py
@@ -17,7 +17,7 @@
 """TVM FFI Python package."""
 
 # version
-__version__ = "0.1.0b14"
+__version__ = "0.1.0b15"
 
 # order matters here so we need to skip isort here
 # isort: skip_file


### PR DESCRIPTION
This PR fixes a memory leak when tensor alloc inside the function and return to python. We need to delete the chandle to prevent memory leak as the ownership count is transfered to DLManagedTensor.