### PR TITLE
doc: Remove stale notes

### DIFF
--- a/include/tvm/ffi/function.h
+++ b/include/tvm/ffi/function.h
@@ -845,8 +845,6 @@ inline int32_t TypeKeyToIndex(std::string_view type_key) {
  *
  * \param ExportName The symbol name to be exported.
  * \param Function The typed function.
- * \note ExportName and Function must be different,
- *       see code examples below.
  *
  * \sa ffi::TypedFunction
  *


### PR DESCRIPTION
There was a note in `TVM_FFI_DLL_EXPORT_TYPED_FUNC` saying:

```
\note ExportName and Function must be different
```

which has been stale for a while. The system doesn't have the constraint as of today. This PR removes this line.