### PR TITLE
[CYTHON][REFACTOR] __tvm_ffi_object__ protocol

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@
 
 [project]
 name = "apache-tvm-ffi"
-version = "0.1.0b17"
+version = "0.1.0b18"
 description = "tvm ffi"
 
 authors = [{ name = "TVM FFI team" }]

--- a/python/tvm_ffi/__init__.py
+++ b/python/tvm_ffi/__init__.py
@@ -17,7 +17,7 @@
 """TVM FFI Python package."""
 
 # version
-__version__ = "0.1.0b17"
+__version__ = "0.1.0b18"
 
 # order matters here so we need to skip isort here
 # isort: skip_file

--- a/python/tvm_ffi/_tensor.py
+++ b/python/tvm_ffi/_tensor.py
@@ -45,13 +45,13 @@ class Shape(tuple, PyNativeObject):
 
     """
 
-    __tvm_ffi_object__: Any
+    _tvm_ffi_cached_object: Any
 
     def __new__(cls, content: tuple[int, ...]) -> Shape:
         if any(not isinstance(x, Integral) for x in content):
             raise ValueError("Shape must be a tuple of integers")
         val: Shape = tuple.__new__(cls, content)
-        val.__init_tvm_ffi_object_by_constructor__(_ffi_api.Shape, *content)
+        val.__init_cached_object_by_constructor__(_ffi_api.Shape, *content)
         return val
 
     # pylint: disable=no-self-argument
@@ -59,7 +59,7 @@ class Shape(tuple, PyNativeObject):
         """Construct from a given tvm object."""
         content = _shape_obj_get_py_tuple(obj)
         val: Shape = tuple.__new__(cls, content)  # type: ignore[arg-type]
-        val.__tvm_ffi_object__ = obj  # type: ignore[attr-defined]
+        val._tvm_ffi_cached_object = obj  # type: ignore[attr-defined]
         return val
 
 

--- a/python/tvm_ffi/core.pyi
+++ b/python/tvm_ffi/core.pyi
@@ -206,7 +206,7 @@ class PyNativeObject:
     """
 
     __slots__: list[str]
-    def __init_tvm_ffi_object_by_constructor__(self, fconstructor: Any, *args: Any) -> None: ...
+    def __init_cached_object_by_constructor__(self, fconstructor: Any, *args: Any) -> None: ...
 
 def _set_class_object(cls: type) -> None: ...
 def _register_object_by_index(type_index: int, type_cls: type) -> TypeInfo: ...
@@ -602,8 +602,8 @@ class String(str, PyNativeObject):
 
     """
 
-    __slots__ = ["__tvm_ffi_object__"]
-    __tvm_ffi_object__: Object | None
+    __slots__ = ["_tvm_ffi_cached_object"]
+    _tvm_ffi_cached_object: Object | None
 
     def __new__(cls, value: str) -> String:
         """Create a new ``String`` from a Python ``str``."""
@@ -620,8 +620,8 @@ class Bytes(bytes, PyNativeObject):
     layer constructs :class:`Bytes` as needed.
     """
 
-    __slots__ = ["__tvm_ffi_object__"]
-    __tvm_ffi_object__: Object | None
+    __slots__ = ["_tvm_ffi_cached_object"]
+    _tvm_ffi_cached_object: Object | None
 
     def __new__(cls, value: bytes) -> Bytes:
         """Create a new ``Bytes`` from a Python ``bytes`` value."""

--- a/python/tvm_ffi/cython/object.pxi
+++ b/python/tvm_ffi/cython/object.pxi
@@ -218,8 +218,8 @@ class PyNativeObject:
     """Base class of all TVM objects that also subclass python's builtin types."""
     __slots__ = []
 
-    def __init_tvm_ffi_object_by_constructor__(self, fconstructor, *args):
-        """Initialize the internal tvm_ffi_object by calling constructor function.
+    def __init_cached_object_by_constructor__(self, fconstructor, *args):
+        """Initialize the internal _tvm_ffi_cached_object by calling constructor function.
 
         Parameters
         ----------
@@ -236,7 +236,7 @@ class PyNativeObject:
         """
         obj = _CLASS_OBJECT.__new__(_CLASS_OBJECT)
         obj.__init_handle_by_constructor__(fconstructor, *args)
-        self.__tvm_ffi_object__ = obj
+        self._tvm_ffi_cached_object = obj
 
 
 def _object_type_key_to_index(str type_key):

--- a/python/tvm_ffi/cython/string.pxi
+++ b/python/tvm_ffi/cython/string.pxi
@@ -29,7 +29,7 @@ cdef inline bytes _bytes_obj_get_py_bytes(obj):
 
 
 class String(str, PyNativeObject):
-    __slots__ = ["__tvm_ffi_object__"]
+    __slots__ = ["_tvm_ffi_cached_object"]
     """String object that is possibly returned by FFI call.
 
     Note
@@ -39,7 +39,7 @@ class String(str, PyNativeObject):
     """
     def __new__(cls, value):
         val = str.__new__(cls, value)
-        val.__tvm_ffi_object__ = None
+        val._tvm_ffi_cached_object = None
         return val
 
     # pylint: disable=no-self-argument
@@ -47,7 +47,7 @@ class String(str, PyNativeObject):
         """Construct from a given tvm object."""
         content = _string_obj_get_py_str(obj)
         val = str.__new__(cls, content)
-        val.__tvm_ffi_object__ = obj
+        val._tvm_ffi_cached_object = obj
         return val
 
 
@@ -64,7 +64,7 @@ class Bytes(bytes, PyNativeObject):
     """
     def __new__(cls, value):
         val = bytes.__new__(cls, value)
