### PR TITLE
[CMake] Add config.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,20 @@ cmake_minimum_required(VERSION 3.18)
 
 project(tvm_ffi LANGUAGES CXX C)
 
+# load the config.cmake file
+if (EXISTS ${CMAKE_BINARY_DIR}/config.cmake)
+  message(STATUS "Config file: ${CMAKE_BINARY_DIR}/config.cmake")
+  include(${CMAKE_BINARY_DIR}/config.cmake)
+elseif (EXISTS ${PROJECT_SOURCE_DIR}/config.cmake)
+  message(STATUS "Config file: ${PROJECT_SOURCE_DIR}/config.cmake")
+  include(${PROJECT_SOURCE_DIR}/config.cmake)
+elseif (EXISTS ${PROJECT_SOURCE_DIR}/cmake/config.cmake)
+  message(STATUS "Config file: ${PROJECT_SOURCE_DIR}/cmake/config.cmake")
+  include(${PROJECT_SOURCE_DIR}/cmake/config.cmake)
+else ()
+  message(STATUS "No config.cmake found. Using the default config")
+endif ()
+
 option(TVM_FFI_USE_LIBBACKTRACE "Enable libbacktrace" ON)
 option(TVM_FFI_USE_EXTRA_CXX_API "Enable extra CXX API in shared lib" ON)
 option(TVM_FFI_BACKTRACE_ON_SEGFAULT "Set signal handler to print backtrace on segfault" ON)

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
+
+# Options
+set(TVM_FFI_USE_LIBBACKTRACE ON)
+set(TVM_FFI_USE_EXTRA_CXX_API ON)
+set(TVM_FFI_BACKTRACE_ON_SEGFAULT ON)
+set(TVM_FFI_ATTACH_DEBUG_SYMBOLS OFF)
+set(TVM_FFI_BUILD_TESTS OFF)
+set(TVM_FFI_BUILD_PYTHON_MODULE OFF)


### PR DESCRIPTION
This PR adds a config.cmake file to conveniently configure the cmake options with file.