### PR TITLE
[Error] Unify EnvErrorAlreadySet to error.kind

### DIFF
--- a/docs/concepts/func_module.rst
+++ b/docs/concepts/func_module.rst
@@ -225,7 +225,6 @@ that the caller must zero-initialize before the call.
 
 - **Error code 0**: Success
 - **Error code -1**: Error occurred, retrievable with :cpp:func:`TVMFFIErrorMoveFromRaised`
-- **Error code -2**: Very rare frontend error
 
 .. hint::
   See :doc:`Any <any>` for more details on the semantics of :cpp:type:`tvm::ffi::AnyView` and :cpp:type:`tvm::ffi::Any`.
@@ -326,10 +325,18 @@ An :cpp:class:`~tvm::ffi::ErrorObj` is stored in thread-local storage (TLS) and 
 with :cpp:func:`TVMFFIErrorMoveFromRaised`.
 
 - **Error code -1:** Retrieve the error from TLS, print it, and release via :cpp:func:`TVMFFIObjectDecRef`.
-- **Error code -2:** A rare frontend error; consult the frontend's error mechanism instead of TLS.
 
 To raise an error, use :cpp:func:`TVMFFIErrorSetRaisedFromCStr` to set the TLS error and return ``-1``.
 For chains of calls, simply propagate return codes - TLS carries the error details.
+
+
+.. note::
+
+  In the very rare case, the error kind can be ``EnvErrorAlreadySet``,
+  which indicates that an error has already been set in the frontend environment.
+  In this case, the caller (python binding) should raise the error stored in the
+  frontend environment. This is handled by the our python package so
+  you generally do not need to handle this case explicitly.
 
 See :ref:`abi-exception` for C code examples.
 

--- a/docs/guides/python_lang_guide.md
+++ b/docs/guides/python_lang_guide.md
@@ -206,8 +206,8 @@ Traceback (most recent call last):
 File "example.py", line 7, in <module>
   test_raise_error("ValueError", "message")
   ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
-File "python/tvm_ffi/cython/function.pxi", line 325, in core.Function.__call__
-  raise move_from_last_error().py_error()
+File "python/tvm_ffi/cython/function.pxi", line 927, in tvm_ffi.core.Function.__call__
+  raise error.py_error()
   ^^^
 File "src/ffi/extra/testing.cc", line 60, in void tvm::ffi::TestRaiseError(tvm::ffi::String, tvm::ffi::String)
   throw ffi::Error(kind, msg, TVMFFITraceback(__FILE__, __LINE__, TVM_FFI_FUNC_SIG, 0));

--- a/examples/abi_overview/example_code.c
+++ b/examples/abi_overview/example_code.c
@@ -273,10 +273,6 @@ void Error_HandleReturnCode(int rc) {
       // IMPORTANT: Release the error object, or gets memory leaks
       TVMFFIObjectDecRef(err);
     }
-  } else if (rc == -2) {
-    // Frontend (e.g., Python) already has an exception set.
-    // Do not fetch from TLS; consult the frontend's error mechanism.
-    return;
   }
 }
 // [Error.HandleReturnCode.end]

