### PR TITLE
[Fix] Cast Shape from DLTensor*

### DIFF
--- a/include/tvm/ffi/container/shape.h
+++ b/include/tvm/ffi/container/shape.h
@@ -330,10 +330,16 @@ inline constexpr bool use_default_type_traits_v<Shape> = false;
 
 // Allow auto conversion from Array<int64_t> to Shape, but not from Shape to Array<int64_t>
 template <>
-struct TypeTraits<Shape> : public ObjectRefWithFallbackTraitsBase<Shape, Array<int64_t>> {
+struct TypeTraits<Shape> : public ObjectRefWithFallbackTraitsBase<Shape, Array<int64_t>, DLTensor*> {
   static constexpr int32_t field_static_type_index = TypeIndex::kTVMFFIShape;
+
   TVM_FFI_INLINE static Shape ConvertFallbackValue(Array<int64_t> src) {
     return Shape(std::move(src));
+  }
+
+  TVM_FFI_INLINE static Shape ConvertFallbackValue(DLTensor* src) {
+    std::vector<int64_t> shape_vec(src->shape, src->shape + src->ndim);
+    return Shape(Array<int64_t>(shape_vec));
   }
 };
 

--- a/tests/cpp/test_shape.cc
+++ b/tests/cpp/test_shape.cc
@@ -93,4 +93,18 @@ TEST(Shape, ShapeView) {
   EXPECT_EQ(view_from_init.Product(), 7 * 8 * 9);
 }
 
+TEST(Shape, DLTensor) {
+  int64_t shape_data[] = {1, 2, 3};
+  DLTensor dltensor;
+  dltensor.ndim = 3;
+  dltensor.shape = shape_data;
+
+  AnyView view_dl = &dltensor;
+  auto shape = view_dl.cast<Shape>();
+  EXPECT_EQ(shape.size(), 3);
+  EXPECT_EQ(shape[0], 1);
+  EXPECT_EQ(shape[1], 2);
+  EXPECT_EQ(shape[2], 3);
+}
+
 }  // namespace


### PR DESCRIPTION
# Description

- Type error: Cannot convert from type ' DLTensor* '  to ' ffi.Shape '

# Detail
- onnx  -> lib.so -> Run via RPC -> Happen error

<img width="1473" height="601" alt="DLTensorConvertShape" src="https://github.com/user-attachments/assets/e4b9edc2-7a35-4282-aa68-90f6c8e47b3e" />

- Fixed type error: Cannot convert from type ' DLTensor* '  to ' ffi.Shape '

