### PR TITLE
doc: Reorder Sections in Python Packaging

### DIFF
--- a/docs/packaging/cpp_tooling.rst
+++ b/docs/packaging/cpp_tooling.rst
@@ -82,7 +82,7 @@ Configure Target
 
 The configure helper wires a target to TVM-FFI and provides sensible defaults.
 It links the TVM-FFI headers and shared library, and it configures debug symbol handling.
-Optionally, it runs the Python :ref:`stub generation <sec-subgen>` tool after
+Optionally, it runs the Python :ref:`stub generation <sec-stubgen>` tool after
 the build completes.
 
 .. code-block:: cmake


### PR DESCRIPTION
Depends on #363.

Existing order being

- Export C++ to Python;
- Build a Python wheel;
- Generate Python package stubs.

follows a natural bottom-up order. However, as a Python packaging tutorial, it would be more desirable to empahsis the "Python Packaging" part. Therefore, we reorder it to:

- Build a Python wheel;
- Export C++ to Python;
- Generate Python package stubs.