### PR TITLE
[CYTHON] Expose API to construct Function from extern c

### DIFF
--- a/python/tvm_ffi/core.pyi
+++ b/python/tvm_ffi/core.pyi
@@ -528,6 +528,28 @@ class Function(Object):
         Python object.
         """
 
+    @staticmethod
+    def __from_extern_c__(c_symbol: int, keep_alive_object: Any | None = None) -> Function:
+        """Construct a ``Function`` from a C symbol and keep_alive_object.
+
+        Parameters
+        ----------
+        c_symbol : int
+            function pointer to the safe call function
+            The function pointer must ignore the first argument,
+            which is the function handle
+
+        keep_alive_object : object
+            optional closure to be captured and kept alive
+            Usually can be the execution engine that JITed the function
+
+        Returns
+        -------
+        Function
+            The constructed ``Function`` instance.
+
+        """
+
 def _register_global_func(
     name: str, pyfunc: Callable[..., Any] | Function, override: bool
 ) -> Function: ...

--- a/python/tvm_ffi/cython/base.pxi
+++ b/python/tvm_ffi/cython/base.pxi
@@ -114,7 +114,7 @@ cdef extern from "tvm/ffi/c_api.h":
         uint64_t combined_ref_count
         int32_t type_index
         uint32_t __padding
-        void (*deleter)(TVMFFIObject* self)
+        void (*deleter)(void* self, int flags)
 
     ctypedef struct TVMFFIAny:
         int32_t type_index


### PR DESCRIPTION
This PR exposes `Function.__from_extern_c__` method that allows constructing of a function from raw int and an optional keep alive var. It can be helpful to be used to create a function from JIT execution engine that provides such a symbol.