### PR TITLE
Update the logic of checking `#embed`

### DIFF
--- a/examples/cubin_launcher/embedded_cubin/cpp_embed/CMakeLists.txt
+++ b/examples/cubin_launcher/embedded_cubin/cpp_embed/CMakeLists.txt
@@ -25,7 +25,9 @@ set(CMAKE_CXX_STANDARD 26)
 include(CheckCXXSymbolExists)
 check_cxx_symbol_exists(__cpp_pp_embed "" HAVE_EMBED)
 if (NOT HAVE_EMBED)
-  message(FATAL_ERROR "Compiler does not support `#embed`")
+  message(FATAL_ERROR "Compiler does not support `#embed`."
+                      "Please use a newer compiler (e.g. GCC 15+, Clang 19+)"
+  )
 endif ()
 
 set(CMAKE_TVM_FFI_CUBIN_LAUNCHER_USE_DRIVER_API


### PR DESCRIPTION
This PR slightly update the example to use cubin launcher with c++'s `#embed`, make it fail earlier if compiler do not support the feature.