### PR TITLE
[RFC][Error][ABI] Update Error to enable future compact to cause chaining

### DIFF
--- a/include/tvm/ffi/c_api.h
+++ b/include/tvm/ffi/c_api.h
@@ -394,6 +394,16 @@ typedef struct {
    */
   void (*update_backtrace)(TVMFFIObjectHandle self, const TVMFFIByteArray* backtrace,
                            int32_t update_mode);
+  /*!
+   * \brief Optional cause error chain that caused this error to be raised.
+   * \note This handle is owned by the ErrorCell.
+   */
+  TVMFFIObjectHandle cause_chain;
+  /*!
+   * \brief Optional extra context that can be used to record additional info about the error.
+   * \note This handle is owned by the ErrorCell.
+   */
+  TVMFFIObjectHandle extra_context;
 } TVMFFIErrorCell;
 
 /*!
@@ -630,6 +640,20 @@ TVM_FFI_DLL void TVMFFIErrorSetRaisedFromCStrParts(const char* kind, const char*
  */
 TVM_FFI_DLL int TVMFFIErrorCreate(const TVMFFIByteArray* kind, const TVMFFIByteArray* message,
                                   const TVMFFIByteArray* backtrace, TVMFFIObjectHandle* out);
+
+/*!
+ * \brief Create an initial error object with cause chain and extra context.
+ * \param kind The kind of the error.
+ * \param message The error message.
+ * \param backtrace The backtrace of the error.
+ * \param cause_chain The cause error chain that caused this error to be raised.
+ * \param extra_context The extra context that can be used to record additional information.
+ * \param out The output error object handle.
+ * \return 0 on success, nonzero on failure.
+ */
+TVM_FFI_DLL int TVMFFIErrorCreateWithCauseAndExtraContext(
+    const TVMFFIByteArray* kind, const TVMFFIByteArray* message, const TVMFFIByteArray* backtrace,
+    TVMFFIObjectHandle cause_chain, TVMFFIObjectHandle extra_context, TVMFFIObjectHandle* out);
 
 //------------------------------------------------------------
 // Section: DLPack support APIs

--- a/tests/cpp/test_error.cc
+++ b/tests/cpp/test_error.cc
@@ -118,4 +118,15 @@ TEST(Error, TracebackMostRecentCallLast) {
   Error error("TypeError", "here", "test0\ntest1\ntest2\n");
   EXPECT_EQ(error.TracebackMostRecentCallLast(), "test2\ntest1\ntest0\n");
 }
+
+TEST(Error, CauseChain) {
+  Error original_error("TypeError", "here", "test0");
+  Error cause_chain("ValueError", "cause", "test1", original_error, std::nullopt);
+  auto opt_cause = cause_chain.cause_chain();
+  EXPECT_TRUE(opt_cause.has_value());
+  if (opt_cause.has_value()) {
+    EXPECT_EQ(opt_cause->kind(), "TypeError");
+  }
+  EXPECT_TRUE(!cause_chain.extra_context().has_value());
+}
 }  // namespace


### PR DESCRIPTION
This PR brings a backward compatible update to error ABI to enable possible future support of cause chaining. Specifically, we add two fields:

- cause_chain is an optional field for chaining errors
- extra_context can be used to optionally attach opaque object (e.g. python error) if needed.

The change is backward compatible as we only append to the error field. Most of the existing usages will simply ignore the two fields and use a single error.