### PR TITLE
feat: add starts_with and ends_with to String

### DIFF
--- a/include/tvm/ffi/string.h
+++ b/include/tvm/ffi/string.h
@@ -667,6 +667,15 @@ class String {
    * \param prefix The prefix to check for
    * \return true if the string starts with prefix, false otherwise
    */
+  bool starts_with(std::string_view prefix) const {
+    return starts_with(prefix.data(), prefix.size());
+  }
+
+  /*!
+   * \brief Check if the string starts with a prefix
+   * \param prefix The prefix to check for
+   * \return true if the string starts with prefix, false otherwise
+   */
   bool starts_with(const char* prefix) const { return starts_with(prefix, std::strlen(prefix)); }
 
   /*!
@@ -688,6 +697,13 @@ class String {
    * \return true if the string ends with suffix, false otherwise
    */
   bool ends_with(const String& suffix) const { return ends_with(suffix.data(), suffix.size()); }
+
+  /*!
+   * \brief Check if the string ends with a suffix
+   * \param suffix The suffix to check for
+   * \return true if the string ends with suffix, false otherwise
+   */
+  bool ends_with(std::string_view suffix) const { return ends_with(suffix.data(), suffix.size()); }
 
   /*!
    * \brief Check if the string ends with a suffix

--- a/tests/cpp/test_string.cc
+++ b/tests/cpp/test_string.cc
@@ -488,12 +488,15 @@ TEST(String, StartsWith) {
   EXPECT_TRUE(s.starts_with("h"));
   EXPECT_TRUE(s.starts_with(""));
   EXPECT_TRUE(s.starts_with(String{"hello"}));
+  EXPECT_TRUE(s.starts_with(std::string_view{"hello"}));
   EXPECT_FALSE(s.starts_with("world"));
   EXPECT_FALSE(s.starts_with("Hello"));
   EXPECT_FALSE(s.starts_with("hello world extra"));
+  EXPECT_FALSE(s.starts_with(std::string_view{"world"}));
 
   String empty{""};
   EXPECT_TRUE(empty.starts_with(""));
+  EXPECT_TRUE(empty.starts_with(std::string_view{""}));
   EXPECT_FALSE(empty.starts_with("x"));
 
   String single{"x"};
@@ -508,12 +511,15 @@ TEST(String, EndsWith) {
   EXPECT_TRUE(s.ends_with("d"));
   EXPECT_TRUE(s.ends_with(""));
   EXPECT_TRUE(s.ends_with(String{"world"}));
+  EXPECT_TRUE(s.ends_with(std::string_view{"world"}));
   EXPECT_FALSE(s.ends_with("hello"));
   EXPECT_FALSE(s.ends_with("World"));
   EXPECT_FALSE(s.ends_with("extra hello world"));
+  EXPECT_FALSE(s.ends_with(std::string_view{"hello"}));
 
   String empty{""};
   EXPECT_TRUE(empty.ends_with(""));
+  EXPECT_TRUE(empty.ends_with(std::string_view{""}));
   EXPECT_FALSE(empty.ends_with("x"));
 
   String single{"x"};


### PR DESCRIPTION
## Why

String pattern matching is essential for validation and parsing in compiler infrastructure. Users currently lack efficient prefix/suffix checking methods.

## How

- Add `starts_with(prefix)` method supporting String, const char*, and raw pointer with length
- Add `ends_with(suffix)` method with same overload variants
- Add tests
