### PR TITLE
[COMPACT][TEMP] Array compact temp fix 

### DIFF
--- a/include/tvm/ffi/container/array.h
+++ b/include/tvm/ffi/container/array.h
@@ -376,7 +376,7 @@ class Array : public ObjectRef {
    * \param i The index
    * \return the i-th element.
    */
-  T operator[](int64_t i) const {
+  const T operator[](int64_t i) const {
     ArrayObj* p = GetArrayObj();
     if (p == nullptr) {
       TVM_FFI_THROW(IndexError) << "cannot index a null array";


### PR DESCRIPTION
In the 0.1.19 patch, we changed the operator[] to return T(from const T). This is the right change. However, flashinfer depends on an sutble implicit conversion rule that requires const T behavior (which is also not desirable). There is a patch in flashinfer to fx this issue.

This PR is a temp workaround so 0.1.19 release won't block flashinfer. We can reland this in next release as flashinfer's change gets into a release.