--- a/include/tvm/ffi/c_api.h
+++ b/include/tvm/ffi/c_api.h
@@ -436,7 +436,6 @@ typedef struct {
  *  Possible return error of the API functions:
  *  * 0: success
  *  * -1: error happens, can be retrieved by TVMFFIErrorMoveFromRaised
- *  * -2: a frontend error occurred and recorded in the frontend.
  *
  * \note We decided to leverage TVMFFIErrorMoveFromRaised and TVMFFIErrorSetRaised
  *  for C function error propagation. This design choice, while

--- a/include/tvm/ffi/error.h
+++ b/include/tvm/ffi/error.h
@@ -61,26 +61,6 @@ namespace tvm {
 namespace ffi {
 
 /*!
- * \brief Error already set in frontend env.
- *
- *  This error can be thrown by EnvCheckSignals to indicate
- *  that there is an error set in the frontend environment(e.g.
- *  python interpreter). The TVM FFI should catch this error
- *  and return a proper code to tell the frontend caller about
- *  this fact.
- *
- * \code{.cpp}
- * void ExampleLongRunningFunction() {
- *   if (TVMFFIEnvCheckSignals() != 0) {
- *     throw ::tvm::ffi::EnvErrorAlreadySet();
- *   }
- *   // do work here
- * }
- * \endcode
- */
-struct EnvErrorAlreadySet : public std::exception {};
-
-/*!
  * \brief Error object class.
  */
 class ErrorObj : public Object, public TVMFFIErrorCell {
@@ -316,6 +296,24 @@ class Error : public ObjectRef, public std::exception {
   TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(Error, ObjectRef, ErrorObj);
   /// \endcond
 };
+
+/*!
+ * \brief Error object for EnvErrorAlreadySet
+ *
+ *  This error can be thrown by EnvCheckSignals to indicate
+ *  that there is an error set in the frontend environment(e.g.
+ *  python interpreter).
+ *
+ * \code{.cpp}
+ * void ExampleLongRunningFunction() {
+ *   if (TVMFFIEnvCheckSignals() != 0) {
+ *     throw ::tvm::ffi::EnvErrorAlreadySet();
+ *   }
+ *   // do work here
+ * }
+ * \endcode
+ */
+inline Error EnvErrorAlreadySet() { return Error("EnvErrorAlreadySet", "", ""); }
 
 namespace details {
 

--- a/include/tvm/ffi/function.h
+++ b/include/tvm/ffi/function.h
@@ -82,9 +82,6 @@ namespace ffi {
     ::tvm::ffi::details::SetSafeCallRaised(err);                                               \
     return -1;                                                                                 \
   }                                                                                            \
-  catch (const ::tvm::ffi::EnvErrorAlreadySet&) {                                              \
-    return -2;                                                                                 \
-  }                                                                                            \
   catch (const std::exception& ex) {                                                           \
     ::tvm::ffi::details::SetSafeCallRaised(::tvm::ffi::Error("InternalError", ex.what(), "")); \
     return -1;                                                                                 \
@@ -104,9 +101,6 @@ namespace ffi {
   {                                                        \
     int ret_code = (func);                                 \
     if (ret_code != 0) {                                   \
-      if (ret_code == -2) {                                \
-        throw ::tvm::ffi::EnvErrorAlreadySet();            \
-      }                                                    \
       throw ::tvm::ffi::details::MoveFromSafeCallRaised(); \
     }                                                      \
   }

--- a/python/tvm_ffi/cython/error.pxi
+++ b/python/tvm_ffi/cython/error.pxi
@@ -153,7 +153,11 @@ cdef inline int CHECK_CALL(int ret) except -2:
     """Check the return code of the C API function call"""
     if ret == 0:
         return 0
-    # -2 brings exception
+    # backward compact with error already set case
+    # TODO(tqchen): remove after we move beyond a few versions.
     if ret == -2:
         raise raise_existing_error()
-    raise move_from_last_error().py_error()
+    error = move_from_last_error()
+    if error.kind == "EnvErrorAlreadySet":
+        raise raise_existing_error()
+    raise error.py_error()

--- a/python/tvm_ffi/cython/function.pxi
+++ b/python/tvm_ffi/cython/function.pxi
@@ -918,9 +918,15 @@ cdef class Function(Object):
         # directly inline here to simplify the resulting trace
         if c_api_ret_code == 0:
             return make_ret(result, c_ctx_dlpack_api)
-        elif c_api_ret_code == -2:
-            raise_existing_error()
-        raise move_from_last_error().py_error()
+        # backward compact with error already set case
+        # TODO(tqchen): remove after we move beyond a few versions.
+        if c_api_ret_code == -2:
+            raise raise_existing_error()
+        # epecial handle env error already set
+        error = move_from_last_error()
+        if error.kind == "EnvErrorAlreadySet":
+            raise raise_existing_error()
+        raise error.py_error()
 
     @staticmethod
     def __from_extern_c__(

--- a/python/tvm_ffi/cython/type_info.pxi
+++ b/python/tvm_ffi/cython/type_info.pxi
@@ -55,9 +55,16 @@ cdef class FieldSetter:
         # directly inline here to simplify backtrace
         if c_api_ret_code == 0:
             return
-        elif c_api_ret_code == -2:
-            raise_existing_error()
-        raise move_from_last_error().py_error()
+        # backward compact with error already set case
+        # TODO(tqchen): remove after we move beyond a few versions.
+        if c_api_ret_code == -2:
+            raise raise_existing_error()
+        # epecial handle env error already set
+        error = move_from_last_error()
+        if error.kind == "EnvErrorAlreadySet":
+            raise raise_existing_error()
+        raise error.py_error()
+
 
 _TYPE_SCHEMA_ORIGIN_CONVERTER = {
     # A few Python-native types


### PR DESCRIPTION
Previously we relied on a special error to handle EnvErrorAlreadySet, this PR updates the behavior so that the Error being thrown can also have kind EnvErrorAlreadySet, which indicate there is an interrupt. This allows the error handling behavior to be overall simpler and more consistent, removing boliler plate in C++ exposure.

ABI impact: this change only impacts the downstream c++ usage that uses EnvErrorAlreadySet. The downstream DSLs and libraries are not impacted by this change.

The only usecase so far is tvm compiler autotuning service to propagate KeyboardInterrupt. Given the benefit and limited impact, we could consider bring it in, since it simplifies the checking and throw logics in the function and further streamlines error handling.