### PR TITLE
fix: add unified_api.h include to device_guard.h

### DIFF
--- a/include/tvm/ffi/extra/cuda/device_guard.h
+++ b/include/tvm/ffi/extra/cuda/device_guard.h
@@ -23,7 +23,6 @@
 #ifndef TVM_FFI_EXTRA_CUDA_DEVICE_GUARD_H_
 #define TVM_FFI_EXTRA_CUDA_DEVICE_GUARD_H_
 
-#include <tvm/ffi/extra/cuda/base.h>
 #include <tvm/ffi/extra/cuda/internal/unified_api.h>
 
 namespace tvm {


### PR DESCRIPTION
The `include/tvm/ffi/extra/cuda/device_guard.h` misses `#include <tvm/ffi/extra/cuda/internal/unified_api.h>` after #300, would cause `TVM_FFI_CHECK_CUDA_ERROR` undefined error.