### PR TITLE
Introduce dtype protocol

### DIFF
--- a/python/tvm_ffi/_dtype.py
+++ b/python/tvm_ffi/_dtype.py
@@ -60,15 +60,39 @@ class dtype(str):
 
     """
 
-    __slots__ = ["__tvm_ffi_dtype__"]
-    __tvm_ffi_dtype__: core.DataType
+    __slots__ = ["_tvm_ffi_dtype"]
+    _tvm_ffi_dtype: core.DataType
 
     _NUMPY_DTYPE_TO_STR: ClassVar[dict[Any, str]] = {}
 
     def __new__(cls, content: Any) -> dtype:
         content = str(content)
         val = str.__new__(cls, content)
-        val.__tvm_ffi_dtype__ = core.DataType(content)
+        val._tvm_ffi_dtype = core.DataType(content)
+        return val
+
+    @staticmethod
+    def from_dlpack_data_type(dltype_data_type: tuple[int, int, int]) -> dtype:
+        """Create a dtype from a DLPack data type tuple.
+
+        Parameters
+        ----------
+        dltype_data_type
+            The DLPack data type tuple (type_code, bits, lanes).
+
+        Returns
+        -------
+        The created dtype.
+
+        """
+        cdtype = core._create_dtype_from_tuple(
+            core.DataType,
+            dltype_data_type[0],
+            dltype_data_type[1],
+            dltype_data_type[2],
+        )
+        val = str.__new__(dtype, str(cdtype))
+        val._tvm_ffi_dtype = cdtype
         return val
 
     def __repr__(self) -> str:
@@ -90,29 +114,29 @@ class dtype(str):
         """
         cdtype = core._create_dtype_from_tuple(
             core.DataType,
-            self.__tvm_ffi_dtype__.type_code,
-            self.__tvm_ffi_dtype__.bits,
+            self._tvm_ffi_dtype.type_code,
+            self._tvm_ffi_dtype.bits,
             lanes,
         )
         val = str.__new__(dtype, str(cdtype))
-        val.__tvm_ffi_dtype__ = cdtype
+        val._tvm_ffi_dtype = cdtype
         return val
 
     @property
     def itemsize(self) -> int:
-        return self.__tvm_ffi_dtype__.itemsize
+        return self._tvm_ffi_dtype.itemsize
 
     @property
     def type_code(self) -> int:
-        return self.__tvm_ffi_dtype__.type_code
+        return self._tvm_ffi_dtype.type_code
 
     @property
     def bits(self) -> int:
-        return self.__tvm_ffi_dtype__.bits
+        return self._tvm_ffi_dtype.bits
 
     @property
     def lanes(self) -> int:
-        return self.__tvm_ffi_dtype__.lanes
+        return self._tvm_ffi_dtype.lanes
 
 
 try:

--- a/python/tvm_ffi/cython/dtype.pxi
+++ b/python/tvm_ffi/cython/dtype.pxi
@@ -155,7 +155,7 @@ cdef inline object make_ret_dtype(TVMFFIAny result):
     cdtype = DataType.__new__(DataType)
     (<DataType>cdtype).cdtype = result.v_dtype
     val = str.__new__(_CLASS_DTYPE, cdtype.__str__())
-    val.__tvm_ffi_dtype__ = cdtype
+    val._tvm_ffi_dtype = cdtype
     return val
 
 

--- a/tests/python/test_dtype.py
+++ b/tests/python/test_dtype.py
@@ -160,3 +160,10 @@ def test_ml_dtypes_dtype_conversion() -> None:
     _check_dtype(np.dtype(ml_dtypes.float6_e2m3fn), 15, 6, 1)
     _check_dtype(np.dtype(ml_dtypes.float6_e3m2fn), 16, 6, 1)
     _check_dtype(np.dtype(ml_dtypes.float4_e2m1fn), 17, 4, 1)
+
+
+def test_dtype_from_dlpack_data_type() -> None:
+    dtype = tvm_ffi.dtype.from_dlpack_data_type((0, 8, 1))
+    assert dtype.type_code == 0
+    assert dtype.bits == 8
+    assert dtype.lanes == 1

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import ctypes
 import gc
@@ -312,3 +313,18 @@ def test_function_with_opaque_ptr_protocol() -> None:
     y = fecho(x)
     assert isinstance(y, ctypes.c_void_p)
     assert y.value == 10
+
+
+def test_function_with_dlpack_data_type_protocol() -> None:
+    class DLPackDataTypeProtocol:
+        def __init__(self, dlpack_data_type: tuple[int, int, int]) -> None:
+            self.dlpack_data_type = dlpack_data_type
+
+        def __dlpack_data_type__(self) -> tuple[int, int, int]:
+            return self.dlpack_data_type
+
+    dtype = tvm_ffi.dtype("float32")
+    fecho = tvm_ffi.get_global_func("testing.echo")
+    x = DLPackDataTypeProtocol((dtype.type_code, dtype.bits, dtype.lanes))
+    y = fecho(x)
+    assert y == dtype


### PR DESCRIPTION
This PR adds support for `__dlpack_data_type__` to enable exchange of dtype from arguments. Note the intention is to use DLDataType to ingest dtype into tvm ffi since it is the most close to metal repr.

Likely we also can look into numpy dtype protocol once that materializes.