### PR TITLE
MSVC compiler fix

### DIFF
--- a/include/tvm/ffi/container/tensor.h
+++ b/include/tvm/ffi/container/tensor.h
@@ -38,6 +38,8 @@
 namespace tvm {
 namespace ffi {
 
+class Tensor;
+
 /*!
  * \brief Check if the device uses direct address, where address of data indicate alignment.
  * \param device The input device.


### PR DESCRIPTION
This pull request adds a forward declaration of Tensor class to prevent errors when compiling with MSVC.