### PR TITLE
doc(python): Add example coverage to docstrings

### DIFF
--- a/docs/reference/python/index.rst
+++ b/docs/reference/python/index.rst
@@ -99,6 +99,7 @@ Stream Context
   StreamContext
   use_torch_stream
   use_raw_stream
+  get_raw_stream
 
 
 Inline Loading
@@ -118,8 +119,11 @@ Misc
 .. autosummary::
   :toctree: generated/
 
-  serialization
-  access_path
+  serialization.from_json_graph_str
+  serialization.to_json_graph_str
+  access_path.AccessKind
+  access_path.AccessPath
+  access_path.AccessStep
   convert
   ObjectConvertible
 

--- a/python/tvm_ffi/_convert.py
+++ b/python/tvm_ffi/_convert.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Conversion utilities to bring python objects into ffi values."""
+"""Conversion utilities to convert Python objects into TVM FFI values."""
 
 from __future__ import annotations
 
@@ -38,17 +38,50 @@ except ImportError:
 
 
 def convert(value: Any) -> Any:  # noqa: PLR0911,PLR0912
-    """Convert a python object to ffi values.
+    """Convert a Python object into TVM FFI values.
+
+    This helper mirrors the automatic argument conversion that happens when
+    calling FFI functions. It is primarily useful in tests or places where
+    an explicit conversion is desired.
 
     Parameters
     ----------
     value
-        The python object to be converted.
+        The Python object to be converted.
 
     Returns
     -------
     ffi_obj
         The converted TVM FFI object.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import tvm_ffi
+
+        # Lists and tuples become tvm_ffi.Array
+        a = tvm_ffi.convert([1, 2, 3])
+        assert isinstance(a, tvm_ffi.Array)
+
+        # Dicts become tvm_ffi.Map
+        m = tvm_ffi.convert({"a": 1, "b": 2})
+        assert isinstance(m, tvm_ffi.Map)
+
+        # Strings and bytes become zero-copy FFI-aware types
+        s = tvm_ffi.convert("hello")
+        b = tvm_ffi.convert(b"bytes")
+        assert isinstance(s, tvm_ffi.core.String)
+        assert isinstance(b, tvm_ffi.core.Bytes)
+
+        # Callables are wrapped as tvm_ffi.Function
+        f = tvm_ffi.convert(lambda x: x + 1)
+        assert isinstance(f, tvm_ffi.Function)
+
+        # Array libraries that support DLPack export can be converted to Tensor
+        import numpy as np
+        x = tvm_ffi.convert(np.arange(4, dtype="int32"))
+        assert isinstance(x, tvm_ffi.Tensor)
 
     Note
     ----

--- a/python/tvm_ffi/_tensor.py
+++ b/python/tvm_ffi/_tensor.py
@@ -43,6 +43,16 @@ class Shape(tuple, PyNativeObject):
     This class subclasses :class:`tuple` so it can be used in most places where
     :class:`tuple` is used in Python array APIs.
 
+    Examples
+    --------
+    .. code-block:: python
+
+        import numpy as np
+        import tvm_ffi
+
+        x = tvm_ffi.from_dlpack(np.arange(6, dtype="int32").reshape(2, 3))
+        assert x.shape == (2, 3)
+
     """
 
     _tvm_ffi_cached_object: Any
@@ -85,6 +95,7 @@ def device(device_type: str | int | DLDeviceType, index: int | None = None) -> D
 
     .. code-block:: python
 
+      import tvm_ffi
       assert tvm_ffi.device("cuda:0") == tvm_ffi.device("cuda", 0)
       assert tvm_ffi.device("cpu:0") == tvm_ffi.device("cpu", 0)
 

--- a/python/tvm_ffi/access_path.py
+++ b/python/tvm_ffi/access_path.py
@@ -53,7 +53,25 @@ class AccessStep(Object):
 
 @register_object("ffi.reflection.AccessPath")
 class AccessPath(Object):
-    """Access path container."""
+    """Access path container.
+
+    An ``AccessPath`` describes how to reach a nested attribute or item
+    inside a complex FFI object by recording a sequence of steps
+    (attribute, array index, or map key). It is primarily used by
+    diagnostics to pinpoint structural mismatches.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from tvm_ffi.access_path import AccessPath
+
+        root = AccessPath.root()
+        # Build a path equivalent to obj.layer.weight[2]
+        p = root.attr("layer").attr("weight").array_item(2)
+        assert isinstance(p, AccessPath)
+
+    """
 
     # tvm-ffi-stubgen(begin): object/ffi.reflection.AccessPath
     if TYPE_CHECKING:
@@ -86,7 +104,14 @@ class AccessPath(Object):
 
     @staticmethod
     def root() -> AccessPath:
-        """Create a root access path."""
+        """Create a root access path.
+
+        Returns
+        -------
+        AccessPath
+            A path representing the root of an object graph.
+
+        """
         return AccessPath._root()
 
     def __eq__(self, other: Any) -> bool:

