### PR TITLE
[Fix] Enhanced check for CUDA availability

### DIFF
--- a/addons/torch_c_dlpack_ext/build_backend.py
+++ b/addons/torch_c_dlpack_ext/build_backend.py
@@ -75,10 +75,15 @@ def build_wheel(
             )
         else:
             extra_args = []
-            if torch.version.cuda is not None:
-                extra_args.append("--build-with-cuda")
-            elif torch.version.hip is not None:
-                extra_args.append("--build-with-rocm")
+            # First use "torch.cuda.is_available()" to check whether GPU environment
+            # is available. Then determine the GPU type.
+            if torch.cuda.is_available():
+                if torch.version.cuda is not None:
+                    extra_args.append("--build-with-cuda")
+                elif torch.version.hip is not None:
+                    extra_args.append("--build-with-rocm")
+                else:
+                    raise ValueError("Cannot determine whether to build with CUDA or ROCm.")
             subprocess.run(
                 [
                     sys.executable,

--- a/include/tvm/ffi/c_api.h
+++ b/include/tvm/ffi/c_api.h
@@ -62,7 +62,7 @@
 /*! \brief TVM FFI minor version. */
 #define TVM_FFI_VERSION_MINOR 1
 /*! \brief TVM FFI patch version. */
-#define TVM_FFI_VERSION_PATCH 2
+#define TVM_FFI_VERSION_PATCH 3
 // NOLINTEND(modernize-macro-to-enum)
 
 #ifdef __cplusplus

--- a/tests/python/test_optional_torch_c_dlpack.py
+++ b/tests/python/test_optional_torch_c_dlpack.py
@@ -44,10 +44,15 @@ def test_build_torch_c_dlpack_extension() -> None:
         "--libname",
         "libtorch_c_dlpack_addon_test.so",
     ]
-    if torch.version.cuda is not None:
-        args.append("--build-with-cuda")
-    elif torch.version.hip is not None:
-        args.append("--build-with-rocm")
+    # First use "torch.cuda.is_available()" to check whether GPU environment
+    # is available. Then determine the GPU type.
+    if torch.cuda.is_available():
+        if torch.version.cuda is not None:
+            args.append("--build-with-cuda")
+        elif torch.version.hip is not None:
+            args.append("--build-with-rocm")
+        else:
+            raise ValueError("Cannot determine whether to build with CUDA or ROCm.")
     subprocess.run(args, check=True)
 
     lib_path = str(Path("./output-dir/libtorch_c_dlpack_addon_test.so").resolve())

--- a/tests/python/test_tensor.py
+++ b/tests/python/test_tensor.py
@@ -115,7 +115,8 @@ def test_tvm_ffi_tensor_compatible() -> None:
 
 
 @pytest.mark.skipif(
-    torch is None or torch.version.hip is None, reason="ROCm is not enabled in PyTorch"
+    torch is None or not torch.cuda.is_available() or torch.version.hip is None,
+    reason="ROCm is not enabled in PyTorch",
 )
 def test_tensor_from_pytorch_rocm() -> None:
     assert torch is not None


### PR DESCRIPTION
This commit fixes a bug that only uses `torch.version.cuda` to check if CUDA is available. This is insufficient and we need an additional check of `torch.cuda.is_available()` to ensure that CUDA can be found in the environment.