### PR TITLE
Introduce opaque ptr protocol

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@
 
 [project]
 name = "apache-tvm-ffi"
-version = "0.1.0b19"
+version = "0.1.0b20"
 description = "tvm ffi"
 
 authors = [{ name = "TVM FFI team" }]

--- a/python/tvm_ffi/__init__.py
+++ b/python/tvm_ffi/__init__.py
@@ -18,7 +18,7 @@
 
 # order matters here so we need to skip isort here
 # isort: skip_file
-__version__ = "0.1.0b19"
+__version__ = "0.1.0b20"
 
 # HACK: try importing torch first, to avoid a potential
 # symbol conflict when both torch and tvm_ffi are imported.

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -297,3 +297,18 @@ def test_function_subclass() -> None:
     assert isinstance(fechoed, tvm_ffi.Function)
     assert fechoed.__chandle__() == f_sub.__chandle__()
     assert fechoed(10) == 10
+
+
+def test_function_with_opaque_ptr_protocol() -> None:
+    class MyObject:
+        def __init__(self, value: Any) -> None:
+            self.value = value
+
+        def __tvm_ffi_opaque_ptr__(self) -> Any:
+            return self.value
+
+    fecho = tvm_ffi.get_global_func("testing.echo")
+    x = MyObject(10)
+    y = fecho(x)
+    assert isinstance(y, ctypes.c_void_p)
+    assert y.value == 10


### PR DESCRIPTION
This PR introduces opaque ptr protocol of so DSL can pass in opaque c structs if needed and pass through to internla function.