-        val.__tvm_ffi_object__ = None
+        val._tvm_ffi_cached_object = None
         return val
 
     # pylint: disable=no-self-argument
@@ -72,7 +72,7 @@ class Bytes(bytes, PyNativeObject):
         """Construct from a given tvm object."""
         content = _bytes_obj_get_py_bytes(obj)
         val = bytes.__new__(cls, content)
-        val.__tvm_ffi_object__ = obj
+        val._tvm_ffi_cached_object = obj
         return val
 
 

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -109,7 +109,7 @@ def test_string_bytes_passing() -> None:
     x = "hello" * 100
     y = fecho(x)
     assert y == x
-    assert y.__tvm_ffi_object__ is not None
+    assert y._tvm_ffi_cached_object is not None
     use_count(y) == 1
     # small bytes
     assert fecho(b"hello") == b"hello"
@@ -117,7 +117,7 @@ def test_string_bytes_passing() -> None:
     x2 = b"hello" * 100
     y2 = fecho(x2)
     assert y2 == x2
-    assert y2.__tvm_ffi_object__ is not None
+    assert y2._tvm_ffi_cached_object is not None
     fecho(y2) == 1
 
 

--- a/tests/python/test_object.py
+++ b/tests/python/test_object.py
@@ -133,6 +133,22 @@ def test_opaque_type_error() -> None:
     )
 
 
+def test_object_protocol() -> None:
+    class CompactObject:
+        def __init__(self, backend_obj: Any) -> None:
+            self.backend_obj = backend_obj
+
+        def __tvm_ffi_object__(self) -> Any:
+            return self.backend_obj
+
+    x = tvm_ffi.convert([])
+    assert isinstance(x, tvm_ffi.Object)
+    x_compact = CompactObject(x)
+    test_echo = tvm_ffi.get_global_func("testing.echo")
+    y = test_echo(x_compact)
+    assert y.__chandle__() == x.__chandle__()
+
+
 def test_unregistered_object_fallback() -> None:
     def _check_type(x: Any) -> None:
         type_info: TypeInfo = type(x).__tvm_ffi_type_info__  # type: ignore[attr-defined]

--- a/tests/python/test_tensor.py
+++ b/tests/python/test_tensor.py
@@ -53,12 +53,12 @@ def test_shape_object() -> None:
 
     fecho = tvm_ffi.convert(lambda x: x)
     shape2: tvm_ffi.Shape = fecho(shape)
-    assert shape2.__tvm_ffi_object__.same_as(shape.__tvm_ffi_object__)
+    assert shape2._tvm_ffi_cached_object.same_as(shape._tvm_ffi_cached_object)
     assert isinstance(shape2, tvm_ffi.Shape)
     assert isinstance(shape2, tuple)
 
     shape3: tvm_ffi.Shape = tvm_ffi.convert(shape)
-    assert shape3.__tvm_ffi_object__.same_as(shape.__tvm_ffi_object__)
+    assert shape3._tvm_ffi_cached_object.same_as(shape._tvm_ffi_cached_object)
     assert isinstance(shape3, tvm_ffi.Shape)
 
 
@@ -100,8 +100,8 @@ def test_tvm_ffi_tensor_compatible() -> None:
             """Initialize the MyTensor."""
             self._tensor = tensor
 
-        def __tvm_ffi_tensor__(self) -> tvm_ffi.Tensor:
-            """Implement __tvm_ffi_tensor__ protocol."""
+        def __tvm_ffi_object__(self) -> tvm_ffi.Tensor:
+            """Implement __tvm_ffi_object__ protocol."""
             return self._tensor
 
     data = np.zeros((10, 8, 4, 2), dtype="int32")

--- a/tests/scripts/benchmark_dlpack.py
+++ b/tests/scripts/benchmark_dlpack.py
@@ -39,14 +39,14 @@ import tvm_ffi
 
 
 class TestFFITensor:
-    """Test FFI Tensor that exposes __tvm_ffi_tensor__ protocol."""
+    """Test FFI Tensor that exposes __tvm_ffi_object__ protocol."""
 
     def __init__(self, tensor: tvm_ffi.Tensor) -> None:
         """Initialize the TestFFITensor."""
         self._tensor = tensor
 
-    def __tvm_ffi_tensor__(self) -> tvm_ffi.Tensor:
-        """Implement __tvm_ffi_tensor__ protocol."""
+    def __tvm_ffi_object__(self) -> tvm_ffi.Tensor:
+        """Implement __tvm_ffi_object__ protocol."""
         return self._tensor
 
 


### PR DESCRIPTION
This PR does two things:
- We renamed `PyNativeObject.__tvm_ffi_object__` to `_tvm_ffi_cached_object` This is because the dunder convention is normally used for functions instead of attributes
- We then updated the original `__tvm_ffi_tensor__` protocol to `__tvm_ffi_object__` so that the same protocol can be used for generic objects.

Given the original attribute is hidden to user and we did not yet introduce `__tvm_ffi_tensor__` in a formal release, the change should have low impact. We will however freeze the protocol for formal release ideally soon.