### PR TITLE
[BUILD] Enable free threaded python build

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -79,10 +79,10 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - {os: ubuntu-latest, arch: x86_64, python_version: '3.13'}
+          - {os: ubuntu-latest, arch: x86_64, python_version: '3.14t'}
           - {os: ubuntu-24.04-arm, arch: aarch64, python_version: '3.9'}
           - {os: windows-latest, arch: AMD64, python_version: '3.12'}
-          - {os: macos-14, arch: arm64, python_version: '3.10'}
+          - {os: macos-14, arch: arm64, python_version: '3.13'}
 
     steps:
       - uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,8 +192,17 @@ if (TVM_FFI_BUILD_PYTHON_MODULE)
       ${CMAKE_CURRENT_SOURCE_DIR}/python/tvm_ffi/cython/object.pxi
       ${CMAKE_CURRENT_SOURCE_DIR}/python/tvm_ffi/cython/string.pxi
   )
-  # set working directory to source so we can see the exact file name in backtrace relatived to the
-  # project source root
+  # Run a Python script to check for free-threaded build
+  execute_process(
+    COMMAND ${Python_EXECUTABLE} -c
+            "import sysconfig; print(sysconfig.get_config_var('Py_GIL_DISABLED') == 1)"
+    OUTPUT_VARIABLE PYTHON_IS_FREE_THREADED
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if (PYTHON_IS_FREE_THREADED)
+    message(STATUS "Free-threaded Python detected.")
+  endif ()
+
   add_custom_command(
     OUTPUT ${_core_cpp}
     COMMAND ${Python_EXECUTABLE} -m cython --cplus ${_core_pyx} -o ${_core_cpp}
@@ -202,7 +211,8 @@ if (TVM_FFI_BUILD_PYTHON_MODULE)
     DEPENDS ${_cython_sources}
     VERBATIM
   )
-  if (Python_VERSION VERSION_GREATER_EQUAL "3.12")
+
+  if (Python_VERSION VERSION_GREATER_EQUAL "3.12" AND NOT PYTHON_IS_FREE_THREADED)
     # >= Python3.12, use Use_SABI version
     python_add_library(tvm_ffi_cython MODULE "${_core_cpp}" USE_SABI 3.12)
     set_target_properties(tvm_ffi_cython PROPERTIES OUTPUT_NAME "core")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ GitHub = "https://github.com/apache/tvm-ffi"
 # setup tools is needed by torch jit for best perf
 torch = ["torch", "setuptools", "ninja"]
 cpp = ["ninja"]
-test = ["pytest", "numpy", "torch", "ninja"]
+# note pytorch does not yet ship with 3.14t
+test = ["pytest", "numpy", "ninja", "torch; python_version < '3.14'"]
 
 [dependency-groups]
 docs = [
@@ -197,7 +198,8 @@ build-verbosity = 1
 
 # only build up to cp312, cp312
 # will be abi3 and can be used in future versions
-build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
+# ship 314t threaded nogil version
+build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp314t-*"]
 skip = ["*musllinux*"]
 # we only need to test on cp312
 test-skip = ["cp39-*", "cp310-*", "cp311-*"]

--- a/python/tvm_ffi/cython/base.pxi
+++ b/python/tvm_ffi/cython/base.pxi
@@ -339,6 +339,8 @@ cdef extern from "tvm_ffi_python_helpers.h":
     int TVMFFIPyArgSetterInt_(TVMFFIPyArgSetter*, TVMFFIPyCallContext*, PyObject* arg, TVMFFIAny* out) except -1
     int TVMFFIPyArgSetterBool_(TVMFFIPyArgSetter*, TVMFFIPyCallContext*, PyObject* arg, TVMFFIAny* out) except -1
     int TVMFFIPyArgSetterNone_(TVMFFIPyArgSetter*, TVMFFIPyCallContext*, PyObject* arg, TVMFFIAny* out) except -1
+    # deleter for python objects
+    void TVMFFIPyObjectDeleter(void* py_obj) noexcept nogil
 
 
 cdef class ByteArrayArg:

--- a/python/tvm_ffi/cython/core.pyx
+++ b/python/tvm_ffi/cython/core.pyx
@@ -1,3 +1,5 @@
+# cython: freethreading_compatible = True
+# cython: language_level=3
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/src/ffi/object.cc
+++ b/src/ffi/object.cc
@@ -339,7 +339,13 @@ class TypeTable {
                             TypeIndex::kTVMFFIObjectRValueRef);
     ReserveBuiltinTypeIndex(StaticTypeKey::kTVMFFISmallStr, TypeIndex::kTVMFFISmallStr);
     ReserveBuiltinTypeIndex(StaticTypeKey::kTVMFFISmallBytes, TypeIndex::kTVMFFISmallBytes);
-    ReserveBuiltinTypeIndex(StaticTypeKey::kTVMFFIOpaquePyObject, TypeIndex::kTVMFFIOpaquePyObject);
+    // register opaque py whose type depth is 1
+    this->GetOrAllocTypeIndex(StaticTypeKey::kTVMFFIOpaquePyObject,
+                              TypeIndex::kTVMFFIOpaquePyObject,
+                              /*type_depth=*/1,
+                              /*num_child_slots=*/0,
+                              /*child_slots_can_overflow=*/false,
+                              /*parent_type_index=*/TypeIndex::kTVMFFIObject);
     // no need to reserve for object types as they will be registered
   }
 

--- a/tests/python/test_object.py
+++ b/tests/python/test_object.py
@@ -107,17 +107,20 @@ class MyObject:
 
 def test_opaque_object() -> None:
     obj0 = MyObject("hello")
-    assert sys.getrefcount(obj0) == 2
+    base_count = sys.getrefcount(obj0)
+    ref_count = tvm_ffi.get_global_func("testing.object_use_count")
+    assert sys.getrefcount(obj0) == base_count
     obj0_converted = tvm_ffi.convert(obj0)
-    assert sys.getrefcount(obj0) == 3
+    assert ref_count(obj0_converted) == 1
+    assert sys.getrefcount(obj0) == base_count + 1
     assert isinstance(obj0_converted, tvm_ffi.core.OpaquePyObject)
     obj0_cpy = obj0_converted.pyobject()
     assert obj0_cpy is obj0
-    assert sys.getrefcount(obj0) == 4
+    assert sys.getrefcount(obj0) == base_count + 2
     obj0_converted = None
-    assert sys.getrefcount(obj0) == 3
+    assert sys.getrefcount(obj0) == base_count + 1
     obj0_cpy = None
-    assert sys.getrefcount(obj0) == 2
+    assert sys.getrefcount(obj0) == base_count
 
 
 def test_opaque_type_error() -> None:


### PR DESCRIPTION
This PR makes the cmake and tests to be compatible with free threaded python.
Also fixes an issue where OpaqueObject is not recognized as Object type, which is covered by the ffi ref count test.