### PR TITLE
fix(build): Link dl and pthread dependencies for tvm_ffi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,11 +125,11 @@ tvm_ffi_add_msvc_flags(tvm_ffi_objs)
 tvm_ffi_add_target_from_obj(tvm_ffi tvm_ffi_objs)
 
 target_link_libraries(tvm_ffi_shared PRIVATE Threads::Threads)
-target_link_libraries(tvm_ffi_static PRIVATE Threads::Threads)
+target_link_libraries(tvm_ffi_static INTERFACE Threads::Threads)
 
 if (TVM_FFI_USE_EXTRA_CXX_API AND CMAKE_DL_LIBS)
   target_link_libraries(tvm_ffi_shared PRIVATE ${CMAKE_DL_LIBS})
-  target_link_libraries(tvm_ffi_static PRIVATE ${CMAKE_DL_LIBS})
+  target_link_libraries(tvm_ffi_static INTERFACE ${CMAKE_DL_LIBS})
 endif ()
 
 if (TARGET libbacktrace)


### PR DESCRIPTION
Should fix https://github.com/apache/tvm-ffi/issues/344.

There are two linking issues:
- `std::mutex` is used in `src/ffi/backtrace.cc`, which means `libtvm_ffi.so` in theory should link with pthread.
- `dlsym`, `dlopen`, etc are used in `src/ffi/extra/library_module_dynamic_lib.cc`, which means it has to be linked with dl.

This PR adds those two dependencies.