### PR TITLE
chore(build): Skip Python 3.8 on arm64 macOS

### DIFF
--- a/.github/workflows/publish_wheel.yml
+++ b/.github/workflows/publish_wheel.yml
@@ -69,6 +69,7 @@ jobs:
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_ARCHS_WINDOWS: ${{ matrix.arch }}
+          CIBW_SKIP: "cp38-macosx_*"
           CIBW_BUILD_VERBOSITY: 1
           CMAKE_BUILD_PARALLEL_LEVEL: ${{ steps.env_vars.outputs.cpu_count }}
 


### PR DESCRIPTION
ARM64 macOS doesn't have native support for Python 3.8. Therefore, it is pointless to release Python 3.8 wheels in this case.