### PR TITLE
chore: Fix clang-tidy warnings

### DIFF
--- a/include/tvm/ffi/base_details.h
+++ b/include/tvm/ffi/base_details.h
@@ -200,6 +200,7 @@ TVM_FFI_INLINE uint64_t StableHashCombine(uint64_t key, const T& value) {
  * \return the hash value.
  */
 TVM_FFI_INLINE uint64_t StableHashBytes(const void* data_ptr, size_t size) {
+  // NOLINTBEGIN(clang-analyzer-security.ArrayBound)
   const char* data = reinterpret_cast<const char*>(data_ptr);
   const constexpr uint64_t kMultiplier = 1099511628211ULL;
   const constexpr uint64_t kMod = 2147483647ULL;
@@ -215,14 +216,12 @@ TVM_FFI_INLINE uint64_t StableHashBytes(const void* data_ptr, size_t size) {
     // if alignment requirement is met, directly use load
     if (reinterpret_cast<uintptr_t>(it) % 8 == 0) {
       for (; it + 8 <= end; it += 8) {
-        // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
         u.b = *reinterpret_cast<const uint64_t*>(it);
         result = (result * kMultiplier + u.b) % kMod;
       }
     } else {
       // unaligned version
       for (; it + 8 <= end; it += 8) {
-        // NOLINTNEXTLINE(clang-analyzer-security.ArrayBound)
         u.a[0] = it[0];
         u.a[1] = it[1];
         u.a[2] = it[2];
@@ -277,6 +276,7 @@ TVM_FFI_INLINE uint64_t StableHashBytes(const void* data_ptr, size_t size) {
     }
     result = (result * kMultiplier + u.b) % kMod;
   }
+  // NOLINTEND(clang-analyzer-security.ArrayBound)
   return result;
 }
 

--- a/include/tvm/ffi/c_api.h
+++ b/include/tvm/ffi/c_api.h
@@ -56,12 +56,14 @@
 #define TVM_FFI_DLL_EXPORT __attribute__((visibility("default")))
 #endif
 
+// NOLINTBEGIN(modernize-macro-to-enum)
 /*! \brief TVM FFI major version. */
 #define TVM_FFI_VERSION_MAJOR 0
 /*! \brief TVM FFI minor version. */
 #define TVM_FFI_VERSION_MINOR 1
 /*! \brief TVM FFI patch version. */
 #define TVM_FFI_VERSION_PATCH 1
+// NOLINTEND(modernize-macro-to-enum)
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/tvm/ffi/container/array.h
+++ b/include/tvm/ffi/container/array.h
@@ -447,7 +447,7 @@ class Array : public ObjectRef {
    * \tparam IterType The type of iterator
    */
   template <typename IterType>
-  Array(IterType first, IterType last) {
+  Array(IterType first, IterType last) {  // NOLINT(performance-unnecessary-value-param)
     static_assert(is_valid_iterator_v<T, IterType>,
                   "IterType cannot be inserted into a tvm::Array<T>");
     Assign(first, last);
@@ -817,7 +817,7 @@ class Array : public ObjectRef {
    * \tparam IterType The type of iterator
    */
   template <typename IterType>
-  void Assign(IterType first, IterType last) {
+  void Assign(IterType first, IterType last) {  // NOLINT(performance-unnecessary-value-param)
     int64_t cap = std::distance(first, last);
     if (cap < 0) {
       TVM_FFI_THROW(ValueError) << "cannot construct an Array of negative size";

--- a/include/tvm/ffi/reflection/access_path.h
+++ b/include/tvm/ffi/reflection/access_path.h
@@ -329,7 +329,7 @@ class AccessPath : public ObjectRef {
    * \param end The end of the iterator range.
    * \return The access path.
    */
-  template <typename Iter>
+  template <typename Iter>  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   static AccessPath FromSteps(Iter begin, Iter end) {
     AccessPath path = AccessPath::Root();
     for (Iter it = begin; it != end; ++it) {

--- a/include/tvm/ffi/reflection/registry.h
+++ b/include/tvm/ffi/reflection/registry.h
@@ -296,7 +296,7 @@ class ReflectionDefBase {
     static_assert(std::is_base_of_v<ObjectRef, Class> || std::is_base_of_v<Object, Class>,
                   "Class must be derived from ObjectRef or Object");
     if constexpr (std::is_base_of_v<ObjectRef, Class>) {
-      auto fwrap = [func](const Class target, Args... params) -> R {
+      auto fwrap = [func](const Class& target, Args... params) -> R {
         // call method pointer
         return (target.*func)(std::forward<Args>(params)...);
       };

--- a/src/ffi/testing/testing.cc
+++ b/src/ffi/testing/testing.cc
@@ -176,6 +176,7 @@ TVM_FFI_NO_INLINE void TestApply(PackedArgs args, Any* ret) {
   f.CallPacked(args.Slice(1), ret);
 }
 
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
 int __add_one_c_symbol(void*, const TVMFFIAny* args, int32_t num_args, TVMFFIAny* ret) {
   TVM_FFI_SAFE_CALL_BEGIN();
   int x = reinterpret_cast<const AnyView*>(args)[0].cast<int>();
@@ -261,10 +262,12 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def("testing.get_add_one_c_symbol",
            []() {
              TVMFFISafeCallType symbol = __add_one_c_symbol;
+             // NOLINTNEXTLINE(bugprone-casting-through-void)
              return reinterpret_cast<int64_t>(reinterpret_cast<void*>(symbol));
            })
       .def("testing.get_mlir_add_one_c_symbol",
            []() {
+             // NOLINTNEXTLINE(bugprone-casting-through-void)
              return reinterpret_cast<int64_t>(reinterpret_cast<void*>(_mlir_add_one_c_symbol));
            })
       .def_method("testing.TestIntPairSum", &TestIntPair::Sum, "Get sum of the pair");


### PR DESCRIPTION
Following https://github.com/apache/tvm-ffi/pull/78, this PR addresses new warnings from clang-tidy.

After this PR being merged, PR #95 will run clang-tidy tests per-commit to `main` branch to make sure it always passes.