### PR TITLE
[Fix] fix iterator behavior

### DIFF
--- a/include/tvm/ffi/container/container_details.h
+++ b/include/tvm/ffi/container/container_details.h
@@ -239,8 +239,8 @@ class ReverseIterAdapter {
  public:
   using difference_type = typename std::iterator_traits<TIter>::difference_type;
   using value_type = typename Converter::ResultType;
-  using pointer = typename Converter::ResultType*;
-  using reference = typename Converter::ResultType&;  // NOLINT(*)
+  using pointer = const typename Converter::ResultType*;
+  using reference = const typename Converter::ResultType;
   using iterator_category = typename std::iterator_traits<TIter>::iterator_category;
 
   explicit ReverseIterAdapter(TIter iter) : iter_(iter) {}
@@ -275,7 +275,7 @@ class ReverseIterAdapter {
 
   bool operator==(ReverseIterAdapter other) const { return iter_ == other.iter_; }
   bool operator!=(ReverseIterAdapter other) const { return !(*this == other); }
-  const value_type operator*() const { return Converter::convert(*iter_); }
+  reference operator*() const { return Converter::convert(*iter_); }
 
  private:
   TIter iter_;


### PR DESCRIPTION
According to [cppreference](https://en.cppreference.com/w/cpp/named_req/InputIterator.html), the return type of the dereferenced iterator must be equivalent to the `reference_type`.

Before this PR, the IterAdapter does not adhere to legacy iterator, which may potentially leads to undefined behavior when used with STL components(in my case, `std::make_move_iterator`) . We just fix this in this PR.
