### PR TITLE
[CYTHON] Fix ctypes.c_void_p for nullptr

### DIFF
--- a/python/tvm_ffi/cython/base.pxi
+++ b/python/tvm_ffi/cython/base.pxi
@@ -439,7 +439,8 @@ cdef inline object ctypes_handle(void* chandle):
 cdef inline void* c_handle(object handle):
     """Cast C types handle to c handle."""
     cdef unsigned long long v_ptr
-    v_ptr = handle.value
+    cdef object value = handle.value
+    v_ptr = 0 if value is None else value
     return <void*>(v_ptr)
 
 

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -72,6 +72,10 @@ def test_echo() -> None:
     assert isinstance(c_void_p_result, ctypes.c_void_p)
     assert c_void_p_result.value == 0x12345678
 
+    # test c_void_p for nullptr
+    c_void_p_nullptr_result = fecho(ctypes.c_void_p(0))
+    c_void_p_nullptr_result is None
+
     # test function: aka object
     fadd = tvm_ffi.convert(lambda a, b: a + b)
     fadd1 = fecho(fadd)


### PR DESCRIPTION
ctypes.c_void_p.value returns None instead of 0 when we construct a nullptr with value=0. This PR fixes the corner case.