### PR TITLE
[FIX] Fix the config loading in windows case

### DIFF
--- a/python/tvm_ffi/__init__.py
+++ b/python/tvm_ffi/__init__.py
@@ -111,7 +111,14 @@ if TYPE_CHECKING or not _is_config_mode():
         float8_e8m0fnu,
         float4_e2m1fnx2,
     )
+elif sys.platform.startswith("win32"):
+    # On Windows, load the library even in config CLI mode so the DLL search path
+    # is set correctly (needed in some cases when test still loads cython extensions).
+    from . import libinfo
 
+    LIB = libinfo.load_lib_ctypes("apache-tvm-ffi", "tvm_ffi", "RTLD_GLOBAL")
+
+# normal version imports
 try:
     from ._version import __version__, __version_tuple__
 except ImportError:


### PR DESCRIPTION
This PR fixes the config loading in windows case, sometimes in wheel settings the testcase may still need to load core.pyd, so we by default load the library in config mode when it is windows.