### PR TITLE
fix(doc): Remove `?sanitize=true` in SVG URL

### DIFF
--- a/docs/get_started/stable_c_abi.rst
+++ b/docs/get_started/stable_c_abi.rst
@@ -79,7 +79,7 @@ Layout of :cpp:class:`TVMFFIAny`
 - Next 32 bits: reserved (used for flags in rare cases, e.g. small-string optimization).
 - Last 64 bits: payload that is either a 64-bit integer, a 64-bit floating-point number, or a pointer to a heap-allocated object.
 
-.. figure:: https://raw.githubusercontent.com/tlc-pack/web-data/main/images/tvm-ffi/stable-c-abi-layout-any.svg?sanitize=true
+.. figure:: https://raw.githubusercontent.com/tlc-pack/web-data/main/images/tvm-ffi/stable-c-abi-layout-any.svg
    :alt: Layout of the 128-bit Any tagged union
    :name: fig:layout-any
 
@@ -112,7 +112,7 @@ Function calls in TVM-FFI share the same calling convention, :ref:`tvm_ffi_c_abi
 - ``num_args: int``: number of input arguments.
 - ``result: TVMFFIAny*``: out-parameter that receives the function result (use ``kTVMFFINone`` for "no return value").
 
-.. figure:: https://raw.githubusercontent.com/tlc-pack/web-data/main/images/tvm-ffi/stable-c-abi-layout-func.svg?sanitize=true
+.. figure:: https://raw.githubusercontent.com/tlc-pack/web-data/main/images/tvm-ffi/stable-c-abi-layout-func.svg
    :alt: Layout and calling convention for tvm_ffi_c_abi
    :name: fig:layout-func
 


### PR DESCRIPTION
In accordance to commit: https://github.com/apache/tvm-site/commit/81a8c2e94ea1e32d5bfb5c1335cd5a8565e66f46