### PR TITLE
fix(config): `tvm-ffi-config --sourcedir` broken in wheels

### DIFF
--- a/python/tvm_ffi/libinfo.py
+++ b/python/tvm_ffi/libinfo.py
@@ -62,7 +62,7 @@ def find_source_path() -> str:
             _rel_top_directory(),
             _dev_top_directory(),
         ],
-        cond=lambda p: (p / "cmake").is_dir(),
+        cond=lambda p: (p / "src").is_dir(),
     ):
         return ret
     raise RuntimeError("Cannot find home path.")


### PR DESCRIPTION
Bug detected in: https://github.com/apache/tvm-ffi/actions/runs/20001883512/workflow

In fact, checking `${guess}/cmake` is not a reliable way to locate source directory of apache-tvm-ffi wheel, because the cmake directory actually lives under `${guess}/share/cmake` in the wheel.

This PR switches to `${guess}/src`, which always reliably locates in the same relative path.