--- a/python/tvm_ffi/base.py
+++ b/python/tvm_ffi/base.py
@@ -41,7 +41,7 @@ if sys.version_info[:2] < (3, 8):  # noqa: UP036
 
 
 def _load_lib() -> ctypes.CDLL:
-    """Load libary by searching possible path."""
+    """Load the tvm_ffi shared library by searching likely paths."""
     lib_path = libinfo.find_libtvm_ffi()
     # The dll search path need to be added explicitly in windows
     if sys.platform.startswith("win32"):

--- a/python/tvm_ffi/container.py
+++ b/python/tvm_ffi/container.py
@@ -124,7 +124,7 @@ def getitem_helper(
 
 @register_object("ffi.Array")
 class Array(core.Object, Sequence[T]):
-    """Array container that represents a sequence of values in ffi.
+    """Array container that represents a sequence of values in the FFI.
 
     :py:func:`tvm_ffi.convert` will map python list/tuple to this class.
 
@@ -133,19 +133,18 @@ class Array(core.Object, Sequence[T]):
     input_list
         The list of values to be stored in the array.
 
-    See Also
-    --------
-    :py:func:`tvm_ffi.convert`
-
     Examples
     --------
     .. code-block:: python
 
         import tvm_ffi
 
-        a = tvm_ffi.convert([1, 2, 3])
-        assert isinstance(a, tvm_ffi.Array)
-        assert len(a) == 3
+        a = tvm_ffi.Array([1, 2, 3])
+        assert tuple(a) == (1, 2, 3)
+
+    See Also
+    --------
+    :py:func:`tvm_ffi.convert`
 
     """
 
@@ -274,21 +273,20 @@ class Map(core.Object, Mapping[K, V]):
     input_dict
         The dictionary of values to be stored in the map.
 
-    See Also
-    --------
-    :py:func:`tvm_ffi.convert`
-
     Examples
     --------
     .. code-block:: python
 
         import tvm_ffi
 
-        amap = tvm_ffi.convert({"a": 1, "b": 2})
-        assert isinstance(amap, tvm_ffi.Map)
+        amap = tvm_ffi.Map({"a": 1, "b": 2})
         assert len(amap) == 2
         assert amap["a"] == 1
         assert amap["b"] == 2
+
+    See Also
+    --------
+    :py:func:`tvm_ffi.convert`
 
     """
 

--- a/python/tvm_ffi/cython/device.pxi
+++ b/python/tvm_ffi/cython/device.pxi
@@ -35,7 +35,7 @@ def _create_device_from_tuple(cls, device_type, device_id):
 
 
 class DLDeviceType(IntEnum):
-    """Enumeration mirroring DLPack's ``DLDeviceType``.
+    """Enumeration mirroring DLPack's `DLDeviceType <https://dmlc.github.io/dlpack/latest/c_api.html#c.DLDeviceType>`_
 
     Values can be compared against :py:meth:`Device.dlpack_device_type`.
 
@@ -43,6 +43,7 @@ class DLDeviceType(IntEnum):
     --------
     .. code-block:: python
 
+        import tvm_ffi
         dev = tvm_ffi.device("cuda", 0)
         assert dev.dlpack_device_type() == tvm_ffi.DLDeviceType.kDLCUDA
 
@@ -82,6 +83,8 @@ cdef class Device:
     Examples
     --------
     .. code-block:: python
+
+        import tvm_ffi
 
         dev = tvm_ffi.device("cuda:0")
         assert dev.type == "cuda"

--- a/python/tvm_ffi/cython/function.pxi
+++ b/python/tvm_ffi/cython/function.pxi
@@ -769,8 +769,10 @@ cdef class Function(Object):
 
     See Also
     --------
-    tvm_ffi.register_global_func: How to register global function.
-    tvm_ffi.get_global_func: How to get global function.
+    :py:func:`tvm_ffi.register_global_func`
+        Register a Python callable as a global FFI function.
+    :py:func:`tvm_ffi.get_global_func`
+        Look up a previously registered global FFI function by name.
     """
     cdef int c_release_gil
     cdef dict __dict__

--- a/python/tvm_ffi/cython/object.pxi
+++ b/python/tvm_ffi/cython/object.pxi
@@ -101,6 +101,8 @@ cdef class Object:
 
     .. code-block:: python
 
+        import tvm_ffi.testing
+
         # Acquire a testing object constructed through FFI
         obj = tvm_ffi.testing.create_object("testing.TestObjectBase", v_i64=12)
         assert isinstance(obj, tvm_ffi.Object)
@@ -213,6 +215,8 @@ cdef class Object:
         Examples
         --------
         .. code-block:: python
+
+            import tvm_ffi.testing
 
             x = tvm_ffi.testing.create_object("testing.TestObjectBase")
             y = x

--- a/python/tvm_ffi/cython/tensor.pxi
+++ b/python/tvm_ffi/cython/tensor.pxi
@@ -177,6 +177,8 @@ def from_dlpack(
     .. code-block:: python
 
         import numpy as np
+        import tvm_ffi
+
         x_np = np.arange(8, dtype="int32")
         x = tvm_ffi.from_dlpack(x_np)
         y_np = np.from_dlpack(x)
@@ -218,6 +220,8 @@ cdef class Tensor(Object):
     .. code-block:: python
 
         import numpy as np
+        import tvm_ffi
+
         x = tvm_ffi.from_dlpack(np.arange(6, dtype="int32"))
         assert x.shape == (6,)
         assert x.dtype == tvm_ffi.dtype("int32")

--- a/python/tvm_ffi/error.py
+++ b/python/tvm_ffi/error.py
@@ -178,12 +178,17 @@ def register_error(
     --------
     .. code-block:: python
 
-      @tvm.error.register_error
-      class MyError(RuntimeError):
-          pass
+        import tvm_ffi
 
-      err_inst = tvm.error.create_ffi_error("MyError: xyz")
-      assert isinstance(err_inst, MyError)
+        # Register a custom Python exception so tvm_ffi.Error maps to it
+        @tvm_ffi.error.register_error
+        class MyError(RuntimeError):
+            pass
+
+        # Convert a Python exception to an FFI Error and back
+        ffi_err = tvm_ffi.convert(MyError("boom"))
+        py_err = ffi_err.py_error()
+        assert isinstance(py_err, MyError)
 
     """
     if callable(name_or_cls):

--- a/python/tvm_ffi/serialization.py
+++ b/python/tvm_ffi/serialization.py
@@ -14,7 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Serialization related utilities to enable some object can be pickled."""
+"""Utilities for serializing and deserializing FFI object graphs.
+
+These helpers produce a stable JSON graph representation that preserves
+object identity and references. It is useful for debugging and for
+lightweight persistence when pickling is not available.
+"""
 
 from __future__ import annotations
 
@@ -26,9 +31,9 @@ from . import _ffi_api
 def to_json_graph_str(obj: Any, metadata: dict[str, Any] | None = None) -> str:
     """Dump an object to a JSON graph string.
 
-    The JSON graph string is a string representation of of the object
-    graph includes the reference information of same objects, which can
-    be used for serialization and debugging.
+    The JSON graph is a textual representation of the object graph that
+    preserves shared references. It can be used for debugging or simple
+    persistence.
 
     Parameters
     ----------
@@ -43,6 +48,17 @@ def to_json_graph_str(obj: Any, metadata: dict[str, Any] | None = None) -> str:
     json_str
         The JSON graph string.
 
+    Examples
+    --------
+    .. code-block:: python
+
+        import tvm_ffi
+
+        a = tvm_ffi.convert([1, 2, 3])
+        s = tvm_ffi.serialization.to_json_graph_str(a)
+        b = tvm_ffi.serialization.from_json_graph_str(s)
+        assert list(b) == [1, 2, 3]
+
     """
     return _ffi_api.ToJSONGraphString(obj, metadata)
 
@@ -50,8 +66,8 @@ def to_json_graph_str(obj: Any, metadata: dict[str, Any] | None = None) -> str:
 def from_json_graph_str(json_str: str) -> Any:
     """Load an object from a JSON graph string.
 
-    The JSON graph string is a string representation of of the object
-    graph that also includes the reference information.
+    The JSON graph string is produced by :py:func:`to_json_graph_str` and
+    can be converted back into the corresponding FFI-backed objects.
 
     Parameters
     ----------

--- a/python/tvm_ffi/utils/lockfile.py
+++ b/python/tvm_ffi/utils/lockfile.py
@@ -35,6 +35,19 @@ class FileLock:
 
     This class implements an advisory lock, which must be respected by all
     cooperating processes.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from tvm_ffi.utils import FileLock
+
+        with FileLock("/tmp/my.lock"):
+            # Critical section guarded by the lock.
+            # Other processes attempting to acquire the same lock will block
+            # (or fail, if using ``acquire()``) until this context exits.
+            do_work()
+
     """
 
     def __init__(self, lock_file_path: str) -> None:

--- a/src/ffi/testing/testing.cc
+++ b/src/ffi/testing/testing.cc
@@ -446,6 +446,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def("testing.schema_no_args", []() { return 1; })
       .def("testing.schema_no_return", [](int64_t x) {})
       .def("testing.schema_no_args_no_return", []() {});
+  TVMFFIEnvModRegisterSystemLibSymbol("__tvm_ffi_testing.add_one",
+                                      reinterpret_cast<void*>(__add_one_c_symbol));
 }
 
 }  // namespace ffi


### PR DESCRIPTION
This PR refines Python-side documentation. It includes:

- Adding example code to every public API as much as possible
- Making existing examples copy-pastable as much as possible
- Polish writing
- Clarifies a few API usage, e.g. system_lib