### PR TITLE
[CPP] Remove static line based object reg in favor of ObjectDef

### DIFF
--- a/include/tvm/ffi/error.h
+++ b/include/tvm/ffi/error.h
@@ -89,7 +89,7 @@ class ErrorObj : public Object, public TVMFFIErrorCell {
  public:
   /// \cond Doxygen_Suppress
   static constexpr const int32_t _type_index = TypeIndex::kTVMFFIError;
-  TVM_FFI_DECLARE_OBJECT_INFO_STATIC("ffi.Error", ErrorObj, Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_STATIC(StaticTypeKey::kTVMFFIError, ErrorObj, Object);
   /// \endcond
 };
 

--- a/src/ffi/container.cc
+++ b/src/ffi/container.cc
@@ -22,7 +22,6 @@
  */
 #include <tvm/ffi/container/array.h>
 #include <tvm/ffi/container/map.h>
-#include <tvm/ffi/container/shape.h>
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/registry.h>
 

--- a/src/ffi/object.cc
+++ b/src/ffi/object.cc
@@ -339,18 +339,27 @@ class TypeTable {
                             TypeIndex::kTVMFFIObjectRValueRef);
     ReserveBuiltinTypeIndex(StaticTypeKey::kTVMFFISmallStr, TypeIndex::kTVMFFISmallStr);
     ReserveBuiltinTypeIndex(StaticTypeKey::kTVMFFISmallBytes, TypeIndex::kTVMFFISmallBytes);
-    // register opaque py whose type depth is 1
-    this->GetOrAllocTypeIndex(StaticTypeKey::kTVMFFIOpaquePyObject,
-                              TypeIndex::kTVMFFIOpaquePyObject,
-                              /*type_depth=*/1,
-                              /*num_child_slots=*/0,
-                              /*child_slots_can_overflow=*/false,
-                              /*parent_type_index=*/TypeIndex::kTVMFFIObject);
-    // no need to reserve for object types as they will be registered
+    // reserved static type indices for depth 1 object types
+    ReserveDepthOneObjectTypeIndex(StaticTypeKey::kTVMFFIStr, TypeIndex::kTVMFFIStr);
+    ReserveDepthOneObjectTypeIndex(StaticTypeKey::kTVMFFIBytes, TypeIndex::kTVMFFIBytes);
+    ReserveDepthOneObjectTypeIndex(StaticTypeKey::kTVMFFIError, TypeIndex::kTVMFFIError);
+    ReserveDepthOneObjectTypeIndex(StaticTypeKey::kTVMFFIFunction, TypeIndex::kTVMFFIFunction);
+    ReserveDepthOneObjectTypeIndex(StaticTypeKey::kTVMFFIShape, TypeIndex::kTVMFFIShape);
+    ReserveDepthOneObjectTypeIndex(StaticTypeKey::kTVMFFITensor, TypeIndex::kTVMFFITensor);
+    ReserveDepthOneObjectTypeIndex(StaticTypeKey::kTVMFFIArray, TypeIndex::kTVMFFIArray);
+    ReserveDepthOneObjectTypeIndex(StaticTypeKey::kTVMFFIMap, TypeIndex::kTVMFFIMap);
+    ReserveDepthOneObjectTypeIndex(StaticTypeKey::kTVMFFIModule, TypeIndex::kTVMFFIModule);
+    ReserveDepthOneObjectTypeIndex(StaticTypeKey::kTVMFFIOpaquePyObject,
+                                   TypeIndex::kTVMFFIOpaquePyObject);
   }
 
   void ReserveBuiltinTypeIndex(const char* type_key, int32_t static_type_index) {
     this->GetOrAllocTypeIndex(String(type_key), static_type_index, 0, 0, false, -1);
+  }
+
+  void ReserveDepthOneObjectTypeIndex(const char* type_key, int32_t static_type_index) {
+    this->GetOrAllocTypeIndex(String(type_key), static_type_index, 1, 0, false,
+                              TypeIndex::kTVMFFIObject);
   }
 
   static ObjectPtr<details::StringObj> MakeInplaceString(const char* data, size_t length) {

--- a/tests/cpp/test_object.cc
+++ b/tests/cpp/test_object.cc
@@ -55,8 +55,8 @@ TEST(Object, TypeInfo) {
   EXPECT_TRUE(info != nullptr);
   EXPECT_EQ(info->type_index, TIntObj::RuntimeTypeIndex());
   EXPECT_EQ(info->type_depth, 2);
-  EXPECT_EQ(info->type_ancestors[0]->type_index, Object::_type_index);
-  EXPECT_EQ(info->type_ancestors[1]->type_index, TNumberObj::_type_index);
+  EXPECT_EQ(info->type_ancestors[0]->type_index, Object::RuntimeTypeIndex());
+  EXPECT_EQ(info->type_ancestors[1]->type_index, TNumberObj::RuntimeTypeIndex());
   EXPECT_GE(info->type_index, TypeIndex::kTVMFFIDynObjectBegin);
 }
 

--- a/tests/cpp/test_reflection.cc
+++ b/tests/cpp/test_reflection.cc
@@ -172,7 +172,7 @@ TEST(Reflection, ForEachFieldInfo) {
 
 TEST(Reflection, TypeAttrColumn) {
   reflection::TypeAttrColumn size_attr("test.size");
-  EXPECT_EQ(size_attr[TIntObj::_type_index].cast<int>(), sizeof(TIntObj));
+  EXPECT_EQ(size_attr[TIntObj::RuntimeTypeIndex()].cast<int>(), sizeof(TIntObj));
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() {


### PR DESCRIPTION
This PR moves static inline registrations of objects in the object reg macros.

Rationale: while the static inline based registration is convenient and removes the need for explicit registration this can cause extra space overhead for every dll that includes the header file even if the class is not used.

Given that reflection::ObjectDef<T> already registers the type index and static type objects are predefined that we can control, we explicitly removes the static inline based reg trigger to we can save up possible binary space and reduce init logic.

This does mean that when an Object is not registered through ObjectDef the dynamic casting mechanism won't work. But we are OK since expectation is most dynamic ObjectRef needs to do so for it to be useful.