### PR TITLE
feat: add __bool__ support for Array and Map

### DIFF
--- a/python/tvm_ffi/container.py
+++ b/python/tvm_ffi/container.py
@@ -192,6 +192,10 @@ class Array(core.Object, Sequence[T]):
         """Check if the array contains a value."""
         return _ffi_api.ArrayContains(self, value)
 
+    def __bool__(self) -> bool:
+        """Return True if the array is non-empty."""
+        return len(self) > 0
+
     def __add__(self, other: Iterable[T]) -> Array[T]:
         """Concatenate two arrays."""
         return type(self)(itertools.chain(self, other))
@@ -336,6 +340,10 @@ class Map(core.Object, Mapping[K, V]):
     def __len__(self) -> int:
         """Return the number of items in the map."""
         return _ffi_api.MapSize(self)
+
+    def __bool__(self) -> bool:
+        """Return True if the map is non-empty."""
+        return len(self) > 0
 
     def __iter__(self) -> Iterator[K]:
         """Iterate over the map's keys."""

--- a/tests/python/test_container.py
+++ b/tests/python/test_container.py
@@ -227,3 +227,31 @@ def test_large_map_get() -> None:
 def test_array_contains(arr: list[Any], value: Any, expected: bool) -> None:
     a = tvm_ffi.convert(arr)
     assert (value in a) == expected
+
+
+@pytest.mark.parametrize(
+    "arr, expected",
+    [
+        ([1, 2, 3], True),
+        ([1], True),
+        ([], False),
+        (["hello"], True),
+    ],
+)
+def test_array_bool(arr: list[Any], expected: bool) -> None:
+    a = tvm_ffi.Array(arr)
+    assert bool(a) is expected
+
+
+@pytest.mark.parametrize(
+    "mapping, expected",
+    [
+        ({"a": 1, "b": 2}, True),
+        ({"a": 1}, True),
+        ({}, False),
+        ({1: "one"}, True),
+    ],
+)
+def test_map_bool(mapping: dict[Any, Any], expected: bool) -> None:
+    m = tvm_ffi.Map(mapping)
+    assert bool(m) is expected


### PR DESCRIPTION
## Why

Python's built-in list and dict return False when empty. However, Array and Map containers always returned True because they didn't implement __bool__, making bool(Array([])) and bool(Map({})) return True unexpectedly.

## How

- Python: Implemented __bool__ for Array and Map returning len(self) > 0
- Tests: Added parametrized tests verifying truthy/falsy behavior for empty and non-empty containers