### PR TITLE
chore(release): Test wheels nightly

### DIFF
--- a/.github/workflows/publish_wheel.yml
+++ b/.github/workflows/publish_wheel.yml
@@ -18,8 +18,8 @@
 name: Publish wheel
 
 on:
-  push:
-    branches: [main]        # <-- build on every commit to main
+  schedule:
+    - cron: '0 9 * * *'  # every day at 9am UTC
   workflow_dispatch:
     inputs:
       branch:
@@ -28,9 +28,6 @@ on:
 
 jobs:
   build_wheels:
-    # Only build manylinux2014 on manual runs (workflow_dispatch)
-    if: ${{ github.event_name == 'workflow_dispatch' || matrix.linux_image != 'manylinux2014' }}
-    name: Build wheels on ${{ matrix.os }}-${{ matrix.arch }} ${{ matrix.linux_image }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
All wheel building is triggered 9am UTC every day, but publishing is limited to explicit manual trigger (workflow_dispatch)