### PR TITLE
doc: Add sphinx-design as doc dependency

### DIFF
--- a/docs/.rstcheck.cfg
+++ b/docs/.rstcheck.cfg
@@ -1,4 +1,5 @@
 [rstcheck]
 report_level = warning
-ignore_directives = automodule, autosummary, currentmodule, toctree, ifconfig
-ignore_roles = ref, cpp:class, cpp:func, py:func
+ignore_directives = automodule, autosummary, currentmodule, toctree, ifconfig, tab-set, collapse, tabs
+ignore_roles = ref, cpp:class, cpp:func, py:func, c:macro
+ignore_languages = cpp, python

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,7 @@ extensions = [
     "myst_parser",
     "nbsphinx",
     "autodocsumm",
+    "sphinx_design",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.autosummary",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ docs = [
   "sphinx-autobuild",
   "sphinx-book-theme",
   "sphinx-copybutton",
+  "sphinx-design",
   "sphinx-reredirects==0.1.2",
   "sphinx-tabs==3.4.1",
   "sphinx-toolbox==3.4.0",


### PR DESCRIPTION
sphinx design brings many of modern doc features, e.g. dropdown, tabs, buttons.