### PR TITLE
fix(lint): Suppress latest clang-tidy warnings

### DIFF
--- a/include/tvm/ffi/reflection/overload.h
+++ b/include/tvm/ffi/reflection/overload.h
@@ -274,6 +274,7 @@ namespace reflection {
 template <typename Class>
 class OverloadObjectDef : private ObjectDef<Class> {
  public:
+  /*! \brief The super class */
   using Super = ObjectDef<Class>;
   /*!
    * \brief Constructor


### PR DESCRIPTION
Introduced by #286, where `CaptureTuple`, i.e. `CaptureTupleAux<PackedArgs>::type`, is defined as:

```
std::tuple<std::optional<std::decay_t<Args>>...>
```

and star access to its `std::optional` is indeed unchecked but intended.