### PR TITLE
[CMAKE] Allow threads to be not found for cross compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,6 @@ option(TVM_FFI_USE_LIBBACKTRACE "Enable libbacktrace" ON)
 option(TVM_FFI_USE_EXTRA_CXX_API "Enable extra CXX API in shared lib" ON)
 option(TVM_FFI_BACKTRACE_ON_SEGFAULT "Set signal handler to print backtrace on segfault" ON)
 
-find_package(Threads REQUIRED)
-
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/Utils/DetectTargetTriple.cmake)
 
 if (TVM_FFI_USE_LIBBACKTRACE)
@@ -124,8 +122,13 @@ endif ()
 tvm_ffi_add_msvc_flags(tvm_ffi_objs)
 tvm_ffi_add_target_from_obj(tvm_ffi tvm_ffi_objs)
 
-target_link_libraries(tvm_ffi_shared PRIVATE Threads::Threads)
-target_link_libraries(tvm_ffi_static INTERFACE Threads::Threads)
+find_package(Threads)
+if (Threads_FOUND)
+  # link to threads library if found on some cross-compilation platforms, the threads library maynot
+  # be found but downstream may still be able to build extra alternatives via source bundle
+  target_link_libraries(tvm_ffi_shared PRIVATE Threads::Threads)
+  target_link_libraries(tvm_ffi_static INTERFACE Threads::Threads)
+endif ()
 
 if (TVM_FFI_USE_EXTRA_CXX_API AND CMAKE_DL_LIBS)
   target_link_libraries(tvm_ffi_shared PRIVATE ${CMAKE_DL_LIBS})


### PR DESCRIPTION
This PR updates the threads linkage to be optional so the library can be build for cross-compilation targets where threads may not be available.