### PR TITLE
chore: replace C-style cast with static_cast in String::substr

### DIFF
--- a/include/tvm/ffi/string.h
+++ b/include/tvm/ffi/string.h
@@ -647,7 +647,7 @@ class String {
    * \param count The length of the substring (default: until end of string)
    * \return A string containing the substring
    */
-  String substr(size_t pos = 0, size_t count = size_t(-1)) const {
+  String substr(size_t pos = 0, size_t count = npos) const {
     if (pos > size()) {
       throw std::out_of_range("tvm::String substr index out of bounds");
     }


### PR DESCRIPTION
## Related

https://github.com/apache/tvm-ffi/actions/runs/20755375337/job/59595882892

## Why

clang-tidy fails with google-readability-casting error due to C-style cast in default parameter.

## How

Replace size_t(-1) with `nops` in String::substr method