### PR TITLE
fix: out-of-bounds read in `StringViewToDLDataType_` with non-null-terminated strings

### DIFF
--- a/tests/cpp/test_dtype.cc
+++ b/tests/cpp/test_dtype.cc
@@ -180,7 +180,7 @@ TEST(DType, NonNullTerminatedStringView) {
 
   // Test 6: Truly non-null-terminated - overwrite null byte
   char buffer6[] = "float64AAAAA";
-  buffer6[7] = 'X';  // Ensure no null terminator at position 7
+  buffer6[7] = 'X';                                       // Ensure no null terminator at position 7
   DLDataType dtype6 = test_dtype_from_bytes(buffer6, 7);  // "float64"
   EXPECT_EQ(dtype6.code, kDLFloat);
   EXPECT_EQ(dtype6.bits, 64);
@@ -198,5 +198,19 @@ TEST(DType, NonNullTerminatedStringView) {
   EXPECT_EQ(dtype8.code, kDLInt);
   EXPECT_EQ(dtype8.bits, 8);
   EXPECT_EQ(dtype8.lanes, 16);  // Should correctly parse x16
+
+  // Test 9: Scalable vector - "int32xvscalex4"
+  char buffer9[] = "int32xvscalex4extra";
+  DLDataType dtype9 = test_dtype_from_bytes(buffer9, 14);  // "int32xvscalex4"
+  EXPECT_EQ(dtype9.code, kDLInt);
+  EXPECT_EQ(dtype9.bits, 32);
+  EXPECT_EQ(dtype9.lanes, static_cast<uint16_t>(-4));  // Scalable: -4
+
+  // Test 10: Scalable vector with garbage after
+  char buffer10[] = "float16xvscalex8999";
+  DLDataType dtype10 = test_dtype_from_bytes(buffer10, 16);  // "float16xvscalex8"
+  EXPECT_EQ(dtype10.code, kDLFloat);
+  EXPECT_EQ(dtype10.bits, 16);
+  EXPECT_EQ(dtype10.lanes, static_cast<uint16_t>(-8));  // Should be -8, not parse "999"
 }
 }  // namespace


### PR DESCRIPTION
## Summary
Fixes a critical bug in `StringViewToDataType_` that causes undefined behavior when parsing dtype strings from non-null-terminated `std::string_view`. This bug particularly affects Electron applications due to aggresive memory reuse in Chromium's allocators.

## Problem
The original implementation used `strtoul()` to parse numeric values (bits and lanes) directly from `std::string_view::data()`. However, `strtoul()` requires null-terminated strings and will continue reading beyond the string_view bounds until it finds a null terminator or non-digit character.

## Solution
Replace `strtoul()` with manual digit parsing that respects `string_view` boundaries:
```c++
auto parse_digits = [](const char*& ptr, const char* end) -> uint32_t {
  uint32_t value = 0;
  while (ptr < end && *ptr >= '0' && *ptr <= '9') {
    value = value * 10 + (*ptr - '0');
    ptr++;
  }
  return value;
};
```
- Never reads beyond `str.data() + str.length()`
- Works correctly with non-null-terminated strings
- No memory allocation overhead
- Same performance as `strtoul` but safe

## Testing
New test `TEST(DType, NonNullTerminatedStringView)` validates:
- Parsing with digit garbage after the string (`"float16999888777"` length 7 -> bits=16, not 16999888777)
- Parsing with lane specifications outside bounds (`"int32x4extradata"` length 5 -> lanes=1, not 4)
- Correct parsing when lanes are within bounds (`"bfloat16x2"` length 10 -> lanes=2)
- Non-null-terminated buffers (`"float64AAAAA"` length 7 -> float64)
- Edge cases with various dtype types (int, uint, float, bfloat)