### PR TITLE
fix: handle empty metadata in get_global_func_metadata

### DIFF
--- a/python/tvm_ffi/registry.py
+++ b/python/tvm_ffi/registry.py
@@ -275,7 +275,8 @@ def get_global_func_metadata(name: str) -> dict[str, Any]:
         Register a Python callable as a global FFI function.
 
     """
-    return json.loads(get_global_func("ffi.GetGlobalFuncMetadata")(name) or "{}")
+    metadata_json = get_global_func("ffi.GetGlobalFuncMetadata")(name)
+    return json.loads(metadata_json) if metadata_json else {}
 
 
 def init_ffi_api(namespace: str, target_module_name: str | None = None) -> None:

--- a/tests/python/test_metadata.py
+++ b/tests/python/test_metadata.py
@@ -17,7 +17,7 @@
 from typing import Any
 
 import pytest
-from tvm_ffi import get_global_func_metadata
+from tvm_ffi import get_global_func_metadata, register_global_func, remove_global_func
 from tvm_ffi.core import TypeInfo, TypeSchema, _lookup_type_attr
 from tvm_ffi.testing import _SchemaAllTypes
 
@@ -161,6 +161,16 @@ def test_metadata_global_func() -> None:
     assert metadata["bool_attr"] is True
     assert metadata["int_attr"] == 1
     assert metadata["str_attr"] == "hello"
+
+
+def test_metadata_empty_for_python_func() -> None:
+    @register_global_func("test.python_func_no_metadata")
+    def simple_func(x: int) -> int:
+        return x + 1
+
+    metadata = get_global_func_metadata("test.python_func_no_metadata")
+    assert metadata == {}
+    remove_global_func("test.python_func_no_metadata")
 
 
 def test_metadata_field() -> None:


### PR DESCRIPTION
## Related Issue

Fixes #208

## Why

Python-registered global functions without metadata cause JSONDecodeError when get_global_func_metadata() is called because the FFI returns an empty string which json.loads() cannot parse.

## How

- Check for empty metadata string before JSON parsing
- Return empty dict for functions without metadata
- Add regression test for Python functions without metadata