### PR TITLE
[FEAT] Add CMake namespace aliases for source dependency builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/Utils/Library.cmake)
 # they can be used in cases where user do not want to link into the library in cases like deferred
 # linking
 add_library(tvm_ffi_header INTERFACE)
+add_library(tvm_ffi::header ALIAS tvm_ffi_header)
 target_compile_features(tvm_ffi_header INTERFACE cxx_std_17)
 
 if (CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")

--- a/cmake/Utils/Library.cmake
+++ b/cmake/Utils/Library.cmake
@@ -84,6 +84,7 @@ endfunction ()
 # ~~~
 function (tvm_ffi_add_target_from_obj target_name obj_target_name)
   add_library(${target_name}_static STATIC $<TARGET_OBJECTS:${obj_target_name}>)
+  add_library(${target_name}::static ALIAS ${target_name}_static)
   set_target_properties(
     ${target_name}_static
     PROPERTIES OUTPUT_NAME "${target_name}_static"
@@ -92,6 +93,7 @@ function (tvm_ffi_add_target_from_obj target_name obj_target_name)
                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
   )
   add_library(${target_name}_shared SHARED $<TARGET_OBJECTS:${obj_target_name}>)
+  add_library(${target_name}::shared ALIAS ${target_name}_shared)
   set_target_properties(
     ${target_name}_shared
     PROPERTIES OUTPUT_NAME "${target_name}"


### PR DESCRIPTION
## Summary
Add namespace-qualified ALIAS targets (tvm_ffi::header, tvm_ffi::shared, tvm_ffi::static) that point to the in-tree build targets (tvm_ffi_header, tvm_ffi_shared, tvm_ffi_static).

## Problem
When tvm-ffi is used as a source dependency, `tvm_ffi_configure_target` expects `tvm_ffi::header` / `tvm_ffi::shared` targets to exist. However, these are only created by the package config file (`cmake/tvm_ffi-config.cmake`), which is not included during source builds. Downstream projects using source dependencies cannot use these targets.

## Solution
Create ALIAS targets in both:
- Top-level `CMakeLists.txt` for `tvm_ffi::header`
- `cmake/Utils/Library.cmake` for `tvm_ffi::static` and `tvm_ffi::shared` (created by `tvm_ffi_add_target_from_obj`)

This ensures the namespace-qualified names are available in both source and package builds.