### PR TITLE
feat(cython): expose additional C API symbols in base.pxi

### DIFF
--- a/python/tvm_ffi/cython/base.pxi
+++ b/python/tvm_ffi/cython/base.pxi
@@ -195,6 +195,8 @@ cdef extern from "tvm/ffi/c_api.h":
         void (*update_backtrace)(
             TVMFFIObjectHandle self, const TVMFFIByteArray* backtrace, int32_t update_mode
         )
+        TVMFFIObjectHandle cause_chain
+        TVMFFIObjectHandle extra_context
 
     ctypedef int (*TVMFFISafeCallType)(
         void* handle, const TVMFFIAny* args, int32_t num_args,
@@ -204,7 +206,12 @@ cdef extern from "tvm/ffi/c_api.h":
         kTVMFFIFieldFlagBitMaskWritable = 1 << 0
         kTVMFFIFieldFlagBitMaskHasDefault = 1 << 1
         kTVMFFIFieldFlagBitMaskIsStaticMethod = 1 << 2
+        kTVMFFIFieldFlagBitMaskSEqHashIgnore = 1 << 3
+        kTVMFFIFieldFlagBitMaskSEqHashDef = 1 << 4
         kTVMFFIFieldFlagBitMaskDefaultFromFactory = 1 << 5
+        kTVMFFIFieldFlagBitMaskReprOff = 1 << 6
+        kTVMFFIFieldFlagBitMaskCompareOff = 1 << 7
+        kTVMFFIFieldFlagBitMaskHashOff = 1 << 8
         kTVMFFIFieldFlagBitMaskInitOff = 1 << 9
         kTVMFFIFieldFlagBitMaskKwOnly = 1 << 10
         kTVMFFIFieldFlagBitSetterIsFunctionObj = 1 << 11
@@ -233,10 +240,19 @@ cdef extern from "tvm/ffi/c_api.h":
         int64_t flags
         TVMFFIAny method
 
+    cdef enum TVMFFISEqHashKind:
+        kTVMFFISEqHashKindUnsupported = 0
+        kTVMFFISEqHashKindTreeNode = 1
+        kTVMFFISEqHashKindFreeVar = 2
+        kTVMFFISEqHashKindDAGNode = 3
+        kTVMFFISEqHashKindConstTreeNode = 4
+        kTVMFFISEqHashKindUniqueInstance = 5
+
     ctypedef struct TVMFFITypeMetadata:
         TVMFFIByteArray doc
         TVMFFIObjectCreator creator
-        int64_t total_size
+        int32_t total_size
+        TVMFFISEqHashKind structural_eq_hash_kind
 
     ctypedef struct TVMFFITypeInfo:
         int32_t type_index
@@ -297,6 +313,20 @@ cdef extern from "tvm/ffi/c_api.h":
     DLTensor* TVMFFITensorGetDLTensorPtr(TVMFFIObjectHandle obj) nogil
     DLDevice TVMFFIDLDeviceFromIntPair(int32_t device_type, int32_t device_id) nogil
     const TVMFFITypeAttrColumn* TVMFFIGetTypeAttrColumn(const TVMFFIByteArray* attr_name) nogil
+
+    int32_t TVMFFITypeGetOrAllocIndex(
+        const TVMFFIByteArray* type_key,
+        int32_t static_type_index,
+        int32_t type_depth,
+        int32_t num_child_slots,
+        int32_t child_slots_can_overflow,
+        int32_t parent_type_index
+    ) nogil
+    int TVMFFITypeRegisterField(int32_t type_index, const TVMFFIFieldInfo* info) nogil
+    int TVMFFITypeRegisterMetadata(int32_t type_index, const TVMFFITypeMetadata* metadata) nogil
+    int TVMFFITypeRegisterAttr(int32_t type_index, const TVMFFIByteArray* attr_name,
+                               const TVMFFIAny* attr_value) nogil
+    void TVMFFIErrorSetRaisedFromCStr(const char* kind, const char* message) nogil
 
 cdef extern from "tvm/ffi/extra/c_env_api.h":
     ctypedef void* TVMFFIStreamHandle


### PR DESCRIPTION
## Summary

- Add Cython declarations for type-registration functions (`TVMFFITypeGetOrAllocIndex`, `TVMFFITypeRegisterField`, `TVMFFITypeRegisterMetadata`, `TVMFFITypeRegisterAttr`, `TVMFFIErrorSetRaisedFromCStr`) so Python-side type registration can call these symbols directly through Cython
- Add missing field-flag constants (`SEqHashIgnore`, `SEqHashDef`, `ReprOff`, `CompareOff`, `HashOff`) and the `TVMFFISEqHashKind` enum
- Fix `TVMFFITypeMetadata.total_size` type (`int64_t` -> `int32_t`) and add `structural_eq_hash_kind` field to match the C struct layout
- Add `cause_chain` and `extra_context` fields to the error info struct

## Test plan

- [ ] Existing CI tests pass (no behavioral change, declarations only)
- [ ] Verify Cython compilation succeeds with the new declarations via `uv pip install --force-reinstall --verbose -e .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)