### PR TITLE
[CMAKE] Detect endian when possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,15 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/Utils/Library.cmake)
 # linking
 add_library(tvm_ffi_header INTERFACE)
 target_compile_features(tvm_ffi_header INTERFACE cxx_std_17)
+
+if (CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
+  target_compile_definitions(tvm_ffi_header INTERFACE TVM_FFI_CMAKE_LITTLE_ENDIAN=0)
+elseif (CMAKE_CXX_BYTE_ORDER STREQUAL "LITTLE_ENDIAN")
+  target_compile_definitions(tvm_ffi_header INTERFACE TVM_FFI_CMAKE_LITTLE_ENDIAN=1)
+else ()
+  message(STATUS "Endianness could not be determined, skip setting")
+endif ()
+
 target_include_directories(
   tvm_ffi_header INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                            $<INSTALL_INTERFACE:include>

--- a/include/tvm/ffi/endian.h
+++ b/include/tvm/ffi/endian.h
@@ -38,7 +38,8 @@
 #else
 #if defined(__APPLE__) || defined(_WIN32)
 #define TVM_FFI_LITTLE_ENDIAN 1
-#elif defined(__GLIBC__) || defined(__GNU_LIBRARY__) || defined(__ANDROID__) || defined(__RISCV__)
+#elif defined(__GLIBC__) || defined(__GNU_LIBRARY__) || defined(__ANDROID__) || \
+    defined(__RISCV__) || defined(__MUSL__)
 #include <endian.h>
 #define TVM_FFI_LITTLE_ENDIAN (__BYTE_ORDER == __LITTLE_ENDIAN)
 #elif defined(__FreeBSD__) || defined(__OpenBSD__)


### PR DESCRIPTION
This PR updates the cmake to detect endian when possible.