### PR TITLE
feat: add find and substr methods to String

### DIFF
--- a/include/tvm/ffi/string.h
+++ b/include/tvm/ffi/string.h
@@ -611,11 +611,14 @@ class String {
     }
   }
 
+  /*! \brief Value returned by find() when no match is found */
+  static constexpr size_t npos = static_cast<size_t>(-1);
+
   /*!
    * \brief Find the first occurrence of a substring
    * \param str The substring to search for
    * \param pos The position at which to start the search
-   * \return The position of the first character of the first match, or size_t(-1) if not found
+   * \return The position of the first character of the first match, or npos if not found
    */
   size_t find(const String& str, size_t pos = 0) const { return find(str.data(), pos, str.size()); }
 
@@ -623,7 +626,7 @@ class String {
    * \brief Find the first occurrence of a substring
    * \param str The substring to search for
    * \param pos The position at which to start the search
-   * \return The position of the first character of the first match, or size_t(-1) if not found
+   * \return The position of the first character of the first match, or npos if not found
    */
   size_t find(const char* str, size_t pos = 0) const { return find(str, pos, std::strlen(str)); }
 
@@ -632,21 +635,10 @@ class String {
    * \param str The substring to search for
    * \param pos The position at which to start the search
    * \param count The length of the substring
-   * \return The position of the first character of the first match, or size_t(-1) if not found
+   * \return The position of the first character of the first match, or npos if not found
    */
   size_t find(const char* str, size_t pos, size_t count) const {
-    if (count == 0) return pos <= size() ? pos : size_t(-1);
-    if (pos >= size() || count > size() - pos) return size_t(-1);
-
-    const char* this_data = data();
-    size_t this_size = size();
-
-    for (size_t i = pos; i <= this_size - count; ++i) {
-      if (std::memcmp(this_data + i, str, count) == 0) {
-        return i;
-      }
-    }
-    return size_t(-1);
+    return std::string_view(data(), size()).find(std::string_view(str, count), pos);
   }
 
   /*!

--- a/tests/cpp/test_string.cc
+++ b/tests/cpp/test_string.cc
@@ -451,16 +451,17 @@ TEST(String, Find) {
   EXPECT_EQ(s.find("hello"), 0);
   EXPECT_EQ(s.find("o"), 4);
   EXPECT_EQ(s.find("o", 5), 7);
-  EXPECT_EQ(s.find("notfound"), size_t(-1));
+  EXPECT_EQ(s.find("notfound"), String::npos);
   EXPECT_EQ(s.find(""), 0);
   EXPECT_EQ(s.find("", 5), 5);
-  EXPECT_EQ(s.find("", 20), size_t(-1));
+  EXPECT_EQ(s.find("", 11), 11);
+  EXPECT_EQ(s.find("", 20), String::npos);
 
   String pattern{"world"};
   EXPECT_EQ(s.find(pattern), 6);
 
   String empty{""};
-  EXPECT_EQ(empty.find("x"), size_t(-1));
+  EXPECT_EQ(empty.find("x"), String::npos);
   EXPECT_EQ(empty.find(""), 0);
 }
 

--- a/tests/python/test_string.py
+++ b/tests/python/test_string.py
@@ -63,6 +63,9 @@ def test_string_find_substr() -> None:
     assert s.find("o", 5) == 7
     assert s.find("notfound") == -1
     assert s.find("") == 0
+    assert s.find("", 5) == 5
+    assert s.find("", 11) == 11
+    assert s.find("", 20) == -1
 
     assert s[6:11] == "world"
     assert s[0:5] == "hello"


### PR DESCRIPTION
## Why

String class lacks essential string manipulation methods that are commonly expected in standard library equivalents, requiring users to convert to std::string for basic operations like substring search and extraction.

## How

- Add find() method with three overloads (String, const char*, const char* with count) to search for substrings
- Add substr() method to extract substrings with bounds checking