### PR TITLE
ci: add clang-tidy to ci_test

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -51,7 +51,7 @@ jobs:
         id: cpp_files
         run: |
           FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD -- \
-            '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hpp' '*.hxx' | tr '\n' ' ')
+            '*.c' '*.cc' '*.cpp' '*.cxx' | tr '\n' ' ')
           echo "files=$FILES" >> $GITHUB_OUTPUT
           [ -n "$FILES" ] && echo "changed=true" >> $GITHUB_OUTPUT || echo "changed=false" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Why

PR CI passed but main CI failed after merge because clang-tidy only ran on main branch (in ci_mainline_only.yml), not on PRs.

## How

- Add `clang-tidy` hook to `ci_test`