### PR TITLE
[FIX] Prevent integer overflow in GetDataSize on 32-bit platforms

### DIFF
--- a/include/tvm/ffi/container/tensor.h
+++ b/include/tvm/ffi/container/tensor.h
@@ -103,7 +103,8 @@ inline size_t GetDataSize(size_t numel, DLDataType dtype) {
     return numel;
   }
   // for other sub-byte types, packing is preferred
-  return (numel * dtype.bits * dtype.lanes + 7) / 8;
+  // Use uint64_t to avoid overflow on 32-bit platforms (WASM) for large allocations.
+  return static_cast<size_t>((static_cast<uint64_t>(numel) * dtype.bits * dtype.lanes + 7) / 8);
 }
 
 /*!


### PR DESCRIPTION
On 32-bit platforms (e.g. WASM), the intermediate multiplication `numel * dtype.bits * dtype.lanes` in `GetDataSize()` can overflow `size_t` for large tensors, even when the final byte count (after dividing by 8) fits within 32 bits.

This PR casts the intermediate computation to `uint64_t` to avoid the overflow, then casts the result back to `size_t`.

I was experiencing this error when trying to run a model with webllm using a runtime compiled by mlc-llm - the operation was overflowing, causing the allocation of 0-byte buffers.