### PR TITLE
[CORE] Use new for singleton to prevent de-alloc order issues

### DIFF
--- a/src/ffi/object.cc
+++ b/src/ffi/object.cc
@@ -307,7 +307,7 @@ class TypeTable {
 
   static TypeTable* Global() {
     // deliberately create a new instance via raw new
-    // to ensure table lives longe in case unloading
+    // to ensure table lives longer in case unloading
     // still need the table info
     // memory will be recycled by the OS at program exit
     static TypeTable* inst = new TypeTable();


### PR DESCRIPTION
This PR updates the logic to use new for singleton to prevent potential de-alloc order issues during program shutdown