### PR TITLE
feat: Automatically add `__init__` method if available

### DIFF
--- a/python/tvm_ffi/cython/object.pxi
+++ b/python/tvm_ffi/cython/object.pxi
@@ -278,7 +278,7 @@ cdef inline object make_fallback_cls_for_type_index(int32_t type_index):
     # Create `type_info.type_cls` now
     class cls(parent_type_info.type_cls):
         pass
-    attrs = dict(cls.__dict__)
+    attrs = cls.__dict__.copy()
     attrs.pop("__dict__", None)
     attrs.pop("__weakref__", None)
     attrs.update({

--- a/python/tvm_ffi/testing.py
+++ b/python/tvm_ffi/testing.py
@@ -61,10 +61,6 @@ class TestIntPair(Object):
         # fmt: on
     # tvm-ffi-stubgen(end)
 
-    def __init__(self, a: int, b: int) -> None:
-        """Construct the object."""
-        self.__ffi_init__(a, b)
-
 
 @register_object("testing.TestObjectDerived")
 class TestObjectDerived(TestObjectBase):

--- a/tests/python/test_object.py
+++ b/tests/python/test_object.py
@@ -32,7 +32,7 @@ def test_make_object() -> None:
 
 
 def test_make_object_via_init() -> None:
-    obj0 = tvm_ffi.testing.TestIntPair(1, 2)
+    obj0 = tvm_ffi.testing.TestIntPair(1, 2)  # type: ignore[call-arg]
     assert obj0.a == 1
     assert obj0.b == 2
 
@@ -46,7 +46,7 @@ def test_method() -> None:
 
 
 def test_attribute() -> None:
-    obj = tvm_ffi.testing.TestIntPair(3, 4)
+    obj = tvm_ffi.testing.TestIntPair(3, 4)  # type: ignore[call-arg]
     assert obj.a == 3
     assert obj.b == 4
     assert type(obj).a.__doc__ == "Field `a`"


### PR DESCRIPTION
Previously, when `SomeObject.__init__` is not defined, `SomeObject(anything, ...)` will silently do nothing but returns a `SomeObject` with `chandle=None`, which triggers further segfault when trying to access its fields.

This PR fixes this issue by auto-generating `__init__` when it's not available:
- if `__ffi_init__` method is defined, generate a method that calls `__ffi_init__`;
- if not, generate an `__init__` method that explicitly errors out saying it's undefined
