### PR TITLE
feat: add `DefaultFactory` support to field reflection

### DIFF
--- a/include/tvm/ffi/c_api.h
+++ b/include/tvm/ffi/c_api.h
@@ -861,6 +861,15 @@ typedef enum {
    * This is an optional meta-data for structural eq/hash.
    */
   kTVMFFIFieldFlagBitMaskSEqHashDef = 1 << 4,
+  /*!
+   * \brief The default_value_or_factory is a callable factory function () -> Any.
+   *
+   * When this flag is set along with kTVMFFIFieldFlagBitMaskHasDefault,
+   * the default_value_or_factory field contains a Function that should be
+   * called with no arguments to produce the default value, rather than
+   * being used directly as the default value.
+   */
+  kTVMFFIFieldFlagBitMaskDefaultFromFactory = 1 << 5,
 #ifdef __cplusplus
 };
 #else
@@ -960,10 +969,15 @@ typedef struct {
    */
   TVMFFIFieldSetter setter;
   /*!
-   * \brief The default value of the field, this field hold AnyView,
-   *        valid when flags set kTVMFFIFieldFlagBitMaskHasDefault
+   * \brief The default value or default factory of the field.
+   *
+   * When flags has kTVMFFIFieldFlagBitMaskHasDefault set:
+   * - If kTVMFFIFieldFlagBitMaskDefaultFromFactory is NOT set,
+   *   this holds the static default value as AnyView.
+   * - If kTVMFFIFieldFlagBitMaskDefaultFromFactory IS set,
+   *   this holds a Function (() -> Any) that produces the default.
    */
-  TVMFFIAny default_value;
+  TVMFFIAny default_value_or_factory;
   /*!
    * \brief Records the static type kind of the field.
    *

--- a/include/tvm/ffi/reflection/creator.h
+++ b/include/tvm/ffi/reflection/creator.h
@@ -79,7 +79,7 @@ class ObjectCreator {
         field_info->setter(field_addr, reinterpret_cast<const TVMFFIAny*>(&field_value));
         ++match_field_count;
       } else if (field_info->flags & kTVMFFIFieldFlagBitMaskHasDefault) {
-        field_info->setter(field_addr, &(field_info->default_value));
+        SetFieldToDefault(field_info, field_addr);
       } else {
         TVM_FFI_THROW(TypeError) << "Required field `"
                                  << String(field_info->name.data, field_info->name.size)

--- a/include/tvm/ffi/reflection/overload.h
+++ b/include/tvm/ffi/reflection/overload.h
@@ -449,7 +449,7 @@ class OverloadObjectDef : private ObjectDef<Class> {
     info.getter = ReflectionDefBase::FieldGetter<T>;
     info.setter = ReflectionDefBase::FieldSetter<T>;
     // initialize default value to nullptr
-    info.default_value = AnyView(nullptr).CopyToTVMFFIAny();
+    info.default_value_or_factory = AnyView(nullptr).CopyToTVMFFIAny();
     info.doc = TVMFFIByteArray{nullptr, 0};
     info.metadata_.emplace_back("type_schema", details::TypeSchema<T>::v());
     // apply field info traits

--- a/python/tvm_ffi/cython/base.pxi
+++ b/python/tvm_ffi/cython/base.pxi
@@ -203,6 +203,7 @@ cdef extern from "tvm/ffi/c_api.h":
         kTVMFFIFieldFlagBitMaskWritable = 1 << 0
         kTVMFFIFieldFlagBitMaskHasDefault = 1 << 1
         kTVMFFIFieldFlagBitMaskIsStaticMethod = 1 << 2
+        kTVMFFIFieldFlagBitMaskDefaultFromFactory = 1 << 5
 
     ctypedef int (*TVMFFIFieldGetter)(void* field, TVMFFIAny* result) noexcept
     ctypedef int (*TVMFFIFieldSetter)(void* field, const TVMFFIAny* value) noexcept
@@ -218,7 +219,7 @@ cdef extern from "tvm/ffi/c_api.h":
         int64_t offset
         TVMFFIFieldGetter getter
         TVMFFIFieldSetter setter
-        TVMFFIAny default_value
+        TVMFFIAny default_value_or_factory
         int32_t field_static_type_index
 
     ctypedef struct TVMFFIMethodInfo:

--- a/rust/tvm-ffi-sys/src/c_api.rs
+++ b/rust/tvm-ffi-sys/src/c_api.rs
@@ -286,9 +286,11 @@ pub struct TVMFFIFieldInfo {
     /// The setter to access the field
     /// The setter is set even if the field is readonly for serialization
     pub setter: Option<TVMFFIFieldSetter>,
-    /// The default value of the field, this field hold AnyView,
-    /// valid when flags set kTVMFFIFieldFlagBitMaskHasDefault
-    pub default_value: TVMFFIAny,
+    /// The default value or factory of the field, this field holds AnyView.
+    /// Valid when flags set kTVMFFIFieldFlagBitMaskHasDefault.
+    /// When kTVMFFIFieldFlagBitMaskDefaultFromFactory is also set,
+    /// this is a callable factory function () -> Any.
+    pub default_value_or_factory: TVMFFIAny,
     /// Records the static type kind of the field
     pub field_static_type_index: i32,
 }

--- a/src/ffi/extra/reflection_extra.cc
+++ b/src/ffi/extra/reflection_extra.cc
@@ -22,6 +22,7 @@
  * \brief Extra reflection registrations. *
  */
 #include <tvm/ffi/reflection/access_path.h>
+#include <tvm/ffi/reflection/accessor.h>
 #include <tvm/ffi/reflection/registry.h>
 
 namespace tvm {
@@ -78,7 +79,7 @@ void MakeObjectFromPackedArgs(ffi::PackedArgs args, Any* ret) {
         field_info->setter(field_addr, reinterpret_cast<const TVMFFIAny*>(&field_value));
         keys_found[arg_index] = true;
       } else if (field_info->flags & kTVMFFIFieldFlagBitMaskHasDefault) {
-        field_info->setter(field_addr, &(field_info->default_value));
+        reflection::SetFieldToDefault(field_info, field_addr);
       } else {
         TVM_FFI_THROW(TypeError) << "Required field `"
                                  << String(field_info->name.data, field_info->name.size)

--- a/src/ffi/extra/serialization.cc
+++ b/src/ffi/extra/serialization.cc
@@ -396,7 +396,7 @@ class ObjectGraphDeserializer {
         Any field_value = decode_field_value(field_info, data_object[field_name]);
         field_info->setter(field_addr, reinterpret_cast<const TVMFFIAny*>(&field_value));
       } else if (field_info->flags & kTVMFFIFieldFlagBitMaskHasDefault) {
-        field_info->setter(field_addr, &(field_info->default_value));
+        reflection::SetFieldToDefault(field_info, field_addr);
       } else {
         TVM_FFI_THROW(TypeError) << "Required field `"
                                  << String(field_info->name.data, field_info->name.size)

--- a/src/ffi/object.cc
+++ b/src/ffi/object.cc
@@ -211,10 +211,11 @@ class TypeTable {
     field_data.doc = this->CopyString(info->doc);
     field_data.metadata = this->CopyString(info->metadata);
     if (info->flags & kTVMFFIFieldFlagBitMaskHasDefault) {
-      field_data.default_value =
-          this->CopyAny(AnyView::CopyFromTVMFFIAny(info->default_value)).CopyToTVMFFIAny();
+      field_data.default_value_or_factory =
+          this->CopyAny(AnyView::CopyFromTVMFFIAny(info->default_value_or_factory))
+              .CopyToTVMFFIAny();
     } else {
-      field_data.default_value = AnyView(nullptr).CopyToTVMFFIAny();
+      field_data.default_value_or_factory = AnyView(nullptr).CopyToTVMFFIAny();
     }
     entry->type_fields_data.push_back(field_data);
     // refresh ptr as the data can change


### PR DESCRIPTION
`DefaultValue` stores a single static default shared across all instances created via reflection.  For mutable defaults (Array, Map, etc.) this causes aliasing: every object receives the same underlying container.  `DefaultFactory` fixes this by storing a callable `() -> Any` that is invoked each time a default is needed, producing a fresh value per instance—mirroring Python dataclass `default_factory`.

Concrete changes:

- Rename `TVMFFIFieldInfo::default_value` → `default_value_or_factory` to reflect that the slot now holds either a value or a factory.
- Add `kTVMFFIFieldFlagBitMaskDefaultFromFactory` (1 << 5) to `TVMFFIFieldFlagBitMask`.
- Add `reflection::DefaultFactory` trait (registry.h), symmetric to `DefaultValue`.
- Add `reflection::SetFieldToDefault` helper (accessor.h) that resolves the default—calling the factory when the flag is set—so the three consumption sites (creator.h, reflection_extra.cc, serialization.cc) share one implementation.
- Propagate the rename through Rust (`c_api.rs`) and Cython (`base.pxi`) bindings.
- Add `TestObjWithFactory` + three tests exercising flag inspection, per-instance freshness, and explicit-value bypass.
