### PR TITLE
Minor improvement on type hint of `register_object`

### DIFF
--- a/python/tvm_ffi/registry.py
+++ b/python/tvm_ffi/registry.py
@@ -68,12 +68,12 @@ def register_object(type_key: str | None = None) -> Callable[[_T], _T]:
 
     if isinstance(type_key, str):
 
-        def _decorator_with_name(cls: type) -> type:
+        def _decorator_with_name(cls: _T) -> _T:
             return _register(cls, type_key)
 
         return _decorator_with_name
 
-    def _decorator_default(cls: type) -> type:
+    def _decorator_default(cls: _T) -> _T:
         return _register(cls, cls.__name__)
 
     if type_key is None:


### PR DESCRIPTION
Update type hint for register_object function.
This pull request introduces a minor type hint improvement to the `register_object` function in `python/tvm_ffi/registry.py`. The change enhances type safety by introducing a type variable for the function's return type.

* Improved type hinting for `register_object` by adding a `_T` type variable, ensuring the decorator preserves the original type of the class it decorates.

Before, the decorated object is treated as a value, and cause type lint errors

<img width="592" height="171" alt="image" src="https://github.com/user-attachments/assets/a5cd248a-c48e-4755-8706-c836993ee6f0" />

After, the object is treated as a type

<img width="596" height="183" alt="image" src="https://github.com/user-attachments/assets/4b0bd484-7e6a-4830-b10a-bec8f90da9de" />

