### PR TITLE
[CYTHON] Enable ffi function creation from MLIR Packed function

### DIFF
--- a/python/tvm_ffi/core.pyi
+++ b/python/tvm_ffi/core.pyi
@@ -529,7 +529,7 @@ class Function(Object):
         """
 
     @staticmethod
-    def __from_extern_c__(c_symbol: int, keep_alive_object: Any | None = None) -> Function:
+    def __from_extern_c__(c_symbol: int, *, keep_alive_object: Any | None = None) -> Function:
         """Construct a ``Function`` from a C symbol and keep_alive_object.
 
         Parameters
@@ -540,13 +540,35 @@ class Function(Object):
             which is the function handle
 
         keep_alive_object : object
-            optional closure to be captured and kept alive
+            optional object to be captured and kept alive
             Usually can be the execution engine that JITed the function
+            to ensure we keep the execution environment alive
+            as long as the function is alive
 
         Returns
         -------
         Function
             The constructed ``Function`` instance.
+
+        """
+
+    @staticmethod
+    def __from_mlir_packed_safe_call__(
+        mlir_packed_symbol: int, *, keep_alive_object: Any | None = None
+    ) -> Function:
+        """Construct a ``Function`` from a MLIR packed safe call function pointer.
+
+        Parameters
+        ----------
+        mlir_packed_symbol : int
+            function pointer to the MLIR packed call function pointer
+            that represents a safe call function
+
+        keep_alive_object : object
+            optional object to be captured and kept alive
+            Usually can be the execution engine that JITed the function
+            to ensure we keep the execution environment alive
+            as long as the function is alive
 
         """
 

--- a/python/tvm_ffi/cython/base.pxi
+++ b/python/tvm_ffi/cython/base.pxi
@@ -339,6 +339,10 @@ cdef extern from "tvm_ffi_python_helpers.h":
     int TVMFFIPyArgSetterInt_(TVMFFIPyArgSetter*, TVMFFIPyCallContext*, PyObject* arg, TVMFFIAny* out) except -1
     int TVMFFIPyArgSetterBool_(TVMFFIPyArgSetter*, TVMFFIPyCallContext*, PyObject* arg, TVMFFIAny* out) except -1
     int TVMFFIPyArgSetterNone_(TVMFFIPyArgSetter*, TVMFFIPyCallContext*, PyObject* arg, TVMFFIAny* out) except -1
+    # MLIRPackedSafeCall
+    void* TVMFFIPyMLIRPackedSafeCallCreate(void (*mlir_packed_safe_call)(void**) noexcept, PyObject* keep_alive_object)
+    int TVMFFIPyMLIRPackedSafeCallInvoke(void* self, const TVMFFIAny* args, int32_t num_args, TVMFFIAny* rv)
+    void TVMFFIPyMLIRPackedSafeCallDeleter(void* self)
     # deleter for python objects
     void TVMFFIPyObjectDeleter(void* py_obj) noexcept nogil
 

--- a/src/ffi/extra/testing.cc
+++ b/src/ffi/extra/testing.cc
@@ -180,6 +180,15 @@ int __add_one_c_symbol(void*, const TVMFFIAny* args, int32_t num_args, TVMFFIAny
   TVM_FFI_SAFE_CALL_END();
 }
 
+void _mlir_add_one_c_symbol(void** packed_args) {
+  void* handle = *reinterpret_cast<void**>(packed_args[0]);
+  const TVMFFIAny* args = *reinterpret_cast<const TVMFFIAny**>(packed_args[1]);
+  int32_t num_args = *reinterpret_cast<int32_t*>(packed_args[2]);
+  TVMFFIAny* rv = *reinterpret_cast<TVMFFIAny**>(packed_args[3]);
+  int* ret_code = reinterpret_cast<int*>(packed_args[4]);
+  *ret_code = __add_one_c_symbol(handle, args, num_args, rv);
+}
+
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
 
@@ -250,9 +259,13 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def("testing.object_use_count", [](const Object* obj) { return obj->use_count(); })
       .def("testing.make_unregistered_object",
            []() { return ObjectRef(make_object<TestUnregisteredObject>(41, 42)); })
-      .def("testing.get_add_one_c_symbol", []() {
-        TVMFFISafeCallType symbol = __add_one_c_symbol;
-        return reinterpret_cast<int64_t>(reinterpret_cast<void*>(symbol));
+      .def("testing.get_add_one_c_symbol",
+           []() {
+             TVMFFISafeCallType symbol = __add_one_c_symbol;
+             return reinterpret_cast<int64_t>(reinterpret_cast<void*>(symbol));
+           })
+      .def("testing.get_mlir_add_one_c_symbol", []() {
+        return reinterpret_cast<int64_t>(reinterpret_cast<void*>(_mlir_add_one_c_symbol));
       });
 }
 


### PR DESCRIPTION
MLIR Execution engine generates function that corresponds to the packed signature. As of now it is hard to access the raw extern C function pointer of SafeCall directly when we declare the signature in LLVM dialect.

This helper enables us to create ffi.Function from safe call function pointer that are exposed as MLIR packed function pointer calling convention. It can help facilitate DSLs that leverages MLIR execution engine to do JIT.

Note that in theory MLIR execution engine should be able to also support some form of "extern C" feature that directly exposes the funtion pointers of C-compatible functions with an attribute tag. So we keep this feature in the python helper layer for now in case MLIR execution engine supports it in the future.