### PR TITLE
[chore] Hide symbols by default for extension build

### DIFF
--- a/addons/torch_c_dlpack_ext/pyproject.toml
+++ b/addons/torch_c_dlpack_ext/pyproject.toml
@@ -17,7 +17,7 @@
 
 [project]
 name = "torch_c_dlpack_ext"
-version = "0.1.2"
+version = "0.1.3"
 requires-python = ">=3.9"
 description = "torch c dlpack ext"
 dependencies = ["torch"]

--- a/python/tvm_ffi/utils/_build_optional_torch_c_dlpack.py
+++ b/python/tvm_ffi/utils/_build_optional_torch_c_dlpack.py
@@ -599,7 +599,7 @@ def _run_build_on_linux_like(
     """Build the module directly by invoking compiler commands (non-Windows only)."""
     from tvm_ffi.libinfo import find_dlpack_include_path  # noqa: PLC0415
 
-    default_cflags = ["-std=c++17", "-fPIC", "-O3"]
+    default_cflags = ["-std=c++17", "-fPIC", "-O3", "-fvisibility=hidden"]
     # Platform-specific linker flags
     if IS_DARWIN:
         # macOS uses @loader_path instead of $ORIGIN


### PR DESCRIPTION
This PR hides the symbols by default for extension build. not strictly necessary good to avoid potential symbol conflict