### PR TITLE
fix(doc): Always download images to doc site

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -245,6 +245,7 @@ def setup(app: sphinx.application.Sphinx) -> None:
     app.connect("build-finished", _copy_rust_docs_to_output)
     app.connect("autodoc-skip-member", _filter_inherited_members)
     app.connect("autodoc-process-docstring", _link_inherited_members)
+    app.connect("builder-inited", _force_local_images)
 
 
 def _filter_inherited_members(app, what, name, obj, skip, options):  # noqa: ANN001, ANN202
@@ -306,6 +307,14 @@ def _import_cls(cls_name: str) -> type | None:
         return getattr(m, clsname, None)
     except Exception:
         return None
+
+
+def _force_local_images(app: sphinx.application.Sphinx) -> None:
+    # For HTML-family builders, tell Sphinx "do NOT support remote images".
+    # This triggers the built-in ImageDownloader post-transform to fetch & rewrite.
+    if getattr(app, "builder", None) and app.builder.name in {"html", "dirhtml", "singlehtml"}:
+        # Sphinx core will then download to .doctrees/images/ and rewrite URIs.
+        app.builder.supported_remote_images = False
 
 
 autodoc_mock_imports = ["torch"]


### PR DESCRIPTION
This PR explicitly asks Sphinx's builtin image downloader to fetch the external images to local `.doctrees/images/`, as another attempt after #193 to fix the image not rendering issue: https://tvm.apache.org/ffi/get_started/stable_c_abi.html#fig-layout-any.

#193 didn't fix the problem and ChatGPT [suggests](https://github.com/apache/tvm-ffi/pull/193#issuecomment-3449115370) that it's due to `tvm.apache.org`'s Content Security Policy (CSP) that disallows embedding external resources.

It is tested locally that the Sphinx does fetch the images desired. Hopefully this time this issue can be fixed.