### PR TITLE
chore(release): Publish both manylinux2014 and 2_28

### DIFF
--- a/.github/workflows/publish_wheel.yml
+++ b/.github/workflows/publish_wheel.yml
@@ -28,16 +28,20 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    # Only build manylinux2014 on manual runs (workflow_dispatch)
+    if: ${{ github.event_name == 'workflow_dispatch' || matrix.linux_image != 'manylinux2014' }}
+    name: Build wheels on ${{ matrix.os }}-${{ matrix.arch }} ${{ matrix.linux_image }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - {os: ubuntu-latest, arch: x86_64}
-          - {os: ubuntu-24.04-arm, arch: aarch64}
-          - {os: windows-latest, arch: AMD64}
-          - {os: macos-14, arch: arm64}
+          - {os: ubuntu-latest, arch: x86_64, linux_image: manylinux2014}
+          - {os: ubuntu-latest, arch: x86_64, linux_image: manylinux_2_28}
+          - {os: ubuntu-24.04-arm, arch: aarch64, linux_image: manylinux2014}
+          - {os: ubuntu-24.04-arm, arch: aarch64, linux_image: manylinux_2_28}
+          - {os: windows-latest, arch: AMD64, linux_image: ""}
+          - {os: macos-14, arch: arm64, linux_image: ""}
 
     steps:
       - uses: astral-sh/setup-uv@v4
@@ -69,6 +73,8 @@ jobs:
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_ARCHS_WINDOWS: ${{ matrix.arch }}
+          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.linux_image }}
+          CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.linux_image }}
           CIBW_BUILD_VERBOSITY: 1
           CMAKE_BUILD_PARALLEL_LEVEL: ${{ steps.env_vars.outputs.cpu_count }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,8 +221,6 @@ docstring-code-line-length = "dynamic"
 
 [tool.cibuildwheel]
 build-verbosity = 1
-manylinux-x86_64-image = "manylinux2014"
-manylinux-aarch64-image = "manylinux2014"
 
 # only build up to cp312, cp312
 # will be abi3 and can be used in future versions


### PR DESCRIPTION
To maximize coverage, we want to distribute both manylinux2014 and manylinux_2_28 wheels.