### PR TITLE
Reliability update

### DIFF
--- a/addons/torch_c_dlpack_ext/build_backend.py
+++ b/addons/torch_c_dlpack_ext/build_backend.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+from contextlib import suppress
 from pathlib import Path
 
 from setuptools import build_meta as orig
@@ -62,10 +63,12 @@ def build_wheel(
     metadata_directory: orig.StrPath | None = None,
 ) -> str:
     """Build wheel."""
-    if not _is_lib_prebuilt():
-        # build wheel from sdist package, compile the torch c dlpack ext library locally.
+    torch = None
+    with suppress(ModuleNotFoundError):
         import torch  # noqa: PLC0415
 
+    if torch is not None and not _is_lib_prebuilt():
+        # build wheel from sdist package, compile the torch c dlpack ext library locally.
         if hasattr(torch.Tensor, "__dlpack_c_exchange_api__") or hasattr(
             torch.Tensor, "__c_dlpack_exchange_api__"
         ):

--- a/python/tvm_ffi/_optional_torch_c_dlpack.py
+++ b/python/tvm_ffi/_optional_torch_c_dlpack.py
@@ -109,6 +109,11 @@ def load_torch_c_dlpack_extension() -> Any:  # noqa: PLR0912, PLR0915
             return None
     except ImportError:
         pass
+    except AttributeError:
+        # When torch_c_dlpack_ext and torch have different ABI
+        # `ctypes.CDLL` will raise an `AttributeError`.
+        # Keep trying JIT
+        pass
 
     try:
         # check whether a JIT shared library is built in cache


### PR DESCRIPTION
Closes #433 in a way that do not bailout when compiling in environment without torch.

Also fixes that dlpack ext's symbols does not match with torch (e.g. in ngc container)