### PR TITLE
[Feature] Support AMD HIP for cpp extension

### DIFF
--- a/python/tvm_ffi/cpp/extension.py
+++ b/python/tvm_ffi/cpp/extension.py
@@ -1126,6 +1126,7 @@ def build(
     backend
         The GPU backend to use. It can be "cuda" or "hip".
         If not specified, the backend will be automatically determined based on the available GPU and the provided source code.
+
     Returns
     -------
     lib_path: str
@@ -1275,6 +1276,7 @@ def load(
     backend
         The GPU backend to use. It can be "cuda" or "hip".
         If not specified, the backend will be automatically determined based on the available GPU and the provided source code.
+
     Returns
     -------
     mod: Module


### PR DESCRIPTION
Related issue #458 .

I'm not familiar with AMD at all, and most of the code is generated by claude code. I've only cleaned up a little and tried the following example on one AMD machine. Need some reviews from AMD experts.

```python
import torch
from tvm_ffi import Module
import tvm_ffi.cpp

# define the cpp source code
cpp_source = '''
#include <hip/hip_runtime.h>

__global__ void add_one_kernel(const float* __restrict__ x,
                               float* __restrict__ y,
                               int64_t n) {
    int64_t i = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
    if (i < n) y[i] = x[i] + 1.0f;
}

void add_one_hip(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
    int64_t n = x.size(0);
    const float* x_ptr = static_cast<const float*>(x.data_ptr());
    float* y_ptr = static_cast<float*>(y.data_ptr());
    constexpr int threads = 256;
    int blocks = (int)((n + threads - 1) / threads);
    hipStream_t stream = 0;  // default stream; replace if your runtime provides a stream
    hipLaunchKernelGGL(add_one_kernel,
                       dim3(blocks), dim3(threads),
                       0, stream,
                       x_ptr, y_ptr, n);
}
'''

# compile the cpp source code and load the module
mod: Module = tvm_ffi.cpp.load_inline(
    name="hello",
    cuda_sources=cpp_source,
    functions="add_one_hip",
)

# use the function from the loaded module to perform
x = torch.tensor([1, 2, 3, 4, 5], dtype=torch.float32, device="cuda")
y = torch.empty_like(x, device="cuda")
mod.add_one_hip(x, y)
torch.testing.assert_close(x + 1, y)
```