### PR TITLE
fix(build): Broken Wheel Testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,7 +238,7 @@ test-skip = ["cp38-*", "cp39-*", "cp310-*", "cp311-*"]
 # focus on testing abi3 wheel
 build-frontend = "build[uv]"
 test-command = "pytest {package}/tests/python -vvs"
-test-extras = ["test"]
+test-groups = ["test"]
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]


### PR DESCRIPTION
Wheel testing has been broken by https://github.com/apache/tvm-ffi/pull/441, which moves `test` from optional-dependency to dependency-group. This PR fixes this bug.