### PR TITLE
[DLL] Explicit link libtvm_ffi_testing from cython

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,8 @@ if (TVM_FFI_BUILD_PYTHON_MODULE)
   target_compile_features(tvm_ffi_cython PRIVATE cxx_std_17)
   target_link_libraries(tvm_ffi_cython PRIVATE tvm_ffi_header)
   target_link_libraries(tvm_ffi_cython PRIVATE tvm_ffi_shared)
+  # link against testing to ensure right unloading order (cython first then testing)
+  target_link_libraries(tvm_ffi_cython PRIVATE tvm_ffi_testing)
   # Set RPATH for tvm_ffi_cython to find tvm_ffi_shared.so relatively
   if (APPLE)
     # macOS uses @loader_path

--- a/python/tvm_ffi/cython/base.pxi
+++ b/python/tvm_ffi/cython/base.pxi
@@ -374,6 +374,8 @@ cdef extern from "tvm_ffi_python_helpers.h":
     void TVMFFIPyMLIRPackedSafeCallDeleter(void* self)
     # deleter for python objects
     void TVMFFIPyObjectDeleter(void* py_obj) noexcept nogil
+    # dummy target for testing
+    int TVMFFITestingDummyTarget() nogil
 
 
 cdef class ByteArrayArg:
@@ -449,4 +451,8 @@ cdef _init_env_api():
     CHECK_CALL(TVMFFIEnvRegisterCAPI(c_str("PyGILState_Ensure"), <void*>PyGILState_Ensure))
     CHECK_CALL(TVMFFIEnvRegisterCAPI(c_str("PyGILState_Release"), <void*>PyGILState_Release))
 
+
 _init_env_api()
+
+# ensure testing is linked and we can run testcases
+TVMFFITestingDummyTarget()

--- a/python/tvm_ffi/cython/tvm_ffi_python_helpers.h
+++ b/python/tvm_ffi/cython/tvm_ffi_python_helpers.h
@@ -674,4 +674,9 @@ extern "C" void TVMFFIPyObjectDeleter(void* py_obj) noexcept {
   Py_DecRef(static_cast<PyObject*>(py_obj));
 }
 
+/*
+ * \brief Dummy target to ensure testing is linked and we can run testcases
+ */
+extern "C" TVM_FFI_DLL int TVMFFITestingDummyTarget();
+
 #endif  // TVM_FFI_PYTHON_HELPERS_H_

--- a/python/tvm_ffi/testing.py
+++ b/python/tvm_ffi/testing.py
@@ -19,12 +19,6 @@
 
 from __future__ import annotations
 
-from . import libinfo
-from .module import load_module
-
-_LIBTVM_FFI_TESTING = load_module(libinfo.find_library_by_basename("tvm_ffi_testing"))
-
-
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar
 


### PR DESCRIPTION
This PR changes the linking of libtvm_ffi_testing to explicit linking. This helps to simplify the unloading order, to ensure cython always get unloaded before libtvm_ffi_testing in case we need to de-allocate global objects there. While it introduces one testing dep, the behavior is similar as before and on python such extra dep is ok for testing.