### PR TITLE
feat: Introduce `tvm_ffi.libinfo.load_lib_module`

### DIFF
--- a/examples/packaging/CMakeLists.txt
+++ b/examples/packaging/CMakeLists.txt
@@ -60,9 +60,6 @@ add_library(my_ffi_extension SHARED src/extension.cc)
 target_link_libraries(my_ffi_extension tvm_ffi_header)
 target_link_libraries(my_ffi_extension tvm_ffi_shared)
 
-# show as my_ffi_extension.so
-set_target_properties(my_ffi_extension PROPERTIES PREFIX "")
-
 if (TVM_FFI_EXT_SHIP_DEBUG_SYMBOLS)
   # ship debugging symbols for backtrace on macos
   tvm_ffi_add_prefix_map(my_ffi_extension ${CMAKE_CURRENT_SOURCE_DIR})

--- a/examples/packaging/python/my_ffi_extension/base.py
+++ b/examples/packaging/python/my_ffi_extension/base.py
@@ -16,32 +16,6 @@
 # Base logic to load library for extension package
 """Utilities to locate and load the example extension shared library."""
 
-import sys
-from pathlib import Path
-
 import tvm_ffi
 
-
-def _load_lib() -> tvm_ffi.Module:
-    # first look at the directory of the current file
-    file_dir = Path(__file__).resolve().parent
-
-    path_candidates = [
-        file_dir,
-        file_dir / ".." / ".." / "build",
-    ]
-
-    if sys.platform.startswith("win32"):
-        lib_dll_name = "my_ffi_extension.dll"
-    elif sys.platform.startswith("darwin"):
-        lib_dll_name = "my_ffi_extension.dylib"
-    else:
-        lib_dll_name = "my_ffi_extension.so"
-    for candidate in path_candidates:
-        for path in Path(candidate).glob(lib_dll_name):
-            return tvm_ffi.load_module(str(path))
-
-    raise RuntimeError(f"Cannot find {lib_dll_name} in {path_candidates}")
-
-
-_LIB = _load_lib()
+_LIB = tvm_ffi.libinfo.load_lib_module("my-ffi-extension", "my_ffi_extension")


### PR DESCRIPTION
This PR makes downstream library loading process correct and convenient, by bringing in a new API `tvm_ffi.libinfo.load_lib_module`.

To demonstrate the effect, the file `examples/packaging/python/my_ffi_extension/base.py`, which degenerates to only 2 lines after this PR:

```python
import tvm_ffi
_LIB = tvm_ffi.libinfo.load_lib_module("my-ffi-extension", "my_ffi_extension")
```

It's worth mentioning that the new API works smoothly for both editable and non-editable builds, which is more correct than the existing one.