### PR TITLE
[VERSION] Add Version Query API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,18 @@ It has the following technical features:
 With these technical solutions, we can enable better **interoperability** across machine learning frameworks,
 libraries, kernel DSLs, and coding agents, **ship one wheel** to support multiple frameworks and Python versions (including free-threaded python),
 and build infrastructure solutions across environments.
+
+## Status and Release Versioning
+
+C ABI stability is the top priority of this effort. We also prioritize minimalism and
+efficiency in the core so it is portable and can be used broadly.
+We are current in the RFC stage, which means the main features are complete and ABI stable.
+We also recognize potential needs for evolution to ensure it works best for the machine
+learning systems community, and would like to work together collectively with the community for such evolution.
+The RFC stage is a period where we are working with the open source communities
+to ensure we evolve the ABI to meet the potential needs of frameworks.
+
+Releases during the RFC stage will be `0.X.Y`, where bumps in `X` indicate C ABI-breaking changes
+and `Y` indicates other changes. We anticipate the RFC stage will last for a few months, then we will start to follow
+[Semantic Versioning](https://packaging.python.org/en/latest/discussions/versioning/)
+(`major.minor.patch`) going forward.

--- a/include/tvm/ffi/c_api.h
+++ b/include/tvm/ffi/c_api.h
@@ -56,9 +56,28 @@
 #define TVM_FFI_DLL_EXPORT __attribute__((visibility("default")))
 #endif
 
+/*! \brief TVM FFI major version. */
+#define TVM_FFI_VERSION_MAJOR 0
+/*! \brief TVM FFI minor version. */
+#define TVM_FFI_VERSION_MINOR 1
+/*! \brief TVM FFI patch version. */
+#define TVM_FFI_VERSION_PATCH 0
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/*!
+ * \brief TVM FFI version.
+ */
+typedef struct {
+  /*! \brief TVM FFI major version. */
+  uint32_t major;
+  /*! \brief TVM FFI minor version. */
+  uint32_t minor;
+  /*! \brief TVM FFI patch version. */
+  uint32_t patch;
+} TVMFFIVersion;
 
 #ifdef __cplusplus
 enum TVMFFITypeIndex : int32_t {
@@ -439,6 +458,18 @@ typedef struct {
   /*! \brief The handle of the opaque object, for python it is PyObject* */
   void* handle;
 } TVMFFIOpaqueObjectCell;
+
+//-----------------------------------------------------------------------
+// Section: Version API
+//-----------------------------------------------------------------------
+/*!
+ * \brief Get the TVM FFI version from the current C ABI.
+ *
+ * This function is always stable across all versions of the C ABI.
+ *
+ * \param out_version The output version.
+ */
+TVM_FFI_DLL void TVMFFIGetVersion(TVMFFIVersion* out_version);
 
 //------------------------------------------------------------
 // Section: Basic object API

--- a/src/ffi/object.cc
+++ b/src/ffi/object.cc
@@ -431,6 +431,12 @@ class OpaqueObjectImpl : public Object, public TVMFFIOpaqueObjectCell {
 }  // namespace ffi
 }  // namespace tvm
 
+void TVMFFIGetVersion(TVMFFIVersion* out_version) {
+  out_version->major = TVM_FFI_VERSION_MAJOR;
+  out_version->minor = TVM_FFI_VERSION_MINOR;
+  out_version->patch = TVM_FFI_VERSION_PATCH;
+}
+
 int TVMFFIObjectDecRef(TVMFFIObjectHandle handle) {
   TVM_FFI_SAFE_CALL_BEGIN();
   tvm::ffi::details::ObjectUnsafe::DecRefObjectHandle(handle);

--- a/tests/cpp/test_base.cc
+++ b/tests/cpp/test_base.cc
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <gtest/gtest.h>
+#include <tvm/ffi/c_api.h>
+
+namespace {
+
+TEST(Base, Version) {
+  TVMFFIVersion version;
+  TVMFFIGetVersion(&version);
+  EXPECT_EQ(version.major, TVM_FFI_VERSION_MAJOR);
+  EXPECT_EQ(version.minor, TVM_FFI_VERSION_MINOR);
+  EXPECT_EQ(version.patch, TVM_FFI_VERSION_PATCH);
+}
+
+}  // namespace


### PR DESCRIPTION
This PR adds version query API so libraries can query the API from libtvm_ffi. While we do not see immediate needs as we aim to ensure ABI stability. This API will help future compatibility in case of ABI evolution.