### PR TITLE
feat: Add a method to define initializer

### DIFF
--- a/docs/guides/cpp_guide.md
+++ b/docs/guides/cpp_guide.md
@@ -105,7 +105,7 @@ class MyIntPairObj : public tvm::ffi::Object {
 
   // Required: declare type information
   // to register a dynamic type index through the system
-TVM_FFI_DECLARE_OBJECT_INFO_FINAL("example.MyIntPair", MyIntPairObj, tvm::ffi::Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("example.MyIntPair", MyIntPairObj, tvm::ffi::Object);
 };
 
 void ExampleObjectPtr() {

--- a/docs/guides/python_guide.md
+++ b/docs/guides/python_guide.md
@@ -235,7 +235,7 @@ public:
   TestIntPairObj(int64_t a, int64_t b) : a(a), b(b) {}
 
   // Required: declare type information
-TVM_FFI_DECLARE_OBJECT_INFO_FINAL("testing.TestIntPair", TestIntPairObj, tvm::ffi::Object);
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("testing.TestIntPair", TestIntPairObj, tvm::ffi::Object);
 };
 
 // Step 2: Define the reference wrapper (user-facing interface)
@@ -253,13 +253,11 @@ public:
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   // register the object into the system
-  // register field accessors and a global static function `__create__` as ffi::Function
+  // register field accessors and a global static function `__ffi_init__` as ffi::Function
   refl::ObjectDef<TestIntPairObj>()
+    .def(refl::init<int64_t, int64_t>())
     .def_ro("a", &TestIntPairObj::a)
-    .def_ro("b", &TestIntPairObj::b)
-    .def_static("__create__", [](int64_t a, int64_t b) -> TestIntPair {
-      return TestIntPair(a, b);
-    });
+    .def_ro("b", &TestIntPairObj::b);
 }
 ```
 
@@ -274,7 +272,7 @@ class TestIntPair(tvm_ffi.Object):
     def __init__(self, a, b):
         # This is a special method to call an FFI function whose return
         # value exactly initializes the object handle of the object
-        self.__init_handle_by_constructor__(TestIntPair.__create__, a, b)
+        self.__ffi_init__(a, b)
 
 test_int_pair = TestIntPair(1, 2)
 # We can access the fields by name

--- a/src/ffi/testing/testing.cc
+++ b/src/ffi/testing/testing.cc
@@ -68,9 +68,9 @@ class TestIntPair : public tvm::ffi::ObjectRef {
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   refl::ObjectDef<TestIntPairObj>()
+      .def(refl::init<int64_t, int64_t>())
       .def_ro("a", &TestIntPairObj::a, "Field `a`")
       .def_ro("b", &TestIntPairObj::b, "Field `b`")
-      .def_static("__ffi_init__", refl::init<TestIntPairObj, int64_t, int64_t>)
       .def("sum", &TestIntPair::Sum, "Method to compute sum of a and b");
 }
 
@@ -206,40 +206,36 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def_ro("v_array", &TestObjectDerived::v_array);
 
   refl::ObjectDef<TestCxxClassBase>()
-      .def_static("__ffi_init__", refl::init<TestCxxClassBase, int64_t, int32_t>)
+      .def(refl::init<int64_t, int32_t>())
       .def_rw("v_i64", &TestCxxClassBase::v_i64)
       .def_rw("v_i32", &TestCxxClassBase::v_i32);
 
   refl::ObjectDef<TestCxxClassDerived>()
-      .def_static("__ffi_init__", refl::init<TestCxxClassDerived, int64_t, int32_t, double, float>)
+      .def(refl::init<int64_t, int32_t, double, float>())
       .def_rw("v_f64", &TestCxxClassDerived::v_f64)
       .def_rw("v_f32", &TestCxxClassDerived::v_f32);
 
   refl::ObjectDef<TestCxxClassDerivedDerived>()
-      .def_static(
-          "__ffi_init__",
-          refl::init<TestCxxClassDerivedDerived, int64_t, int32_t, double, float, String, bool>)
+      .def(refl::init<int64_t, int32_t, double, float, String, bool>())
       .def_rw("v_str", &TestCxxClassDerivedDerived::v_str)
       .def_rw("v_bool", &TestCxxClassDerivedDerived::v_bool);
 
   refl::ObjectDef<TestCxxInitSubsetObj>()
-      .def_static("__ffi_init__", refl::init<TestCxxInitSubsetObj, int64_t, String>)
+      .def(refl::init<int64_t, String>())
       .def_rw("required_field", &TestCxxInitSubsetObj::required_field)
       .def_rw("optional_field", &TestCxxInitSubsetObj::optional_field)
       .def_rw("note", &TestCxxInitSubsetObj::note);
 
   refl::ObjectDef<TestUnregisteredBaseObject>()
+      .def(refl::init<int64_t>(), "Constructor of TestUnregisteredBaseObject")
       .def_ro("v1", &TestUnregisteredBaseObject::v1)
-      .def_static("__ffi_init__", refl::init<TestUnregisteredBaseObject, int64_t>,
-                  "Constructor of TestUnregisteredBaseObject")
       .def("get_v1_plus_one", &TestUnregisteredBaseObject::GetV1PlusOne,
            "Get (v1 + 1) from TestUnregisteredBaseObject");
 
   refl::ObjectDef<TestUnregisteredObject>()
+      .def(refl::init<int64_t, int64_t>(), "Constructor of TestUnregisteredObject")
       .def_ro("v1", &TestUnregisteredObject::v1)
       .def_ro("v2", &TestUnregisteredObject::v2)
-      .def_static("__ffi_init__", refl::init<TestUnregisteredObject, int64_t, int64_t>,
-                  "Constructor of TestUnregisteredObject")
       .def("get_v2_plus_two", &TestUnregisteredObject::GetV2PlusTwo,
            "Get (v2 + 2) from TestUnregisteredObject");
 

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -5,7 +5,7 @@ if (TVM_FFI_USE_EXTRA_CXX_API)
   list(APPEND _test_sources ${_test_extra_sources})
 endif ()
 
-add_executable(tvm_ffi_tests EXCLUDE_FROM_ALL ${_test_sources})
+add_executable(tvm_ffi_tests ${_test_sources})
 
 set_target_properties(
   tvm_ffi_tests

--- a/tests/cpp/test_reflection.cc
+++ b/tests/cpp/test_reflection.cc
@@ -63,11 +63,11 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   TCustomFuncObj::RegisterReflection();
 
   refl::ObjectDef<TestObjA>()
-      .def_static("__ffi_init__", refl::init<TestObjA, int64_t, int64_t>)
+      .def(refl::init<int64_t, int64_t>())
       .def_ro("x", &TestObjA::x)
       .def_rw("y", &TestObjA::y);
   refl::ObjectDef<TestObjADerived>()
-      .def_static("__ffi_init__", refl::init<TestObjRefADerived, int64_t, int64_t, int64_t>)
+      .def(refl::init<int64_t, int64_t, int64_t>())
       .def_ro("z", &TestObjADerived::z);
 }
 


### PR DESCRIPTION
This PR defines a `def(init<Args...>())` method to define a static initializer function. This replaces the previous method of `def_static("__ffi_init__", ...)`, and fully aligns with nanobind/pybind.