### PR TITLE
refactor(python): use `import tvm_ffi as ffi` alias in examples, docs, and tests

### DIFF
--- a/docs/concepts/func_module.rst
+++ b/docs/concepts/func_module.rst
@@ -69,9 +69,9 @@ which can then be loaded and called via :py:func:`tvm_ffi.load_module`:
 
 .. code-block:: python
 
-   import tvm_ffi
+   import tvm_ffi as ffi
 
-   mod = tvm_ffi.load_module("path/to/library.so")
+   mod = ffi.load_module("path/to/library.so")
    result = mod.add_two(40)  # -> 42
 
 **System library**. For symbols bundled in the same executable, use :cpp:func:`TVMFFIEnvModRegisterSystemLibSymbol`
@@ -105,9 +105,9 @@ In Python, use the decorator :py:func:`tvm_ffi.register_global_func` to register
 
 .. code-block:: python
 
-   import tvm_ffi
+   import tvm_ffi as ffi
 
-   @tvm_ffi.register_global_func("my_ext.add_one")
+   @ffi.register_global_func("my_ext.add_one")
    def add_one(x: int) -> int:
        return x + 1
 
@@ -117,10 +117,10 @@ In Python, use :py:func:`tvm_ffi.get_global_func` to retrieve a global function:
 
 .. code-block:: python
 
-   import tvm_ffi
+   import tvm_ffi as ffi
 
    # Get a function from the global registry
-   add_one = tvm_ffi.get_global_func("my_ext.add_one")
+   add_one = ffi.get_global_func("my_ext.add_one")
    result = add_one(41)  # -> 42
 
 In C++, use :cpp:func:`tvm::ffi::Function::GetGlobal` or :cpp:func:`tvm::ffi::Function::GetGlobalRequired`
@@ -161,19 +161,19 @@ to a :py:class:`tvm_ffi.Function` at the ABI boundary. The example below demonst
 
 .. code-block:: python
 
-   import tvm_ffi
+   import tvm_ffi as ffi
 
-   @tvm_ffi.register_global_func("my_ext.bind")
+   @ffi.register_global_func("my_ext.bind")
    def bind(func, x):
-     assert isinstance(func, tvm_ffi.Function)
-     return lambda *args: func(x, *args)  # converted to `tvm_ffi.Function`
+     assert isinstance(func, ffi.Function)
+     return lambda *args: func(x, *args)  # converted to `ffi.Function`
 
    def add_x_y(x, y):
      return x + y
 
-   func_bind = tvm_ffi.get_global_func("my_ext.bind")
+   func_bind = ffi.get_global_func("my_ext.bind")
    add_y = func_bind(add_x_y, 1)  # bind x = 1
-   assert isinstance(add_y, tvm_ffi.Function)
+   assert isinstance(add_y, ffi.Function)
    print(add_y(2))  # -> 3
 
 
@@ -181,12 +181,12 @@ to a :py:class:`tvm_ffi.Function` at the ABI boundary. The example below demonst
 
 .. code-block:: python
 
-   import tvm_ffi
+   import tvm_ffi as ffi
 
    def add(x, y):
      return x + y
 
-   func_add = tvm_ffi.convert(add)
+   func_add = ffi.convert(add)
    print(func_add(1, 2))
 
 
@@ -311,10 +311,10 @@ a function as a C symbol that follows the TVM-FFI ABI:
 
 .. code-block:: python
 
-   import tvm_ffi
+   import tvm_ffi as ffi
 
    # Load the shared library
-   mod = tvm_ffi.load_module("path/to/library.so")
+   mod = ffi.load_module("path/to/library.so")
 
    # Access functions by name
    result = mod.add_two(40)  # -> 42
@@ -328,10 +328,11 @@ C++/CUDA source files and loads them as a module in one step:
 
 .. code-block:: python
 
+   import tvm_ffi as ffi
    import tvm_ffi.cpp
 
    # Compile and load in one step
-   mod = tvm_ffi.cpp.load(
+   mod = ffi.cpp.load(
        name="my_ops",
        cpp_files="my_ops.cpp",
    )
@@ -379,11 +380,11 @@ a symbol during static initialization:
 
 .. code-block:: python
 
-   import tvm_ffi
+   import tvm_ffi as ffi
 
    # Get system library with symbol prefix "my_prefix."
    # This looks up symbols prefixed with `__tvm_ffi_my_prefix.`
-   mod = tvm_ffi.system_lib("my_prefix.")
+   mod = ffi.system_lib("my_prefix.")
 
    # Call the registered function
    func = mod.add_one  # looks up `__tvm_ffi_my_prefix.add_one`

--- a/docs/concepts/object_and_class.rst
+++ b/docs/concepts/object_and_class.rst
@@ -149,11 +149,11 @@ to register an object's constructor, fields, and methods.
 
 .. code-block:: python
 
-   import tvm_ffi
+   import tvm_ffi as ffi
    from typing import TYPE_CHECKING
 
-   @tvm_ffi.register_object("my_ext.MyObject")
-   class MyObject(tvm_ffi.Object):
+   @ffi.register_object("my_ext.MyObject")
+   class MyObject(ffi.Object):
        # tvm-ffi-stubgen(begin): object/my_ext.MyObject
        value: int
        name: str

--- a/docs/concepts/tensor.rst
+++ b/docs/concepts/tensor.rst
@@ -123,11 +123,11 @@ The following example demonstrates a typical round-trip pattern:
 
 .. code-block:: python
 
-   import tvm_ffi
+   import tvm_ffi as ffi
    import torch
 
    x_torch = torch.randn(1024, device="cuda")
-   x_tvm_ffi = tvm_ffi.from_dlpack(x_torch, require_contiguous=True)
+   x_tvm_ffi = ffi.from_dlpack(x_torch, require_contiguous=True)
    x_torch_again = torch.from_dlpack(x_tvm_ffi)
 
 In this example, :py:func:`tvm_ffi.from_dlpack` creates ``x_tvm_ffi``, which views the same memory as ``x_torch``.

--- a/docs/get_started/quickstart.rst
+++ b/docs/get_started/quickstart.rst
@@ -190,9 +190,9 @@ TVM-FFI's Python package provides :py:func:`tvm_ffi.load_module` to load either
 
 .. code-block:: python
 
-  import tvm_ffi
-  mod  : tvm_ffi.Module   = tvm_ffi.load_module("add_one_cpu.so")
-  func : tvm_ffi.Function = mod.add_one_cpu
+  import tvm_ffi as ffi
+  mod  : ffi.Module   = ffi.load_module("add_one_cpu.so")
+  func : ffi.Function = mod.add_one_cpu
 
 ``mod.add_one_cpu`` retrieves a callable :py:class:`tvm_ffi.Function` that accepts tensors from host frameworks
 directly. This is zero-copy, requires no boilerplate code, and adds very little overhead.
@@ -231,8 +231,8 @@ After installation, ``add_one_cuda`` can be registered as a target for JAX's ``f
 .. code-block:: python
 
   # Step 1. Load `build/add_one_cuda.so`
-  import tvm_ffi
-  mod = tvm_ffi.load_module("build/add_one_cuda.so")
+  import tvm_ffi as ffi
+  mod = ffi.load_module("build/add_one_cuda.so")
 
   # Step 2. Register `mod.add_one_cuda` into JAX
   import jax_tvm_ffi

--- a/docs/guides/dataclass_reflection.rst
+++ b/docs/guides/dataclass_reflection.rst
@@ -65,10 +65,10 @@ packed ``__ffi_init__`` from the reflected fields:
 
 .. code-block:: python
 
-   import tvm_ffi
+   import tvm_ffi as ffi
 
-   @tvm_ffi.register_object("my_ext.Point")
-   class Point(tvm_ffi.Object):
+   @ffi.register_object("my_ext.Point")
+   class Point(ffi.Object):
        x: int
        y: int
        label: str
@@ -378,7 +378,7 @@ by the framework for recursing into child values.
 Python ``c_class`` Decorator
 -----------------------------
 
-On the Python side, ``tvm_ffi.dataclasses.c_class`` provides equivalent
+On the Python side, ``ffi.dataclasses.c_class`` provides equivalent
 functionality to Python's ``@dataclass`` for C++-backed objects:
 
 .. code-block:: python
@@ -386,7 +386,7 @@ functionality to Python's ``@dataclass`` for C++-backed objects:
    from tvm_ffi.dataclasses import c_class
 
    @c_class("my_ext.Point")
-   class Point(tvm_ffi.Object):
+   class Point(ffi.Object):
        x: int
        y: int
        label: str
@@ -402,7 +402,7 @@ The decorator:
 
 .. note::
 
-   ``@tvm_ffi.register_object`` can also be used, which delegates to
+   ``@ffi.register_object`` can also be used, which delegates to
    ``c_class`` internally for objects with reflected fields.
 
 

--- a/docs/guides/export_func_cls.rst
+++ b/docs/guides/export_func_cls.rst
@@ -113,9 +113,9 @@ functions by name:
 
 .. code-block:: python
 
-   import tvm_ffi
+   import tvm_ffi as ffi
 
-   mod = tvm_ffi.load_module("path/to/library.so")
+   mod = ffi.load_module("path/to/library.so")
    result = mod.add_two(40)  # -> 42
 
 .. seealso::
@@ -208,9 +208,9 @@ Register and Retrieve in Python
 
 .. code-block:: python
 
-   import tvm_ffi
+   import tvm_ffi as ffi
 
-   @tvm_ffi.register_global_func("my_ffi_extension.add_one")
+   @ffi.register_global_func("my_ffi_extension.add_one")
    def add_one(x: int) -> int:
        return x + 1
 
@@ -219,9 +219,9 @@ name:
 
 .. code-block:: python
 
-   import tvm_ffi
+   import tvm_ffi as ffi
 
-   add_one = tvm_ffi.get_global_func("my_ffi_extension.add_one")
+   add_one = ffi.get_global_func("my_ffi_extension.add_one")
    result = add_one(3)  # -> 4
 
 .. seealso::

--- a/docs/guides/python_lang_guide.md
+++ b/docs/guides/python_lang_guide.md
@@ -33,11 +33,11 @@ You can follow the [quickstart guide](../get_started/quickstart.rst) for details
 library `build/add_one_cpu.so`. Let's walk through the load and run example again for NumPy
 
 ```python
-import tvm_ffi
+import tvm_ffi as ffi
 import numpy as np
 
 # Load the compiled module
-mod = tvm_ffi.load_module("build/add_one_cpu.so")
+mod = ffi.load_module("build/add_one_cpu.so")
 
 # Create input and output arrays
 x = np.array([1, 2, 3, 4, 5], dtype=np.float32)
@@ -56,11 +56,11 @@ the exported functions. You can access the functions by their names.
 
 ```python
 import numpy as np
-import tvm_ffi
+import tvm_ffi as ffi
 
 # Demonstrate DLPack conversion between NumPy and TVM FFI
 np_data = np.array([1, 2, 3, 4], dtype=np.float32)
-tvm_array = tvm_ffi.from_dlpack(np_data)
+tvm_array = ffi.from_dlpack(np_data)
 # Convert back to NumPy
 np_result = np.from_dlpack(tvm_array)
 ```
@@ -75,11 +75,11 @@ and automatically convert them to {py:class}`tvm_ffi.Tensor`.
 You can retrieve globally registered functions via {py:func}`tvm_ffi.get_global_func`.
 
 ```python
-import tvm_ffi
+import tvm_ffi as ffi
 
 # testing.echo is defined and registered in C++
 # [](ffi::Any x) { return x; }
-fecho = tvm_ffi.get_global_func("testing.echo")
+fecho = ffi.get_global_func("testing.echo")
 assert fecho(1) == 1
 ```
 
@@ -88,11 +88,11 @@ Under the hood, {py:func}`tvm_ffi.convert` is called to convert the Python funct
 {py:class}`tvm_ffi.Function`.
 
 ```python
-import tvm_ffi
+import tvm_ffi as ffi
 
 # testing.apply is registered in C++
 # [](ffi::Function f, ffi::Any val) { return f(x); }
-fapply = tvm_ffi.get_global_func("testing.apply")
+fapply = ffi.get_global_func("testing.apply")
 # invoke fapply with lambda callback as f
 assert fapply(lambda x: x + 1, 1) == 2
 ```
@@ -101,13 +101,13 @@ This is a very powerful pattern that allows us to inject Python callbacks into t
 You can also register a Python callback as a global function.
 
 ```python
-import tvm_ffi
+import tvm_ffi as ffi
 
-@tvm_ffi.register_global_func("example.add_one")
+@ffi.register_global_func("example.add_one")
 def add_one(a):
     return a + 1
 
-assert tvm_ffi.get_global_func("example.add_one")(1) == 2
+assert ffi.get_global_func("example.add_one")(1) == 2
 ```
 
 ## Container Types
@@ -129,11 +129,11 @@ When an FFI function takes arguments from lists/tuples, they will be converted i
 Arrays are **read-only** from Python -- they support indexing and iteration but not mutation.
 
 ```python
-import tvm_ffi
+import tvm_ffi as ffi
 
 # Python lists become Arrays
-arr = tvm_ffi.convert([1, 2, 3, 4])
-assert isinstance(arr, tvm_ffi.Array)
+arr = ffi.convert([1, 2, 3, 4])
+assert isinstance(arr, ffi.Array)
 assert len(arr) == 4
 assert arr[0] == 1
 # arr[0] = 10  # TypeError: Array does not support item assignment
@@ -145,9 +145,9 @@ assert arr[0] == 1
 All handles sharing the same underlying `ListObj` see mutations immediately.
 
 ```python
-import tvm_ffi
+import tvm_ffi as ffi
 
-lst = tvm_ffi.List([1, 2, 3])
+lst = ffi.List([1, 2, 3])
 assert len(lst) == 3
 
 # Mutate in-place
@@ -163,10 +163,10 @@ Dictionaries will be converted to {py:class}`tvm_ffi.Map`.
 Maps are **read-only** from Python -- they support key lookup and iteration but not mutation.
 
 ```python
-import tvm_ffi
+import tvm_ffi as ffi
 
-map_obj = tvm_ffi.convert({"a": 1, "b": 2})
-assert isinstance(map_obj, tvm_ffi.Map)
+map_obj = ffi.convert({"a": 1, "b": 2})
+assert isinstance(map_obj, ffi.Map)
 assert len(map_obj) == 2
 assert map_obj["a"] == 1
 assert map_obj["b"] == 2
@@ -179,9 +179,9 @@ assert map_obj["b"] == 2
 All handles sharing the same underlying `DictObj` see mutations immediately.
 
 ```python
-import tvm_ffi
+import tvm_ffi as ffi
 
-d = tvm_ffi.Dict({"a": 1, "b": 2})
+d = ffi.Dict({"a": 1, "b": 2})
 d["c"] = 3
 assert len(d) == 3
 del d["a"]
@@ -195,10 +195,10 @@ When a Python tuple is passed to an FFI function, it is converted to {py:class}`
 heterogeneous type safety, but on the Python side both lists and tuples map to `Array`.
 
 ```python
-import tvm_ffi
+import tvm_ffi as ffi
 
-t = tvm_ffi.convert((1, "hello", 3.14))
-assert isinstance(t, tvm_ffi.Array)
+t = ffi.convert((1, "hello", 3.14))
+assert isinstance(t, ffi.Array)
 ```
 
 When container values are returned from FFI functions, they are stored in the
@@ -211,6 +211,7 @@ on the fly. For example, we can define a simple kernel that adds one to each ele
 
 ```python
 import torch
+import tvm_ffi as ffi
 from tvm_ffi import Module
 import tvm_ffi.cpp
 
@@ -231,7 +232,7 @@ cpp_source = '''
 '''
 
 # compile the cpp source code and load the module
-mod: Module = tvm_ffi.cpp.load_inline(
+mod: Module = ffi.cpp.load_inline(
     name='hello', cpp_sources=cpp_source, functions='add_one_cpu'
 )
 
@@ -255,11 +256,11 @@ An FFI function may raise an error. In such cases, the Python package will autom
 translate the error to the corresponding error kind in Python
 
 ```python
-import tvm_ffi
+import tvm_ffi as ffi
 
 # defined in C++
 # [](String kind, String msg) { throw Error(kind, msg, backtrace); }
-test_raise_error = tvm_ffi.get_global_func("testing.test_raise_error")
+test_raise_error = ffi.get_global_func("testing.test_raise_error")
 
 test_raise_error("ValueError", "message")
 ```
@@ -271,7 +272,7 @@ Traceback (most recent call last):
 File "example.py", line 7, in <module>
   test_raise_error("ValueError", "message")
   ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
-File "python/tvm_ffi/cython/function.pxi", line 927, in tvm_ffi.core.Function.__call__
+File "python/tvm_ffi/cython/function.pxi", line 927, in ffi.core.Function.__call__
   raise error.py_error()
   ^^^
 File "src/ffi/extra/testing.cc", line 60, in void tvm::ffi::TestRaiseError(tvm::ffi::String, tvm::ffi::String)
@@ -329,11 +330,11 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 You can then create wrapper classes for objects that are in the library as follows:
 
 ```python
-import tvm_ffi
+import tvm_ffi as ffi
 
 # Register the class
-@tvm_ffi.register_object("testing.TestIntPair")
-class TestIntPair(tvm_ffi.Object):
+@ffi.register_object("testing.TestIntPair")
+class TestIntPair(ffi.Object):
     def __init__(self, a, b):
         # This is a special method to call an FFI function whose return
         # value exactly initializes the object handle of the object

--- a/docs/packaging/stubgen.rst
+++ b/docs/packaging/stubgen.rst
@@ -73,8 +73,8 @@ and regenerates the content within those blocks:
 
   .. code-block:: python
 
-     @tvm_ffi.register_object("my_ffi_extension.IntPair")
-     class IntPair(tvm_ffi.Object):
+     @ffi.register_object("my_ffi_extension.IntPair")
+     class IntPair(ffi.Object):
          # tvm-ffi-stubgen(begin): object/my_ffi_extension.IntPair
          a: int
          b: int
@@ -89,7 +89,7 @@ and regenerates the content within those blocks:
   .. code-block:: python
 
      # tvm-ffi-stubgen(begin): global/my_ffi_extension
-     tvm_ffi.init_ffi_api("my_ffi_extension", __name__)
+     ffi.init_ffi_api("my_ffi_extension", __name__)
      if TYPE_CHECKING:
          def add_one(_0: int, /) -> int: ...
          def raise_error(_0: str, /) -> None: ...
@@ -117,7 +117,7 @@ STUB_PKG (default: ``SKBUILD_PROJECT_NAME`` or CMake target name)
 
    .. code-block:: python
 
-      LIB = tvm_ffi.libinfo.load_lib_module("<STUB_PKG>", "<cmake-target-name>")
+      LIB = ffi.libinfo.load_lib_module("<STUB_PKG>", "<cmake-target-name>")
 
    This uses :py:func:`tvm_ffi.libinfo.load_lib_module` to load the shared library.
 
@@ -141,7 +141,7 @@ STUB_PREFIX (default: ``<STUB_PKG>.``)
 
      .. code-block:: python
 
-        @tvm_ffi.register_object("<STUB_PREFIX>IntPair")
+        @ffi.register_object("<STUB_PREFIX>IntPair")
         class IntPair(_ffi_Object):
             # tvm-ffi-stubgen(begin): object/<STUB_PREFIX>IntPair
             a: int
@@ -299,7 +299,7 @@ When you run the tool, it:
 
       # tvm-ffi-stubgen(begin): global/my_ext.arith
       # fmt: off
-      tvm_ffi.init_ffi_api("my_ext.arith", __name__)
+      ffi.init_ffi_api("my_ext.arith", __name__)
       if TYPE_CHECKING:
           def add_one(_0: int, /) -> int: ...
           def add_two(_0: int, /) -> int: ...
@@ -308,11 +308,11 @@ When you run the tool, it:
 
 ``object/<type_key>`` - Object Types
    Marks a section for class field and method stubs. Place inside a class definition
-   decorated with ``@tvm_ffi.register_object``.
+   decorated with ``@ffi.register_object``.
 
    .. code-block:: python
 
-      @tvm_ffi.register_object("my_ffi_extension.IntPair")
+      @ffi.register_object("my_ffi_extension.IntPair")
       class IntPair(_ffi_Object):
           # tvm-ffi-stubgen(begin): object/my_ffi_extension.IntPair
           # fmt: off

--- a/examples/cubin_launcher/example_nvrtc_cubin.py
+++ b/examples/cubin_launcher/example_nvrtc_cubin.py
@@ -20,7 +20,7 @@
 
 This example demonstrates:
 1. Compiling CUDA C++ source code to CUBIN using NVRTC
-2. Embedding the CUBIN into a C++ module using tvm_ffi.cpp.load_inline
+2. Embedding the CUBIN into a C++ module using ffi.cpp.load_inline
 3. Launching the kernel through TVM-FFI
 
 Notes:

--- a/examples/cubin_launcher/example_triton_cubin.py
+++ b/examples/cubin_launcher/example_triton_cubin.py
@@ -21,7 +21,7 @@
 This script:
 1. Embeds a minimal Triton kernel definition (elementwise square)
 2. Compiles it to a CUBIN using the Triton runtime API
-3. Defines C++ code inline using tvm_ffi.cpp.load_inline to load the CUBIN
+3. Defines C++ code inline using ffi.cpp.load_inline to load the CUBIN
 4. Launches the kernel through the TVM-FFI exported function pointer
 
 Notes:

--- a/examples/inline_module/main.py
+++ b/examples/inline_module/main.py
@@ -17,13 +17,14 @@
 """Example: Build and run an inline C++/CUDA tvm-ffi module."""
 
 import torch
+import tvm_ffi as ffi
 import tvm_ffi.cpp
 from tvm_ffi.module import Module
 
 
 def main() -> None:
     """Build, load, and run inline CPU/CUDA functions."""
-    mod: Module = tvm_ffi.cpp.load_inline(
+    mod: Module = ffi.cpp.load_inline(
         name="hello",
         cpp_sources=r"""
             void add_one_cpu(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {

--- a/examples/kernel_library/load_scale.py
+++ b/examples/kernel_library/load_scale.py
@@ -18,10 +18,10 @@
 
 # [load_and_call.begin]
 import torch
-import tvm_ffi
+import tvm_ffi as ffi
 
 # Load the compiled shared library
-mod = tvm_ffi.load_module("build/scale_kernel.so")
+mod = ffi.load_module("build/scale_kernel.so")
 
 # Pre-allocate input and output tensors in PyTorch
 x = torch.randn(1024, device="cuda", dtype=torch.float32)

--- a/examples/quickstart/load/load_cupy.py
+++ b/examples/quickstart/load/load_cupy.py
@@ -19,8 +19,8 @@
 # mypy: ignore-errors
 # [example.begin]
 # File: load/load_cupy.py
-import tvm_ffi
-mod = tvm_ffi.load_module("build/add_one_cuda.so")
+import tvm_ffi as ffi
+mod = ffi.load_module("build/add_one_cuda.so")
 
 import cupy as cp
 x = cp.array([1, 2, 3, 4, 5], dtype=cp.float32)

--- a/examples/quickstart/load/load_numpy.py
+++ b/examples/quickstart/load/load_numpy.py
@@ -19,8 +19,8 @@
 # mypy: ignore-errors
 # [example.begin]
 # File: load/load_numpy.py
-import tvm_ffi
-mod = tvm_ffi.load_module("build/add_one_cpu.so")
+import tvm_ffi as ffi
+mod = ffi.load_module("build/add_one_cpu.so")
 
 import numpy as np
 x = np.array([1, 2, 3, 4, 5], dtype=np.float32)

--- a/examples/quickstart/load/load_paddle.py
+++ b/examples/quickstart/load/load_paddle.py
@@ -19,8 +19,8 @@
 # mypy: ignore-errors
 # [example.begin]
 # File: load/load_paddle.py
-import tvm_ffi
-mod = tvm_ffi.load_module("build/add_one_cuda.so")
+import tvm_ffi as ffi
+mod = ffi.load_module("build/add_one_cuda.so")
 
 import paddle
 x = paddle.tensor([1, 2, 3, 4, 5], dtype=paddle.float32, device="cuda")

--- a/examples/quickstart/load/load_pytorch.py
+++ b/examples/quickstart/load/load_pytorch.py
@@ -20,8 +20,8 @@
 # [example.begin]
 # File: load/load_pytorch.py
 # Step 1. Load `build/add_one_cuda.so`
-import tvm_ffi
-mod = tvm_ffi.load_module("build/add_one_cuda.so")
+import tvm_ffi as ffi
+mod = ffi.load_module("build/add_one_cuda.so")
 
 # Step 2. Run `mod.add_one_cuda` with PyTorch
 import torch

--- a/python/tvm_ffi/_convert.py
+++ b/python/tvm_ffi/_convert.py
@@ -58,31 +58,31 @@ def convert(value: Any) -> Any:  # noqa: PLR0911,PLR0912
     --------
     .. code-block:: python
 
-        import tvm_ffi
+        import tvm_ffi as ffi
 
-        # Lists and tuples become tvm_ffi.Array
-        a = tvm_ffi.convert([1, 2, 3])
-        assert isinstance(a, tvm_ffi.Array)
+        # Lists and tuples become ffi.Array
+        a = ffi.convert([1, 2, 3])
+        assert isinstance(a, ffi.Array)
 
-        # Dicts become tvm_ffi.Map
-        m = tvm_ffi.convert({"a": 1, "b": 2})
-        assert isinstance(m, tvm_ffi.Map)
+        # Dicts become ffi.Map
+        m = ffi.convert({"a": 1, "b": 2})
+        assert isinstance(m, ffi.Map)
 
         # Strings and bytes become zero-copy FFI-aware types
-        s = tvm_ffi.convert("hello")
-        b = tvm_ffi.convert(b"bytes")
-        assert isinstance(s, tvm_ffi.core.String)
-        assert isinstance(b, tvm_ffi.core.Bytes)
+        s = ffi.convert("hello")
+        b = ffi.convert(b"bytes")
+        assert isinstance(s, ffi.core.String)
+        assert isinstance(b, ffi.core.Bytes)
 
-        # Callables are wrapped as tvm_ffi.Function
-        f = tvm_ffi.convert(lambda x: x + 1)
-        assert isinstance(f, tvm_ffi.Function)
+        # Callables are wrapped as ffi.Function
+        f = ffi.convert(lambda x: x + 1)
+        assert isinstance(f, ffi.Function)
 
         # Array libraries that support DLPack export can be converted to Tensor
         import numpy as np
 
-        x = tvm_ffi.convert(np.arange(4, dtype="int32"))
-        assert isinstance(x, tvm_ffi.Tensor)
+        x = ffi.convert(np.arange(4, dtype="int32"))
+        assert isinstance(x, ffi.Tensor)
 
     Note
     ----

--- a/python/tvm_ffi/_dtype.py
+++ b/python/tvm_ffi/_dtype.py
@@ -63,10 +63,10 @@ class dtype(str):
     --------
     .. code-block:: python
 
-        import tvm_ffi
+        import tvm_ffi as ffi
 
         # Create from string
-        f32 = tvm_ffi.dtype("float32")
+        f32 = ffi.dtype("float32")
         assert f32.bits == 32
         assert f32.itemsize == 4
 
@@ -75,7 +75,7 @@ class dtype(str):
         assert v4f32 == "float32x4"
 
         # Round-trip from a DLPack (code, bits, lanes) triple
-        f16 = tvm_ffi.dtype.from_dlpack_data_type((2, 16, 1))
+        f16 = ffi.dtype.from_dlpack_data_type((2, 16, 1))
         assert f16 == "float16"
 
     Note
@@ -114,11 +114,11 @@ class dtype(str):
         --------
         .. code-block:: python
 
-            import tvm_ffi
+            import tvm_ffi as ffi
 
             # Create float16 and int8 directly from DLPack triples
-            f16 = tvm_ffi.dtype.from_dlpack_data_type((2, 16, 1))
-            i8 = tvm_ffi.dtype.from_dlpack_data_type((0, 8, 1))
+            f16 = ffi.dtype.from_dlpack_data_type((2, 16, 1))
+            i8 = ffi.dtype.from_dlpack_data_type((0, 8, 1))
             assert f16 == "float16"
             assert i8 == "int8"
 
@@ -160,9 +160,9 @@ class dtype(str):
         --------
         .. code-block:: python
 
-            import tvm_ffi
+            import tvm_ffi as ffi
 
-            f32 = tvm_ffi.dtype("float32")
+            f32 = ffi.dtype("float32")
             v4f32 = f32.with_lanes(4)
             assert v4f32 == "float32x4"
             assert v4f32.bits == f32.bits and v4f32.lanes == 4
@@ -195,10 +195,10 @@ class dtype(str):
         --------
         .. code-block:: python
 
-            import tvm_ffi
+            import tvm_ffi as ffi
 
-            assert tvm_ffi.dtype("float32").itemsize == 4
-            assert tvm_ffi.dtype("float32").with_lanes(4).itemsize == 16
+            assert ffi.dtype("float32").itemsize == 4
+            assert ffi.dtype("float32").with_lanes(4).itemsize == 16
 
         See Also
         --------
@@ -220,15 +220,13 @@ class dtype(str):
         --------
         .. code-block:: python
 
-            import tvm_ffi
+            import tvm_ffi as ffi
 
-            f32 = tvm_ffi.dtype("float32")
+            f32 = ffi.dtype("float32")
             # The type code is an integer following DLPack conventions
             assert isinstance(f32.type_code, int)
             # Consistent with constructing from an explicit (code, bits, lanes)
-            assert (
-                f32.type_code == tvm_ffi.dtype.from_dlpack_data_type((2, 32, 1)).type_code
-            )
+            assert f32.type_code == ffi.dtype.from_dlpack_data_type((2, 32, 1)).type_code
 
         See Also
         --------
@@ -246,10 +244,10 @@ class dtype(str):
         --------
         .. code-block:: python
 
-            import tvm_ffi
+            import tvm_ffi as ffi
 
-            assert tvm_ffi.dtype("int8").bits == 8
-            v4f32 = tvm_ffi.dtype("float32").with_lanes(4)
+            assert ffi.dtype("int8").bits == 8
+            v4f32 = ffi.dtype("float32").with_lanes(4)
             assert v4f32.bits == 32  # per-lane bit width
 
         See Also
@@ -273,10 +271,10 @@ class dtype(str):
         --------
         .. code-block:: python
 
-            import tvm_ffi
+            import tvm_ffi as ffi
 
-            assert tvm_ffi.dtype("float32").lanes == 1
-            assert tvm_ffi.dtype("float32").with_lanes(4).lanes == 4
+            assert ffi.dtype("float32").lanes == 1
+            assert ffi.dtype("float32").with_lanes(4).lanes == 4
 
         See Also
         --------

--- a/python/tvm_ffi/_tensor.py
+++ b/python/tvm_ffi/_tensor.py
@@ -48,9 +48,9 @@ class Shape(tuple, PyNativeObject):
     .. code-block:: python
 
         import numpy as np
-        import tvm_ffi
+        import tvm_ffi as ffi
 
-        x = tvm_ffi.from_dlpack(np.arange(6, dtype="int32").reshape(2, 3))
+        x = ffi.from_dlpack(np.arange(6, dtype="int32").reshape(2, 3))
         assert x.shape == (2, 3)
 
     """
@@ -91,7 +91,7 @@ def device(device_type: str | int | DLDeviceType, index: int | None = None) -> D
 
     Returns
     -------
-    device: tvm_ffi.Device
+    device: ffi.Device
 
     Examples
     --------
@@ -100,10 +100,10 @@ def device(device_type: str | int | DLDeviceType, index: int | None = None) -> D
 
     .. code-block:: python
 
-      import tvm_ffi
+      import tvm_ffi as ffi
 
-      assert tvm_ffi.device("cuda:0") == tvm_ffi.device("cuda", 0)
-      assert tvm_ffi.device("cpu:0") == tvm_ffi.device("cpu", 0)
+      assert ffi.device("cuda:0") == ffi.device("cuda", 0)
+      assert ffi.device("cpu:0") == ffi.device("cpu", 0)
 
     """
     # must refer to core._CLASS_DEVICE so we pick up override here

--- a/python/tvm_ffi/container.py
+++ b/python/tvm_ffi/container.py
@@ -148,9 +148,9 @@ class Array(core.Object, Sequence[T]):
     --------
     .. code-block:: python
 
-        import tvm_ffi
+        import tvm_ffi as ffi
 
-        a = tvm_ffi.Array([1, 2, 3])
+        a = ffi.Array([1, 2, 3])
         assert tuple(a) == (1, 2, 3)
 
     Notes
@@ -452,9 +452,9 @@ class Map(core.Object, Mapping[K, V]):
     --------
     .. code-block:: python
 
-        import tvm_ffi
+        import tvm_ffi as ffi
 
-        amap = tvm_ffi.Map({"a": 1, "b": 2})
+        amap = ffi.Map({"a": 1, "b": 2})
         assert len(amap) == 2
         assert amap["a"] == 1
         assert amap["b"] == 2
@@ -560,9 +560,9 @@ class Dict(core.Object, MutableMapping[K, V]):
     --------
     .. code-block:: python
 
-        import tvm_ffi
+        import tvm_ffi as ffi
 
-        d = tvm_ffi.Dict({"a": 1, "b": 2})
+        d = ffi.Dict({"a": 1, "b": 2})
         d["c"] = 3
         assert len(d) == 3
 

--- a/python/tvm_ffi/cpp/extension.py
+++ b/python/tvm_ffi/cpp/extension.py
@@ -797,14 +797,14 @@ def build_inline(  # noqa: PLR0913
         '''
 
         # compile the cpp source code and load the module
-        lib_path: str = tvm_ffi.cpp.build_inline(
+        lib_path: str = ffi.cpp.build_inline(
             name="hello",
             cpp_sources=cpp_source,
             functions="add_one_cpu",
         )
 
         # load the module
-        mod: Module = tvm_ffi.load_module(lib_path)
+        mod: Module = ffi.load_module(lib_path)
 
         # use the function from the loaded module to perform
         x = torch.tensor([1, 2, 3, 4, 5], dtype=torch.float32)
@@ -1018,7 +1018,7 @@ def load_inline(  # noqa: PLR0913
         '''
 
         # compile the cpp source code and load the module
-        mod: Module = tvm_ffi.cpp.load_inline(
+        mod: Module = ffi.cpp.load_inline(
             name="hello",
             cpp_sources=cpp_source,
             functions="add_one_cpu",
@@ -1165,13 +1165,13 @@ def build(
         # ```
 
         # compile the cpp source file and get the library path
-        lib_path: str = tvm_ffi.cpp.build(
+        lib_path: str = ffi.cpp.build(
             name="my_ops",
             cpp_files="my_ops.cpp",
         )
 
         # load the module
-        mod: Module = tvm_ffi.load_module(lib_path)
+        mod: Module = ffi.load_module(lib_path)
 
         # use the function from the loaded module
         x = torch.tensor([1, 2, 3, 4, 5], dtype=torch.float32)
@@ -1319,7 +1319,7 @@ def load(
         # ```
 
         # compile the cpp source file and load the module
-        mod: Module = tvm_ffi.cpp.load(
+        mod: Module = ffi.cpp.load(
             name="my_ops",
             cpp_files="my_ops.cpp",
         )

--- a/python/tvm_ffi/cpp/nvrtc.py
+++ b/python/tvm_ffi/cpp/nvrtc.py
@@ -75,7 +75,7 @@ def nvrtc_compile(  # noqa: PLR0912, PLR0915
         '''
 
         cubin_bytes = nvrtc.nvrtc_compile(cuda_source)
-        # Use cubin_bytes with tvm_ffi.cpp.load_inline and embed_cubin parameter
+        # Use cubin_bytes with ffi.cpp.load_inline and embed_cubin parameter
 
     """
     try:

--- a/python/tvm_ffi/error.py
+++ b/python/tvm_ffi/error.py
@@ -225,17 +225,17 @@ def register_error(
     --------
     .. code-block:: python
 
-        import tvm_ffi
+        import tvm_ffi as ffi
 
 
-        # Register a custom Python exception so tvm_ffi.Error maps to it
-        @tvm_ffi.error.register_error
+        # Register a custom Python exception so ffi.Error maps to it
+        @ffi.error.register_error
         class MyError(RuntimeError):
             pass
 
 
         # Convert a Python exception to an FFI Error and back
-        ffi_err = tvm_ffi.convert(MyError("boom"))
+        ffi_err = ffi.convert(MyError("boom"))
         py_err = ffi_err.py_error()
         assert isinstance(py_err, MyError)
 

--- a/python/tvm_ffi/module.py
+++ b/python/tvm_ffi/module.py
@@ -55,10 +55,10 @@ class Module(core.Object):
     --------
     .. code-block:: python
 
-        import tvm_ffi
+        import tvm_ffi as ffi
 
         # Load the module from a shared library
-        mod = tvm_ffi.load_module("path/to/library.so")
+        mod = ffi.load_module("path/to/library.so")
 
         # Call exported function
         mod.func_name(*args)
@@ -90,14 +90,14 @@ class Module(core.Object):
 
         def bad_pattern(x):
             # Bad: unload order of `tensor` and `mod` is not guaranteed
-            mod = tvm_ffi.load_module("path/to/library.so")
+            mod = ffi.load_module("path/to/library.so")
             # ... do something with the tensor
             tensor = mod.func_create_and_return_tensor(x)
 
 
         def good_pattern(x):
             # Good: `tensor` is freed before `mod` goes out of scope
-            mod = tvm_ffi.load_module("path/to/library.so")
+            mod = ffi.load_module("path/to/library.so")
 
             def run_some_tests():
                 tensor = mod.func_create_and_return_tensor(x)
@@ -218,11 +218,11 @@ class Module(core.Object):
         --------
         .. code-block:: python
 
-            import tvm_ffi
+            import tvm_ffi as ffi
             from tvm_ffi.core import TypeSchema
             import json
 
-            mod = tvm_ffi.load_module("add_one_cpu.so")
+            mod = ffi.load_module("add_one_cpu.so")
             metadata = mod.get_function_metadata("add_one_cpu")
             schema = TypeSchema.from_json_str(metadata["type_schema"])
             print(schema)  # Shows function signature
@@ -260,9 +260,9 @@ class Module(core.Object):
         --------
         .. code-block:: python
 
-            import tvm_ffi
+            import tvm_ffi as ffi
 
-            mod = tvm_ffi.load_module("mylib.so")
+            mod = ffi.load_module("mylib.so")
             doc = mod.get_function_doc("process_batch")
             if doc:
                 print(doc)
@@ -423,12 +423,12 @@ def system_lib(symbol_prefix: str = "") -> Module:
 
     .. code-block:: python
 
-        import tvm_ffi
+        import tvm_ffi as ffi
 
-        mod: tvm_ffi.Module = tvm_ffi.system_lib(
+        mod: ffi.Module = ffi.system_lib(
             "testing."
         )  # symbols prefixed with `__tvm_ffi_testing.`
-        func: tvm_ffi.Function = mod["add_one"]  # looks up `__tvm_ffi_testing.add_one`
+        func: ffi.Function = mod["add_one"]  # looks up `__tvm_ffi_testing.add_one`
         assert func(10) == 11
 
     """
@@ -455,13 +455,13 @@ def load_module(path: str | PathLike, keep_module_alive: bool = True) -> Module:
     --------
     .. code-block:: python
 
-        import tvm_ffi
+        import tvm_ffi as ffi
         from pathlib import Path
 
         # Works with string paths
-        mod = tvm_ffi.load_module("path/to/module.so")
+        mod = ffi.load_module("path/to/module.so")
         # Also works with pathlib.Path objects
-        mod = tvm_ffi.load_module(Path("path/to/module.so"))
+        mod = ffi.load_module(Path("path/to/module.so"))
 
         mod.func_name(*args)
 

--- a/python/tvm_ffi/registry.py
+++ b/python/tvm_ffi/registry.py
@@ -49,7 +49,7 @@ def register_object(type_key: str | None = None) -> Callable[[_T], _T]:
     arbitrary instance attributes, declare ``__slots__ = ("__dict__",)``
     explicitly in the class body::
 
-        @tvm_ffi.register_object("test.MyObject")
+        @ffi.register_object("test.MyObject")
         class MyObject(Object):
             __slots__ = ("__dict__",)
 
@@ -60,7 +60,7 @@ def register_object(type_key: str | None = None) -> Callable[[_T], _T]:
 
     .. code-block:: python
 
-      @tvm_ffi.register_object("test.MyObject")
+      @ffi.register_object("test.MyObject")
       class MyObject(Object):
           pass
 
@@ -123,22 +123,22 @@ def register_global_func(
     --------
     .. code-block:: python
 
-        import tvm_ffi
+        import tvm_ffi as ffi
 
 
         # we can use decorator to register a function
-        @tvm_ffi.register_global_func("mytest.echo")
+        @ffi.register_global_func("mytest.echo")
         def echo(x):
             return x
 
 
         # After registering, we can get the function by its name
-        f = tvm_ffi.get_global_func("mytest.echo")
+        f = ffi.get_global_func("mytest.echo")
         assert f(1) == 1
 
         # we can also directly register a function
-        tvm_ffi.register_global_func("mytest.add_one", lambda x: x + 1)
-        f = tvm_ffi.get_global_func("mytest.add_one")
+        ffi.register_global_func("mytest.add_one", lambda x: x + 1)
+        f = ffi.get_global_func("mytest.add_one")
         assert f(1) == 2
 
     See Also
@@ -191,15 +191,15 @@ def get_global_func(name: str, allow_missing: bool = False) -> core.Function | N
     --------
     .. code-block:: python
 
-        import tvm_ffi
+        import tvm_ffi as ffi
 
 
-        @tvm_ffi.register_global_func("demo.echo")
+        @ffi.register_global_func("demo.echo")
         def echo(x):
             return x
 
 
-        f = tvm_ffi.get_global_func("demo.echo")
+        f = ffi.get_global_func("demo.echo")
         assert f(123) == 123
 
     See Also
@@ -236,17 +236,17 @@ def remove_global_func(name: str) -> None:
     --------
     .. code-block:: python
 
-        import tvm_ffi
+        import tvm_ffi as ffi
 
 
-        @tvm_ffi.register_global_func("my.temp")
+        @ffi.register_global_func("my.temp")
         def temp():
             return 42
 
 
-        assert tvm_ffi.get_global_func("my.temp", allow_missing=True) is not None
-        tvm_ffi.remove_global_func("my.temp")
-        assert tvm_ffi.get_global_func("my.temp", allow_missing=True) is None
+        assert ffi.get_global_func("my.temp", allow_missing=True) is not None
+        ffi.remove_global_func("my.temp")
+        assert ffi.get_global_func("my.temp", allow_missing=True) is None
 
     See Also
     --------
@@ -275,9 +275,9 @@ def get_global_func_metadata(name: str) -> dict[str, Any]:
     --------
     .. code-block:: python
 
-        import tvm_ffi
+        import tvm_ffi as ffi
 
-        meta = tvm_ffi.get_global_func_metadata("testing.add_one")
+        meta = ffi.get_global_func_metadata("testing.add_one")
         print(meta)
 
     See Also
@@ -315,9 +315,9 @@ def init_ffi_api(namespace: str, target_module_name: str | None = None) -> None:
     .. code-block:: python
 
         # _ffi_api.py
-        import tvm_ffi
+        import tvm_ffi as ffi
 
-        tvm_ffi.init_ffi_api("mypackage", __name__)
+        ffi.init_ffi_api("mypackage", __name__)
 
     """
     target_module_name = target_module_name if target_module_name else namespace

--- a/python/tvm_ffi/serialization.py
+++ b/python/tvm_ffi/serialization.py
@@ -52,11 +52,11 @@ def to_json_graph_str(obj: Any, metadata: dict[str, Any] | None = None) -> str:
     --------
     .. code-block:: python
 
-        import tvm_ffi
+        import tvm_ffi as ffi
 
-        a = tvm_ffi.convert([1, 2, 3])
-        s = tvm_ffi.serialization.to_json_graph_str(a)
-        b = tvm_ffi.serialization.from_json_graph_str(s)
+        a = ffi.convert([1, 2, 3])
+        s = ffi.serialization.to_json_graph_str(a)
+        b = ffi.serialization.from_json_graph_str(s)
         assert list(b) == [1, 2, 3]
 
     """

--- a/python/tvm_ffi/stream.py
+++ b/python/tvm_ffi/stream.py
@@ -115,11 +115,11 @@ try:
         .. code-block:: python
 
             s = torch.cuda.Stream()
-            with tvm_ffi.use_torch_stream(torch.cuda.stream(s)):
+            with ffi.use_torch_stream(torch.cuda.stream(s)):
                 ...
 
             g = torch.cuda.CUDAGraph()
-            with tvm_ffi.use_torch_stream(torch.cuda.graph(g)):
+            with ffi.use_torch_stream(torch.cuda.graph(g)):
                 ...
 
         Note
@@ -160,12 +160,12 @@ def use_raw_stream(device: core.Device, stream: int | c_void_p) -> StreamContext
 
     .. code-block:: python
 
-        import tvm_ffi
+        import tvm_ffi as ffi
 
-        dev = tvm_ffi.device("cpu:0")
-        with tvm_ffi.use_raw_stream(dev, 0):
+        dev = ffi.device("cpu:0")
+        with ffi.use_raw_stream(dev, 0):
             # Within the context, the current stream for this device is set
-            assert tvm_ffi.get_raw_stream(dev) == 0
+            assert ffi.get_raw_stream(dev) == 0
 
     See Also
     --------
@@ -200,12 +200,12 @@ def get_raw_stream(device: core.Device) -> int:
     --------
     .. code-block:: python
 
-        import tvm_ffi
+        import tvm_ffi as ffi
 
-        dev = tvm_ffi.device("cpu:0")
+        dev = ffi.device("cpu:0")
         # Default stream is implementation-defined; set it explicitly
-        with tvm_ffi.use_raw_stream(dev, 0):
-            assert tvm_ffi.get_raw_stream(dev) == 0
+        with ffi.use_raw_stream(dev, 0):
+            assert ffi.get_raw_stream(dev) == 0
 
     See Also
     --------

--- a/python/tvm_ffi/structural.py
+++ b/python/tvm_ffi/structural.py
@@ -69,10 +69,10 @@ def structural_equal(
     --------
     .. code-block:: python
 
-        import tvm_ffi
+        import tvm_ffi as ffi
 
-        assert tvm_ffi.structural_equal([1, 2, 3], [1, 2, 3])
-        assert not tvm_ffi.structural_equal([1, 2, 3], [1, 2, 4])
+        assert ffi.structural_equal([1, 2, 3], [1, 2, 3])
+        assert not ffi.structural_equal([1, 2, 3], [1, 2, 4])
 
     See Also
     --------
@@ -114,10 +114,10 @@ def structural_hash(
     --------
     .. code-block:: python
 
-        import tvm_ffi
+        import tvm_ffi as ffi
 
-        h0 = tvm_ffi.structural_hash([1, 2, 3])
-        h1 = tvm_ffi.structural_hash([1, 2, 3])
+        h0 = ffi.structural_hash([1, 2, 3])
+        h1 = ffi.structural_hash([1, 2, 3])
         assert h0 == h1
 
     Notes
@@ -174,11 +174,11 @@ class StructuralKey(Object):
 
     .. code-block:: python
 
-        import tvm_ffi
+        import tvm_ffi as ffi
 
-        k0 = tvm_ffi.StructuralKey([1, 2, 3])
-        k1 = tvm_ffi.StructuralKey([1, 2, 3])
-        k2 = tvm_ffi.StructuralKey([1, 2, 4])
+        k0 = ffi.StructuralKey([1, 2, 3])
+        k1 = ffi.StructuralKey([1, 2, 3])
+        k2 = ffi.StructuralKey([1, 2, 4])
 
         d = {k0: "value-a", k2: "value-b"}
         assert d[k1] == "value-a"  # k1 matches k0 structurally
@@ -188,7 +188,7 @@ class StructuralKey(Object):
 
     .. code-block:: python
 
-        m = tvm_ffi.Map({k0: 1, k1: 2})
+        m = ffi.Map({k0: 1, k1: 2})
         assert len(m) == 1
         assert m[k0] == 2
 

--- a/python/tvm_ffi/stub/utils.py
+++ b/python/tvm_ffi/stub/utils.py
@@ -61,7 +61,7 @@ class InitConfig:
     """
 
     prefix: str
-    """Only generate stubs for global function and objects with the given prefix, e.g. `tvm_ffi.`"""
+    """Only generate stubs for global function and objects with the given prefix, e.g. `ffi.`"""
 
 
 @dataclasses.dataclass

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -18,7 +18,7 @@ import pathlib
 
 import numpy
 import pytest
-import tvm_ffi
+import tvm_ffi as ffi
 import tvm_ffi.cpp
 from tvm_ffi.core import TypeSchema
 from tvm_ffi.module import Module
@@ -26,12 +26,12 @@ from tvm_ffi.module import Module
 
 def test_build_cpp() -> None:
     cpp_path = pathlib.Path(__file__).parent.resolve() / "test_build.cc"
-    output_lib_path = tvm_ffi.cpp.build(
+    output_lib_path = ffi.cpp.build(
         name="hello",
         cpp_files=[str(cpp_path)],
     )
 
-    mod: Module = tvm_ffi.load_module(output_lib_path)
+    mod: Module = ffi.load_module(output_lib_path)
 
     metadata = mod.get_function_metadata("add_one_cpu")
     assert metadata is not None, "add_one_cpu should have metadata"
@@ -50,7 +50,7 @@ def test_build_cpp() -> None:
 def test_build_inline_with_metadata() -> None:  # noqa: PLR0915
     """Test functions with various input and output types."""
     # Keep module alive until all returned objects are destroyed
-    mod: Module = tvm_ffi.cpp.load_inline(
+    mod: Module = ffi.cpp.load_inline(
         name="test_io_types",
         cpp_sources=r"""
             // int input -> int output
@@ -217,7 +217,7 @@ def test_build_inline_with_docstrings() -> None:
 
     divide_docstring = "Divides two floats. Returns a/b."
 
-    mod: Module = tvm_ffi.cpp.load_inline(
+    mod: Module = ffi.cpp.load_inline(
         name="test_docs",
         cpp_sources=r"""
             int add(int a, int b) {
@@ -277,7 +277,7 @@ def test_build_inline_with_docstrings() -> None:
 
 def test_build_without_metadata() -> None:
     """Test building without metadata export."""
-    mod: Module = tvm_ffi.cpp.load_inline(
+    mod: Module = ffi.cpp.load_inline(
         name="test_no_meta",
         cpp_sources=r"""
             // Note: NOT defining TVM_FFI_DLL_EXPORT_INCLUDE_METADATA

--- a/tests/python/test_build_inline.py
+++ b/tests/python/test_build_inline.py
@@ -16,12 +16,13 @@
 # under the License.
 import numpy
 import pytest
+import tvm_ffi as ffi
 import tvm_ffi.cpp
 from tvm_ffi.module import Module
 
 
 def test_build_inline_cpp() -> None:
-    output_lib_path = tvm_ffi.cpp.build_inline(
+    output_lib_path = ffi.cpp.build_inline(
         name="hello",
         cpp_sources=r"""
             void add_one_cpu(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
@@ -40,7 +41,7 @@ def test_build_inline_cpp() -> None:
         functions=["add_one_cpu"],
     )
 
-    mod: Module = tvm_ffi.load_module(output_lib_path)
+    mod: Module = ffi.load_module(output_lib_path)
 
     x = numpy.array([1, 2, 3, 4, 5], dtype=numpy.float32)
     y = numpy.empty_like(x)

--- a/tests/python/test_container.py
+++ b/tests/python/test_container.py
@@ -21,7 +21,7 @@ import sys
 from typing import Any
 
 import pytest
-import tvm_ffi
+import tvm_ffi as ffi
 from tvm_ffi import testing
 from tvm_ffi.container import MISSING as CONTAINER_MISSING
 from tvm_ffi.core import MISSING
@@ -36,8 +36,8 @@ else:  # Python 3.8
 
 
 def test_array() -> None:
-    a = tvm_ffi.convert([1, 2, 3])
-    assert isinstance(a, tvm_ffi.Array)
+    a = ffi.convert([1, 2, 3])
+    assert isinstance(a, ffi.Array)
     assert len(a) == 3
     assert a[-1] == 3
     a_slice = a[-3:-1]
@@ -53,28 +53,28 @@ def test_bad_constructor_init_state() -> None:
     proper repr code
     """
     with pytest.raises(TypeError):
-        tvm_ffi.Array(1)  # ty: ignore[invalid-argument-type]
+        ffi.Array(1)  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(TypeError):
-        tvm_ffi.List(1)  # ty: ignore[invalid-argument-type]
+        ffi.List(1)  # ty: ignore[invalid-argument-type]
 
     with pytest.raises(AttributeError):
-        tvm_ffi.Map(1)  # ty: ignore[invalid-argument-type]
+        ffi.Map(1)  # ty: ignore[invalid-argument-type]
 
 
 def test_array_of_array_map() -> None:
-    a = tvm_ffi.convert([[1, 2, 3], {"A": 5, "B": 6}])
-    assert isinstance(a, tvm_ffi.Array)
+    a = ffi.convert([[1, 2, 3], {"A": 5, "B": 6}])
+    assert isinstance(a, ffi.Array)
     assert len(a) == 2
-    assert isinstance(a[0], tvm_ffi.Array)
-    assert isinstance(a[1], tvm_ffi.Map)
+    assert isinstance(a[0], ffi.Array)
+    assert isinstance(a[1], ffi.Map)
     assert tuple(a[0]) == (1, 2, 3)
     assert a[1]["A"] == 5
     assert a[1]["B"] == 6
 
 
 def test_int_map() -> None:
-    amap = tvm_ffi.convert({3: 2, 4: 3})
+    amap = ffi.convert({3: 2, 4: 3})
     assert 3 in amap
     assert len(amap) == 2
     dd = dict(amap.items())
@@ -91,16 +91,16 @@ def test_array_map_of_opaque_object() -> None:
         def __init__(self, value: Any) -> None:
             self.value = value
 
-    a = tvm_ffi.convert([MyObject("hello"), MyObject(1)])
-    assert isinstance(a, tvm_ffi.Array)
+    a = ffi.convert([MyObject("hello"), MyObject(1)])
+    assert isinstance(a, ffi.Array)
     assert len(a) == 2
     assert isinstance(a[0], MyObject)
     assert a[0].value == "hello"
     assert isinstance(a[1], MyObject)
     assert a[1].value == 1
 
-    y = tvm_ffi.convert({"a": MyObject(1), "b": MyObject("hello")})
-    assert isinstance(y, tvm_ffi.Map)
+    y = ffi.convert({"a": MyObject(1), "b": MyObject("hello")})
+    assert isinstance(y, ffi.Map)
     assert len(y) == 2
     assert isinstance(y["a"], MyObject)
     assert y["a"].value == 1
@@ -112,7 +112,7 @@ def test_str_map() -> None:
     data = []
     for i in reversed(range(10)):
         data.append((f"a{i}", i))
-    amap = tvm_ffi.convert({k: v for k, v in data})
+    amap = ffi.convert({k: v for k, v in data})
     assert tuple(amap.items()) == tuple(data)
     for k, v in data:
         assert k in amap
@@ -123,23 +123,23 @@ def test_str_map() -> None:
 
 
 def test_key_not_found() -> None:
-    amap = tvm_ffi.convert({3: 2, 4: 3})
+    amap = ffi.convert({3: 2, 4: 3})
     with pytest.raises(KeyError):
         amap[5]
 
 
 def test_repr() -> None:
-    a = tvm_ffi.convert([1, 2, 3])
+    a = ffi.convert([1, 2, 3])
     assert str(a) == "(1, 2, 3)"
-    amap = tvm_ffi.convert({3: 2, 4: 3})
+    amap = ffi.convert({3: 2, 4: 3})
     assert str(amap) == "{3: 2, 4: 3}"
 
-    smap = tvm_ffi.convert({"a": 1, "b": 2})
+    smap = ffi.convert({"a": 1, "b": 2})
     assert str(smap) == '{"a": 1, "b": 2}'
 
 
 def test_serialization() -> None:
-    a = tvm_ffi.convert([1, 2, 3])
+    a = ffi.convert([1, 2, 3])
     b = pickle.loads(pickle.dumps(a))
     assert str(b) == "(1, 2, 3)"
 
@@ -148,54 +148,54 @@ def test_serialization() -> None:
     "a, b, c_expected",
     [
         (
-            tvm_ffi.Array([1, 2, 3]),
-            tvm_ffi.Array([4, 5, 6]),
-            tvm_ffi.Array([1, 2, 3, 4, 5, 6]),
+            ffi.Array([1, 2, 3]),
+            ffi.Array([4, 5, 6]),
+            ffi.Array([1, 2, 3, 4, 5, 6]),
         ),
         (
-            tvm_ffi.Array([1, 2, 3]),
+            ffi.Array([1, 2, 3]),
             [4, 5, 6],
-            tvm_ffi.Array([1, 2, 3, 4, 5, 6]),
+            ffi.Array([1, 2, 3, 4, 5, 6]),
         ),
         (
             [1, 2, 3],
-            tvm_ffi.Array([4, 5, 6]),
-            tvm_ffi.Array([1, 2, 3, 4, 5, 6]),
+            ffi.Array([4, 5, 6]),
+            ffi.Array([1, 2, 3, 4, 5, 6]),
         ),
         (
-            tvm_ffi.Array([]),
-            tvm_ffi.Array([1, 2, 3]),
-            tvm_ffi.Array([1, 2, 3]),
+            ffi.Array([]),
+            ffi.Array([1, 2, 3]),
+            ffi.Array([1, 2, 3]),
         ),
         (
-            tvm_ffi.Array([1, 2, 3]),
+            ffi.Array([1, 2, 3]),
             [],
-            tvm_ffi.Array([1, 2, 3]),
+            ffi.Array([1, 2, 3]),
         ),
         (
             [],
-            tvm_ffi.Array([1, 2, 3]),
-            tvm_ffi.Array([1, 2, 3]),
+            ffi.Array([1, 2, 3]),
+            ffi.Array([1, 2, 3]),
         ),
         (
-            tvm_ffi.Array([]),
+            ffi.Array([]),
             [],
-            tvm_ffi.Array([]),
+            ffi.Array([]),
         ),
         (
-            tvm_ffi.Array([]),
+            ffi.Array([]),
             [],
-            tvm_ffi.Array([]),
+            ffi.Array([]),
         ),
         (
-            tvm_ffi.Array([1, 2, 3]),
+            ffi.Array([1, 2, 3]),
             (4, 5, 6),
-            tvm_ffi.Array([1, 2, 3, 4, 5, 6]),
+            ffi.Array([1, 2, 3, 4, 5, 6]),
         ),
         (
             (1, 2, 3),
-            tvm_ffi.Array([4, 5, 6]),
-            tvm_ffi.Array([1, 2, 3, 4, 5, 6]),
+            ffi.Array([4, 5, 6]),
+            ffi.Array([1, 2, 3, 4, 5, 6]),
         ),
     ],
 )
@@ -211,7 +211,7 @@ def test_array_concat(
 
 
 def test_large_map_get() -> None:
-    amap = tvm_ffi.convert({k: k**2 for k in range(100)})
+    amap = ffi.convert({k: k**2 for k in range(100)})
     assert amap.get(101) is None
     assert amap.get(3) == 9
 
@@ -231,7 +231,7 @@ def test_large_map_get() -> None:
     ],
 )
 def test_array_contains(arr: list[Any], value: Any, expected: bool) -> None:
-    a = tvm_ffi.convert(arr)
+    a = ffi.convert(arr)
     assert (value in a) == expected
 
 
@@ -245,7 +245,7 @@ def test_array_contains(arr: list[Any], value: Any, expected: bool) -> None:
     ],
 )
 def test_array_bool(arr: list[Any], expected: bool) -> None:
-    a = tvm_ffi.Array(arr)
+    a = ffi.Array(arr)
     assert bool(a) is expected
 
 
@@ -259,13 +259,13 @@ def test_array_bool(arr: list[Any], expected: bool) -> None:
     ],
 )
 def test_map_bool(mapping: dict[Any, Any], expected: bool) -> None:
-    m = tvm_ffi.Map(mapping)
+    m = ffi.Map(mapping)
     assert bool(m) is expected
 
 
 def test_list_basic() -> None:
-    lst = tvm_ffi.List([1, 2, 3])
-    assert isinstance(lst, tvm_ffi.List)
+    lst = ffi.List([1, 2, 3])
+    assert isinstance(lst, ffi.List)
     assert len(lst) == 3
     assert tuple(lst) == (1, 2, 3)
     assert lst[0] == 1
@@ -275,7 +275,7 @@ def test_list_basic() -> None:
 
 
 def test_list_mutation_methods() -> None:
-    lst = tvm_ffi.List([1, 2, 3])
+    lst = ffi.List([1, 2, 3])
     lst.append(4)
     assert tuple(lst) == (1, 2, 3, 4)
     lst.insert(2, 9)
@@ -294,7 +294,7 @@ def test_list_mutation_methods() -> None:
 
 
 def test_list_setitem_and_delitem() -> None:
-    lst = tvm_ffi.List([0, 1, 2, 3, 4, 5])
+    lst = ffi.List([0, 1, 2, 3, 4, 5])
     lst[1] = 10
     lst[-1] = 60
     assert tuple(lst) == (0, 10, 2, 3, 4, 60)
@@ -306,7 +306,7 @@ def test_list_setitem_and_delitem() -> None:
 
 
 def test_list_slice_assignment_and_delete() -> None:
-    lst = tvm_ffi.List([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    lst = ffi.List([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 
     lst[2:6] = [20, 21]
     assert tuple(lst) == (0, 1, 20, 21, 6, 7, 8, 9)
@@ -331,25 +331,25 @@ def test_list_slice_assignment_and_delete() -> None:
 
 
 def test_list_slice_edge_cases() -> None:
-    lst = tvm_ffi.List([0, 1, 2, 3, 4])
+    lst = ffi.List([0, 1, 2, 3, 4])
     lst[3:1] = [9]
     assert tuple(lst) == (0, 1, 2, 9, 3, 4)
 
-    lst = tvm_ffi.List([0, 1, 2, 3])
+    lst = ffi.List([0, 1, 2, 3])
     del lst[3:1]
     assert tuple(lst) == (0, 1, 2, 3)
 
-    lst = tvm_ffi.List([0, 1, 2, 3, 4, 5])
+    lst = ffi.List([0, 1, 2, 3, 4, 5])
     del lst[5:1:-1]
     assert tuple(lst) == (0, 1)
 
-    lst = tvm_ffi.List([0, 1, 2, 3])
+    lst = ffi.List([0, 1, 2, 3])
     del lst[::-1]
     assert tuple(lst) == ()
 
 
 def test_list_contains_bool_repr_and_concat() -> None:
-    lst = tvm_ffi.List([1, 2, 3])
+    lst = ffi.List([1, 2, 3])
     assert 2 in lst
     assert 5 not in lst
     assert bool(lst) is True
@@ -357,13 +357,13 @@ def test_list_contains_bool_repr_and_concat() -> None:
     assert tuple(lst.__add__([4, 5])) == (1, 2, 3, 4, 5)
     assert tuple(lst.__radd__([0])) == (0, 1, 2, 3)
 
-    empty = tvm_ffi.List()
+    empty = ffi.List()
     assert bool(empty) is False
     assert str(empty) == "[]"
 
 
 def test_list_insert_index_normalization() -> None:
-    lst = tvm_ffi.List([1, 2, 3])
+    lst = ffi.List([1, 2, 3])
     lst.insert(-100, 0)
     assert tuple(lst) == (0, 1, 2, 3)
     lst.insert(100, 4)
@@ -371,7 +371,7 @@ def test_list_insert_index_normalization() -> None:
 
 
 def test_list_error_cases() -> None:
-    lst = tvm_ffi.List([1, 2, 3])
+    lst = ffi.List([1, 2, 3])
 
     with pytest.raises(IndexError):
         _ = lst[3]
@@ -383,41 +383,41 @@ def test_list_error_cases() -> None:
         del lst[3]
 
     with pytest.raises(IndexError):
-        tvm_ffi.List().pop()
+        ffi.List().pop()
 
 
 def test_list_pickle_roundtrip() -> None:
-    lst = tvm_ffi.List([1, "a", {"k": 2}])
+    lst = ffi.List([1, "a", {"k": 2}])
     restored = pickle.loads(pickle.dumps(lst))
-    assert isinstance(restored, tvm_ffi.List)
+    assert isinstance(restored, ffi.List)
     assert restored[0] == 1
     assert restored[1] == "a"
-    assert isinstance(restored[2], tvm_ffi.Map)
+    assert isinstance(restored[2], ffi.Map)
     assert restored[2]["k"] == 2
 
 
 def test_list_reverse() -> None:
-    lst = tvm_ffi.List([3, 1, 2])
+    lst = ffi.List([3, 1, 2])
     lst.reverse()
     assert tuple(lst) == (2, 1, 3)
 
-    empty = tvm_ffi.List()
+    empty = ffi.List()
     empty.reverse()
     assert tuple(empty) == ()
 
-    single = tvm_ffi.List([42])
+    single = ffi.List([42])
     single.reverse()
     assert tuple(single) == (42,)
 
 
 def test_list_self_aliasing_slice_assignment() -> None:
-    lst = tvm_ffi.List([0, 1, 2, 3, 4])
+    lst = ffi.List([0, 1, 2, 3, 4])
     lst[1:3] = lst
     assert tuple(lst) == (0, 0, 1, 2, 3, 4, 3, 4)
 
 
 def test_list_is_mutable_and_shared() -> None:
-    lst = tvm_ffi.List([1, 2])
+    lst = ffi.List([1, 2])
     alias = lst
     alias.append(3)
     alias[0] = 10
@@ -429,76 +429,76 @@ def test_list_is_mutable_and_shared() -> None:
 # ---------------------------------------------------------------------------
 def test_seq_cross_conv_list_to_array_int() -> None:
     """List<int> passed to a function expecting Array<int> (new behavior)."""
-    lst = tvm_ffi.List([10, 20, 30])
+    lst = ffi.List([10, 20, 30])
     result = testing.schema_id_arr_int(lst)
-    assert isinstance(result, tvm_ffi.Array)
+    assert isinstance(result, ffi.Array)
     assert list(result) == [10, 20, 30]
 
 
 def test_seq_cross_conv_array_to_list_int() -> None:
     """Array<int> passed to a function expecting List<int>."""
-    arr = tvm_ffi.Array([10, 20, 30])
+    arr = ffi.Array([10, 20, 30])
     result = testing.schema_id_list_int(arr)  # type: ignore[invalid-argument-type]
-    assert isinstance(result, tvm_ffi.List)
+    assert isinstance(result, ffi.List)
     assert list(result) == [10, 20, 30]
 
 
 def test_seq_cross_conv_list_to_array_str() -> None:
     """List<String> passed to a function expecting Array<String>."""
-    lst = tvm_ffi.List(["a", "b", "c"])
+    lst = ffi.List(["a", "b", "c"])
     result = testing.schema_id_arr_str(lst)
-    assert isinstance(result, tvm_ffi.Array)
+    assert isinstance(result, ffi.Array)
     assert list(result) == ["a", "b", "c"]
 
 
 def test_seq_cross_conv_array_to_list_str() -> None:
     """Array<String> passed to a function expecting List<String>."""
-    arr = tvm_ffi.Array(["a", "b", "c"])
+    arr = ffi.Array(["a", "b", "c"])
     result = testing.schema_id_list_str(arr)  # type: ignore[invalid-argument-type]
-    assert isinstance(result, tvm_ffi.List)
+    assert isinstance(result, ffi.List)
     assert list(result) == ["a", "b", "c"]
 
 
 def test_seq_cross_conv_empty_list_to_array() -> None:
     """Empty List passed to a function expecting Array<int>."""
-    lst = tvm_ffi.List([])
+    lst = ffi.List([])
     result = testing.schema_id_arr_int(lst)
-    assert isinstance(result, tvm_ffi.Array)
+    assert isinstance(result, ffi.Array)
     assert len(result) == 0
 
 
 def test_seq_cross_conv_empty_array_to_list() -> None:
     """Empty Array passed to a function expecting List<int>."""
-    arr = tvm_ffi.Array([])
+    arr = ffi.Array([])
     result = testing.schema_id_list_int(arr)  # type: ignore[invalid-argument-type]
-    assert isinstance(result, tvm_ffi.List)
+    assert isinstance(result, ffi.List)
     assert len(result) == 0
 
 
 def test_seq_cross_conv_python_list_to_array() -> None:
     """Plain Python list passed to Array<int> function."""
     result = testing.schema_id_arr_int([1, 2, 3])
-    assert isinstance(result, tvm_ffi.Array)
+    assert isinstance(result, ffi.Array)
     assert list(result) == [1, 2, 3]
 
 
 def test_seq_cross_conv_python_list_to_list() -> None:
     """Plain Python list passed to List<int> function."""
     result = testing.schema_id_list_int([1, 2, 3])
-    assert isinstance(result, tvm_ffi.List)
+    assert isinstance(result, ffi.List)
     assert list(result) == [1, 2, 3]
 
 
 def test_seq_cross_conv_incompatible_list_to_array() -> None:
     """List with incompatible element types should fail when cast to Array<int>."""
-    lst = tvm_ffi.List(["not", "ints"])
+    lst = ffi.List(["not", "ints"])
     with pytest.raises(TypeError):
         testing.schema_id_arr_int(lst)  # type: ignore[arg-type]
 
 
 def test_seq_cross_conv_incompatible_array_to_list() -> None:
     """Array with incompatible element types should fail when cast to List<int>."""
-    arr = tvm_ffi.Array(["not", "ints"])
+    arr = ffi.Array(["not", "ints"])
     with pytest.raises(TypeError):
         testing.schema_id_list_int(arr)  # type: ignore[arg-type]
 
@@ -506,11 +506,11 @@ def test_seq_cross_conv_incompatible_array_to_list() -> None:
 def test_missing_object() -> None:
     """Test that MISSING is a valid singleton and works with Map.get()."""
     # MISSING should be an Object instance
-    assert isinstance(MISSING, tvm_ffi.Object)
+    assert isinstance(MISSING, ffi.Object)
     # MISSING should be the same object across imports
     assert MISSING.same_as(CONTAINER_MISSING)
     # Map.get() should use MISSING internally
-    m = tvm_ffi.Map({"a": 1})
+    m = ffi.Map({"a": 1})
     assert m.get("a") == 1
     assert m.get("b") is None
     assert m.get("b", 42) == 42
@@ -520,7 +520,7 @@ def test_missing_object() -> None:
 # Dict tests
 # ---------------------------------------------------------------------------
 def test_dict_basic() -> None:
-    d = tvm_ffi.Dict({"a": 1, "b": 2})
+    d = ffi.Dict({"a": 1, "b": 2})
     assert len(d) == 2
     assert "a" in d
     assert d["a"] == 1
@@ -529,7 +529,7 @@ def test_dict_basic() -> None:
 
 
 def test_dict_setitem_delitem() -> None:
-    d = tvm_ffi.Dict({"a": 1})
+    d = ffi.Dict({"a": 1})
     d["b"] = 2
     assert len(d) == 2
     assert d["b"] == 2
@@ -541,7 +541,7 @@ def test_dict_setitem_delitem() -> None:
 
 
 def test_dict_shared_mutation() -> None:
-    d1 = tvm_ffi.Dict({"a": 1})
+    d1 = ffi.Dict({"a": 1})
     d2 = d1  # alias, same underlying object
     d1["b"] = 2
     assert d2["b"] == 2
@@ -549,7 +549,7 @@ def test_dict_shared_mutation() -> None:
 
 
 def test_dict_keys_values_items() -> None:
-    d = tvm_ffi.Dict({"x": 10, "y": 20})
+    d = ffi.Dict({"x": 10, "y": 20})
     keys = set(d.keys())
     assert keys == {"x", "y"}
     values = set(d.values())
@@ -559,14 +559,14 @@ def test_dict_keys_values_items() -> None:
 
 
 def test_dict_get_with_default() -> None:
-    d = tvm_ffi.Dict({"a": 1})
+    d = ffi.Dict({"a": 1})
     assert d.get("a") == 1
     assert d.get("b") is None
     assert d.get("b", 42) == 42
 
 
 def test_dict_pop() -> None:
-    d = tvm_ffi.Dict({"a": 1, "b": 2})
+    d = ffi.Dict({"a": 1, "b": 2})
     val = d.pop("a")
     assert val == 1
     assert len(d) == 1
@@ -579,20 +579,20 @@ def test_dict_pop() -> None:
 
 
 def test_dict_clear() -> None:
-    d = tvm_ffi.Dict({"a": 1, "b": 2})
+    d = ffi.Dict({"a": 1, "b": 2})
     d.clear()
     assert len(d) == 0
 
 
 def test_dict_update() -> None:
-    d = tvm_ffi.Dict({"a": 1})
+    d = ffi.Dict({"a": 1})
     d.update({"b": 2, "c": 3})
     assert len(d) == 3
     assert d["b"] == 2
 
 
 def test_dict_iteration() -> None:
-    d = tvm_ffi.Dict({"a": 1, "b": 2})
+    d = ffi.Dict({"a": 1, "b": 2})
     keys = list(d)
     assert set(keys) == {"a", "b"}
 
@@ -600,7 +600,7 @@ def test_dict_iteration() -> None:
 def test_dict_iteration_many_entries() -> None:
     """Regression: ensure iterator visits ALL entries, not just the first."""
     entries = {f"key_{i}": i for i in range(10)}
-    d = tvm_ffi.Dict(entries)
+    d = ffi.Dict(entries)
     # keys
     keys_list = list(d.keys())
     assert len(keys_list) == 10
@@ -621,7 +621,7 @@ def test_dict_iteration_many_entries() -> None:
 
 def test_dict_iteration_after_mutation() -> None:
     """Regression: iteration after insert/delete visits correct elements."""
-    d = tvm_ffi.Dict({"a": 1, "b": 2, "c": 3})
+    d = ffi.Dict({"a": 1, "b": 2, "c": 3})
     d["d"] = 4
     del d["b"]
     # should have a, c, d
@@ -637,7 +637,7 @@ def test_dict_iteration_after_mutation() -> None:
 
 
 def test_dict_repr() -> None:
-    d = tvm_ffi.Dict({"a": 1})
+    d = ffi.Dict({"a": 1})
     r = repr(d)
     assert isinstance(r, str)
     # repr should look dict-like
@@ -645,22 +645,22 @@ def test_dict_repr() -> None:
 
 
 def test_dict_bool() -> None:
-    assert not tvm_ffi.Dict()
-    assert tvm_ffi.Dict({"a": 1})
+    assert not ffi.Dict()
+    assert ffi.Dict({"a": 1})
 
 
 def test_dict_empty_init() -> None:
-    d = tvm_ffi.Dict()
+    d = ffi.Dict()
     assert len(d) == 0
     d["a"] = 1
     assert d["a"] == 1
 
 
 def test_dict_pickle_roundtrip() -> None:
-    d = tvm_ffi.Dict({"a": 1, "b": 2})
+    d = ffi.Dict({"a": 1, "b": 2})
     data = pickle.dumps(d)
     d2 = pickle.loads(data)
-    assert isinstance(d2, tvm_ffi.Dict)
+    assert isinstance(d2, ffi.Dict)
     assert len(d2) == 2
     assert d2["a"] == 1
     assert d2["b"] == 2
@@ -673,63 +673,63 @@ def test_dict_pickle_roundtrip() -> None:
 
 def test_map_cross_conv_dict_to_map_str_int() -> None:
     """Dict<String, int> passed to a function expecting Map<String, int>."""
-    d = tvm_ffi.Dict({"a": 1, "b": 2})
+    d = ffi.Dict({"a": 1, "b": 2})
     result = testing.schema_id_map_str_int(d)
-    assert isinstance(result, tvm_ffi.Map)
+    assert isinstance(result, ffi.Map)
     assert dict(result.items()) == {"a": 1, "b": 2}
 
 
 def test_map_cross_conv_map_to_dict_str_int() -> None:
     """Map<String, int> passed to a function expecting Dict<String, int>."""
-    m = tvm_ffi.Map({"a": 1, "b": 2})
+    m = ffi.Map({"a": 1, "b": 2})
     result = testing.schema_id_dict_str_int(m)  # type: ignore[invalid-argument-type]
-    assert isinstance(result, tvm_ffi.Dict)
+    assert isinstance(result, ffi.Dict)
     assert result["a"] == 1
     assert result["b"] == 2
 
 
 def test_map_cross_conv_dict_to_map_str_str() -> None:
     """Dict<String, String> passed to a function expecting Map<String, String>."""
-    d = tvm_ffi.Dict({"x": "hello", "y": "world"})
+    d = ffi.Dict({"x": "hello", "y": "world"})
     result = testing.schema_id_map_str_str(d)
-    assert isinstance(result, tvm_ffi.Map)
+    assert isinstance(result, ffi.Map)
     assert dict(result.items()) == {"x": "hello", "y": "world"}
 
 
 def test_map_cross_conv_map_to_dict_str_str() -> None:
     """Map<String, String> passed to a function expecting Dict<String, String>."""
-    m = tvm_ffi.Map({"x": "hello", "y": "world"})
+    m = ffi.Map({"x": "hello", "y": "world"})
     result = testing.schema_id_dict_str_str(m)  # type: ignore[invalid-argument-type]
-    assert isinstance(result, tvm_ffi.Dict)
+    assert isinstance(result, ffi.Dict)
     assert result["x"] == "hello"
     assert result["y"] == "world"
 
 
 def test_map_cross_conv_empty_dict_to_map() -> None:
     """Empty Dict passed to a function expecting Map<String, int>."""
-    d = tvm_ffi.Dict({})
+    d = ffi.Dict({})
     result = testing.schema_id_map_str_int(d)
-    assert isinstance(result, tvm_ffi.Map)
+    assert isinstance(result, ffi.Map)
     assert len(result) == 0
 
 
 def test_map_cross_conv_empty_map_to_dict() -> None:
     """Empty Map passed to a function expecting Dict<String, int>."""
-    m = tvm_ffi.Map({})
+    m = ffi.Map({})
     result = testing.schema_id_dict_str_int(m)  # type: ignore[invalid-argument-type]
-    assert isinstance(result, tvm_ffi.Dict)
+    assert isinstance(result, ffi.Dict)
     assert len(result) == 0
 
 
 def test_map_cross_conv_incompatible_dict_to_map() -> None:
     """Dict with incompatible value types should fail when cast to Map<String, int>."""
-    d = tvm_ffi.Dict({"a": "not_int", "b": "still_not_int"})
+    d = ffi.Dict({"a": "not_int", "b": "still_not_int"})
     with pytest.raises(TypeError):
         testing.schema_id_map_str_int(d)  # type: ignore[arg-type]
 
 
 def test_map_cross_conv_incompatible_map_to_dict() -> None:
     """Map with incompatible value types should fail when cast to Dict<String, int>."""
-    m = tvm_ffi.Map({"a": "not_int", "b": "still_not_int"})
+    m = ffi.Map({"a": "not_int", "b": "still_not_int"})
     with pytest.raises(TypeError):
         testing.schema_id_dict_str_int(m)  # type: ignore[arg-type]

--- a/tests/python/test_cubin_launcher.py
+++ b/tests/python/test_cubin_launcher.py
@@ -31,6 +31,7 @@ try:
 except ImportError:
     torch = None  # ty: ignore[invalid-assignment]
 
+import tvm_ffi as ffi
 import tvm_ffi.cpp
 
 
@@ -195,7 +196,7 @@ TVM_FFI_DLL_EXPORT_TYPED_FUNC(launch_mul_two, cubin_test::LaunchMulTwo);
 """
 
     # Compile and load the C++ code
-    mod = tvm_ffi.cpp.load_inline(
+    mod = ffi.cpp.load_inline(
         "cubin_test",
         cuda_sources=cpp_code,
         extra_ldflags=["-lcudart"],
@@ -293,7 +294,7 @@ TVM_FFI_DLL_EXPORT_TYPED_FUNC(launch_add_one_ex, cubin_test_launch_ex::LaunchAdd
 }  // namespace cubin_test_launch_ex
 """
 
-    mod = tvm_ffi.cpp.load_inline(
+    mod = ffi.cpp.load_inline(
         "cubin_test_launch_ex",
         cuda_sources=cpp_code,
         extra_ldflags=["-lcudart"],
@@ -385,7 +386,7 @@ TVM_FFI_DLL_EXPORT_TYPED_FUNC(launch_mul_two, cubin_test_chain::LaunchMulTwo);
 }  // namespace cubin_test_chain
 """
 
-    mod = tvm_ffi.cpp.load_inline("cubin_test_chain", cuda_sources=cpp_code)
+    mod = ffi.cpp.load_inline("cubin_test_chain", cuda_sources=cpp_code)
 
     # Load CUBIN from bytes
     load_fn = mod["load_cubin_data"]

--- a/tests/python/test_current_work_stream_gpu.py
+++ b/tests/python/test_current_work_stream_gpu.py
@@ -23,7 +23,7 @@ import pytest
 
 try:
     import torch
-    import tvm_ffi  # noqa: F401
+    import tvm_ffi as ffi  # noqa: F401
     from torch.utils import cpp_extension
     from tvm_ffi import libinfo
 except ImportError:

--- a/tests/python/test_dataclass_compare.py
+++ b/tests/python/test_dataclass_compare.py
@@ -22,7 +22,7 @@ import math
 import struct
 
 import pytest
-import tvm_ffi
+import tvm_ffi as ffi
 import tvm_ffi.testing
 from tvm_ffi._ffi_api import RecursiveEq, RecursiveGe, RecursiveGt, RecursiveLe, RecursiveLt
 from tvm_ffi.testing import (
@@ -149,8 +149,8 @@ def test_nan_payloads_eq() -> None:
 def test_nan_payloads_in_nested_array() -> None:
     nan1 = _make_nan_from_payload(0xA5)
     nan2 = _make_nan_from_payload(0x5A)
-    a = tvm_ffi.Array([1.0, nan1, 2.0])
-    b = tvm_ffi.Array([1.0, nan2, 2.0])
+    a = ffi.Array([1.0, nan1, 2.0])
+    b = ffi.Array([1.0, nan2, 2.0])
     assert RecursiveEq(a, b)
     with pytest.raises(TypeError):
         RecursiveLt(a, b)
@@ -283,14 +283,14 @@ def test_type_mismatch_ordering_raises() -> None:
 
 
 def test_dtype_eq() -> None:
-    assert RecursiveEq(tvm_ffi.dtype("float32"), tvm_ffi.dtype("float32"))
-    assert not RecursiveEq(tvm_ffi.dtype("float32"), tvm_ffi.dtype("float16"))
+    assert RecursiveEq(ffi.dtype("float32"), ffi.dtype("float32"))
+    assert not RecursiveEq(ffi.dtype("float32"), ffi.dtype("float16"))
 
 
 def test_dtype_ordering() -> None:
     # float32 code=2 bits=32, float16 code=2 bits=16 -> float16 < float32
-    assert RecursiveLt(tvm_ffi.dtype("float16"), tvm_ffi.dtype("float32"))
-    assert not RecursiveLt(tvm_ffi.dtype("float32"), tvm_ffi.dtype("float16"))
+    assert RecursiveLt(ffi.dtype("float16"), ffi.dtype("float32"))
+    assert not RecursiveLt(ffi.dtype("float32"), ffi.dtype("float16"))
 
 
 # ---------------------------------------------------------------------------
@@ -299,13 +299,13 @@ def test_dtype_ordering() -> None:
 
 
 def test_device_eq() -> None:
-    assert RecursiveEq(tvm_ffi.Device("cpu", 0), tvm_ffi.Device("cpu", 0))
-    assert not RecursiveEq(tvm_ffi.Device("cpu", 0), tvm_ffi.Device("cpu", 1))
+    assert RecursiveEq(ffi.Device("cpu", 0), ffi.Device("cpu", 0))
+    assert not RecursiveEq(ffi.Device("cpu", 0), ffi.Device("cpu", 1))
 
 
 def test_device_ordering() -> None:
-    assert RecursiveLt(tvm_ffi.Device("cpu", 0), tvm_ffi.Device("cpu", 1))
-    assert RecursiveLt(tvm_ffi.Device("cpu", 0), tvm_ffi.Device("cuda", 0))
+    assert RecursiveLt(ffi.Device("cpu", 0), ffi.Device("cpu", 1))
+    assert RecursiveLt(ffi.Device("cpu", 0), ffi.Device("cuda", 0))
 
 
 # ---------------------------------------------------------------------------
@@ -314,25 +314,25 @@ def test_device_ordering() -> None:
 
 
 def test_array_eq() -> None:
-    a = tvm_ffi.Array([1, 2, 3])
-    b = tvm_ffi.Array([1, 2, 3])
-    c = tvm_ffi.Array([1, 2, 4])
+    a = ffi.Array([1, 2, 3])
+    b = ffi.Array([1, 2, 3])
+    c = ffi.Array([1, 2, 4])
     assert RecursiveEq(a, b)
     assert not RecursiveEq(a, c)
 
 
 def test_array_ordering() -> None:
-    a = tvm_ffi.Array([1, 2, 3])
-    b = tvm_ffi.Array([1, 2, 4])
-    c = tvm_ffi.Array([1, 2, 3, 0])
+    a = ffi.Array([1, 2, 3])
+    b = ffi.Array([1, 2, 4])
+    c = ffi.Array([1, 2, 3, 0])
     assert RecursiveLt(a, b)
     assert RecursiveLt(a, c)  # shorter < longer when prefix matches
     assert not RecursiveLt(b, a)
 
 
 def test_array_empty() -> None:
-    empty = tvm_ffi.Array([])
-    one = tvm_ffi.Array([1])
+    empty = ffi.Array([])
+    one = ffi.Array([1])
     assert RecursiveEq(empty, empty)
     assert RecursiveLt(empty, one)
 
@@ -343,16 +343,16 @@ def test_array_empty() -> None:
 
 
 def test_list_eq() -> None:
-    a = tvm_ffi.List([1, 2, 3])
-    b = tvm_ffi.List([1, 2, 3])
-    c = tvm_ffi.List([1, 2, 4])
+    a = ffi.List([1, 2, 3])
+    b = ffi.List([1, 2, 3])
+    c = ffi.List([1, 2, 4])
     assert RecursiveEq(a, b)
     assert not RecursiveEq(a, c)
 
 
 def test_list_ordering() -> None:
-    a = tvm_ffi.List([1, 2])
-    b = tvm_ffi.List([1, 3])
+    a = ffi.List([1, 2])
+    b = ffi.List([1, 3])
     assert RecursiveLt(a, b)
 
 
@@ -362,17 +362,17 @@ def test_list_ordering() -> None:
 
 
 def test_shape_eq() -> None:
-    a = tvm_ffi.Shape((2, 3, 4))
-    b = tvm_ffi.Shape((2, 3, 4))
-    c = tvm_ffi.Shape((2, 3, 5))
+    a = ffi.Shape((2, 3, 4))
+    b = ffi.Shape((2, 3, 4))
+    c = ffi.Shape((2, 3, 5))
     assert RecursiveEq(a, b)
     assert not RecursiveEq(a, c)
 
 
 def test_shape_ordering() -> None:
-    a = tvm_ffi.Shape((2, 3, 4))
-    b = tvm_ffi.Shape((2, 3, 5))
-    c = tvm_ffi.Shape((2, 3, 4, 0))
+    a = ffi.Shape((2, 3, 4))
+    b = ffi.Shape((2, 3, 5))
+    c = ffi.Shape((2, 3, 4, 0))
     assert RecursiveLt(a, b)
     assert RecursiveLt(a, c)
 
@@ -383,29 +383,29 @@ def test_shape_ordering() -> None:
 
 
 def test_map_eq() -> None:
-    a = tvm_ffi.Map({"x": 1, "y": 2})
-    b = tvm_ffi.Map({"x": 1, "y": 2})
-    c = tvm_ffi.Map({"x": 1, "y": 3})
+    a = ffi.Map({"x": 1, "y": 2})
+    b = ffi.Map({"x": 1, "y": 2})
+    c = ffi.Map({"x": 1, "y": 3})
     assert RecursiveEq(a, b)
     assert not RecursiveEq(a, c)
 
 
 def test_map_different_size() -> None:
-    a = tvm_ffi.Map({"x": 1})
-    b = tvm_ffi.Map({"x": 1, "y": 2})
+    a = ffi.Map({"x": 1})
+    b = ffi.Map({"x": 1, "y": 2})
     assert not RecursiveEq(a, b)
 
 
 def test_map_ordering_raises() -> None:
-    a = tvm_ffi.Map({"x": 1})
-    b = tvm_ffi.Map({"x": 2})
+    a = ffi.Map({"x": 1})
+    b = ffi.Map({"x": 2})
     with pytest.raises(TypeError):
         RecursiveLt(a, b)
 
 
 def test_map_same_size_different_keys() -> None:
-    a = tvm_ffi.Map({"x": 1})
-    b = tvm_ffi.Map({"y": 1})
+    a = ffi.Map({"x": 1})
+    b = ffi.Map({"y": 1})
     assert not RecursiveEq(a, b)
     with pytest.raises(TypeError):
         RecursiveLt(a, b)
@@ -413,8 +413,8 @@ def test_map_same_size_different_keys() -> None:
 
 def test_equal_maps_under_ordering() -> None:
     """Two separate but equal maps pass Le/Ge without raising TypeError."""
-    a = tvm_ffi.Map({"x": 1, "y": 2})
-    b = tvm_ffi.Map({"x": 1, "y": 2})
+    a = ffi.Map({"x": 1, "y": 2})
+    b = ffi.Map({"x": 1, "y": 2})
     assert RecursiveLe(a, b)
     assert RecursiveGe(a, b)
     assert not RecursiveLt(a, b)
@@ -422,22 +422,22 @@ def test_equal_maps_under_ordering() -> None:
 
 
 def test_dict_eq() -> None:
-    a = tvm_ffi.Dict({"x": 1, "y": 2})
-    b = tvm_ffi.Dict({"x": 1, "y": 2})
+    a = ffi.Dict({"x": 1, "y": 2})
+    b = ffi.Dict({"x": 1, "y": 2})
     assert RecursiveEq(a, b)
 
 
 def test_dict_ordering_raises() -> None:
-    a = tvm_ffi.Dict({"x": 1})
-    b = tvm_ffi.Dict({"x": 2})
+    a = ffi.Dict({"x": 1})
+    b = ffi.Dict({"x": 2})
     with pytest.raises(TypeError):
         RecursiveLt(a, b)
 
 
 def test_equal_dicts_under_ordering() -> None:
     """Two separate but equal dicts pass Le/Ge without raising TypeError."""
-    a = tvm_ffi.Dict({"x": 1, "y": 2})
-    b = tvm_ffi.Dict({"x": 1, "y": 2})
+    a = ffi.Dict({"x": 1, "y": 2})
+    b = ffi.Dict({"x": 1, "y": 2})
     assert RecursiveLe(a, b)
     assert RecursiveGe(a, b)
 
@@ -528,8 +528,8 @@ def test_nested_objects_in_array() -> None:
     a2 = TestIntPair(3, 4)
     b1 = TestIntPair(1, 2)
     b2 = TestIntPair(3, 4)
-    arr_a = tvm_ffi.Array([a1, a2])
-    arr_b = tvm_ffi.Array([b1, b2])
+    arr_a = ffi.Array([a1, a2])
+    arr_b = ffi.Array([b1, b2])
     assert RecursiveEq(arr_a, arr_b)
 
 
@@ -538,8 +538,8 @@ def test_nested_objects_in_array_differ() -> None:
     a2 = TestIntPair(3, 4)
     b1 = TestIntPair(1, 2)
     b2 = TestIntPair(3, 5)
-    arr_a = tvm_ffi.Array([a1, a2])
-    arr_b = tvm_ffi.Array([b1, b2])
+    arr_a = ffi.Array([a1, a2])
+    arr_b = ffi.Array([b1, b2])
     assert not RecursiveEq(arr_a, arr_b)
     assert RecursiveLt(arr_a, arr_b)
 
@@ -567,48 +567,48 @@ def test_le_ge_gt() -> None:
 
 
 def test_array_of_arrays_eq() -> None:
-    a = tvm_ffi.Array([tvm_ffi.Array([1, 2]), tvm_ffi.Array([3, 4])])
-    b = tvm_ffi.Array([tvm_ffi.Array([1, 2]), tvm_ffi.Array([3, 4])])
-    c = tvm_ffi.Array([tvm_ffi.Array([1, 2]), tvm_ffi.Array([3, 5])])
+    a = ffi.Array([ffi.Array([1, 2]), ffi.Array([3, 4])])
+    b = ffi.Array([ffi.Array([1, 2]), ffi.Array([3, 4])])
+    c = ffi.Array([ffi.Array([1, 2]), ffi.Array([3, 5])])
     assert RecursiveEq(a, b)
     assert not RecursiveEq(a, c)
 
 
 def test_array_of_arrays_ordering() -> None:
-    a = tvm_ffi.Array([tvm_ffi.Array([1, 2]), tvm_ffi.Array([3, 4])])
-    b = tvm_ffi.Array([tvm_ffi.Array([1, 2]), tvm_ffi.Array([3, 5])])
+    a = ffi.Array([ffi.Array([1, 2]), ffi.Array([3, 4])])
+    b = ffi.Array([ffi.Array([1, 2]), ffi.Array([3, 5])])
     assert RecursiveLt(a, b)  # differ at depth-2: 4 < 5
     assert not RecursiveLt(b, a)
 
 
 def test_list_of_lists_eq() -> None:
-    a = tvm_ffi.List([tvm_ffi.List([1, 2]), tvm_ffi.List([3])])
-    b = tvm_ffi.List([tvm_ffi.List([1, 2]), tvm_ffi.List([3])])
-    c = tvm_ffi.List([tvm_ffi.List([1, 2]), tvm_ffi.List([4])])
+    a = ffi.List([ffi.List([1, 2]), ffi.List([3])])
+    b = ffi.List([ffi.List([1, 2]), ffi.List([3])])
+    c = ffi.List([ffi.List([1, 2]), ffi.List([4])])
     assert RecursiveEq(a, b)
     assert not RecursiveEq(a, c)
 
 
 def test_array_of_shapes() -> None:
-    a = tvm_ffi.Array([tvm_ffi.Shape((1, 2)), tvm_ffi.Shape((3, 4))])
-    b = tvm_ffi.Array([tvm_ffi.Shape((1, 2)), tvm_ffi.Shape((3, 4))])
-    c = tvm_ffi.Array([tvm_ffi.Shape((1, 2)), tvm_ffi.Shape((3, 5))])
+    a = ffi.Array([ffi.Shape((1, 2)), ffi.Shape((3, 4))])
+    b = ffi.Array([ffi.Shape((1, 2)), ffi.Shape((3, 4))])
+    c = ffi.Array([ffi.Shape((1, 2)), ffi.Shape((3, 5))])
     assert RecursiveEq(a, b)
     assert not RecursiveEq(a, c)
     assert RecursiveLt(a, c)
 
 
 def test_array_of_arrays_different_inner_lengths() -> None:
-    a = tvm_ffi.Array([tvm_ffi.Array([1, 2])])
-    b = tvm_ffi.Array([tvm_ffi.Array([1, 2, 3])])
+    a = ffi.Array([ffi.Array([1, 2])])
+    b = ffi.Array([ffi.Array([1, 2, 3])])
     assert not RecursiveEq(a, b)
     assert RecursiveLt(a, b)  # inner [1,2] < [1,2,3]
 
 
 def test_three_level_nested_containers() -> None:
-    a = tvm_ffi.Array([tvm_ffi.Array([tvm_ffi.Array([1])])])
-    b = tvm_ffi.Array([tvm_ffi.Array([tvm_ffi.Array([1])])])
-    c = tvm_ffi.Array([tvm_ffi.Array([tvm_ffi.Array([2])])])
+    a = ffi.Array([ffi.Array([ffi.Array([1])])])
+    b = ffi.Array([ffi.Array([ffi.Array([1])])])
+    c = ffi.Array([ffi.Array([ffi.Array([2])])])
     assert RecursiveEq(a, b)
     assert not RecursiveEq(a, c)
     assert RecursiveLt(a, c)
@@ -625,16 +625,16 @@ def test_object_with_array_field_eq() -> None:
         v_i64=1,
         v_f64=2.0,
         v_str="s",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([10, 20, 30]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([10, 20, 30]),
     )
     b = create_object(
         "testing.TestObjectDerived",
         v_i64=1,
         v_f64=2.0,
         v_str="s",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([10, 20, 30]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([10, 20, 30]),
     )
     assert RecursiveEq(a, b)
 
@@ -645,16 +645,16 @@ def test_object_with_array_field_differ() -> None:
         v_i64=1,
         v_f64=2.0,
         v_str="s",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([10, 20]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([10, 20]),
     )
     b = create_object(
         "testing.TestObjectDerived",
         v_i64=1,
         v_f64=2.0,
         v_str="s",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([10, 21]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([10, 21]),
     )
     assert not RecursiveEq(a, b)
     assert RecursiveLt(a, b)
@@ -666,16 +666,16 @@ def test_object_with_map_field_eq() -> None:
         v_i64=1,
         v_f64=2.0,
         v_str="s",
-        v_map=tvm_ffi.Map({"a": 1, "b": 2}),
-        v_array=tvm_ffi.Array([]),
+        v_map=ffi.Map({"a": 1, "b": 2}),
+        v_array=ffi.Array([]),
     )
     b = create_object(
         "testing.TestObjectDerived",
         v_i64=1,
         v_f64=2.0,
         v_str="s",
-        v_map=tvm_ffi.Map({"a": 1, "b": 2}),
-        v_array=tvm_ffi.Array([]),
+        v_map=ffi.Map({"a": 1, "b": 2}),
+        v_array=ffi.Array([]),
     )
     assert RecursiveEq(a, b)
 
@@ -686,16 +686,16 @@ def test_object_with_map_field_differ() -> None:
         v_i64=1,
         v_f64=2.0,
         v_str="s",
-        v_map=tvm_ffi.Map({"a": 1}),
-        v_array=tvm_ffi.Array([]),
+        v_map=ffi.Map({"a": 1}),
+        v_array=ffi.Array([]),
     )
     b = create_object(
         "testing.TestObjectDerived",
         v_i64=1,
         v_f64=2.0,
         v_str="s",
-        v_map=tvm_ffi.Map({"a": 2}),
-        v_array=tvm_ffi.Array([]),
+        v_map=ffi.Map({"a": 2}),
+        v_array=ffi.Array([]),
     )
     assert not RecursiveEq(a, b)
 
@@ -707,16 +707,16 @@ def test_object_primitive_field_differ_short_circuits() -> None:
         v_i64=1,
         v_f64=2.0,
         v_str="s",
-        v_map=tvm_ffi.Map({"k": 1}),
-        v_array=tvm_ffi.Array([1]),
+        v_map=ffi.Map({"k": 1}),
+        v_array=ffi.Array([1]),
     )
     b = create_object(
         "testing.TestObjectDerived",
         v_i64=2,
         v_f64=2.0,
         v_str="s",
-        v_map=tvm_ffi.Map({"k": 1}),
-        v_array=tvm_ffi.Array([1]),
+        v_map=ffi.Map({"k": 1}),
+        v_array=ffi.Array([1]),
     )
     assert not RecursiveEq(a, b)
     assert RecursiveLt(a, b)  # ordering uses v_i64: 1 < 2
@@ -733,8 +733,8 @@ def test_object_array_of_objects() -> None:
         v_i64=0,
         v_f64=0.0,
         v_str="",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array(
+        v_map=ffi.Map({}),
+        v_array=ffi.Array(
             [
                 TestIntPair(1, 2),
                 TestIntPair(3, 4),
@@ -746,8 +746,8 @@ def test_object_array_of_objects() -> None:
         v_i64=0,
         v_f64=0.0,
         v_str="",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array(
+        v_map=ffi.Map({}),
+        v_array=ffi.Array(
             [
                 TestIntPair(1, 2),
                 TestIntPair(3, 4),
@@ -763,8 +763,8 @@ def test_object_array_of_objects_differ() -> None:
         v_i64=0,
         v_f64=0.0,
         v_str="",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array(
+        v_map=ffi.Map({}),
+        v_array=ffi.Array(
             [
                 TestIntPair(1, 2),
                 TestIntPair(3, 4),
@@ -776,8 +776,8 @@ def test_object_array_of_objects_differ() -> None:
         v_i64=0,
         v_f64=0.0,
         v_str="",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array(
+        v_map=ffi.Map({}),
+        v_array=ffi.Array(
             [
                 TestIntPair(1, 2),
                 TestIntPair(3, 5),
@@ -794,24 +794,24 @@ def test_object_map_with_object_values() -> None:
         v_i64=0,
         v_f64=0.0,
         v_str="",
-        v_map=tvm_ffi.Map(
+        v_map=ffi.Map(
             {
                 "x": TestIntPair(1, 2),
             }
         ),
-        v_array=tvm_ffi.Array([]),
+        v_array=ffi.Array([]),
     )
     b = create_object(
         "testing.TestObjectDerived",
         v_i64=0,
         v_f64=0.0,
         v_str="",
-        v_map=tvm_ffi.Map(
+        v_map=ffi.Map(
             {
                 "x": TestIntPair(1, 2),
             }
         ),
-        v_array=tvm_ffi.Array([]),
+        v_array=ffi.Array([]),
     )
     assert RecursiveEq(a, b)
 
@@ -823,32 +823,32 @@ def test_deep_object_in_object() -> None:
         v_i64=1,
         v_f64=1.0,
         v_str="inner",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([42]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([42]),
     )
     a = create_object(
         "testing.TestObjectDerived",
         v_i64=0,
         v_f64=0.0,
         v_str="outer",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([inner_a]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([inner_a]),
     )
     inner_b = create_object(
         "testing.TestObjectDerived",
         v_i64=1,
         v_f64=1.0,
         v_str="inner",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([42]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([42]),
     )
     b = create_object(
         "testing.TestObjectDerived",
         v_i64=0,
         v_f64=0.0,
         v_str="outer",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([inner_b]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([inner_b]),
     )
     assert RecursiveEq(a, b)
 
@@ -886,13 +886,13 @@ def test_three_level_inheritance_eq_and_differ() -> None:
 
 
 def test_compare_off_inside_array() -> None:
-    a = tvm_ffi.Array(
+    a = ffi.Array(
         [
             TestCompare(1, "x", 100),
             TestCompare(2, "y", 200),
         ]
     )
-    b = tvm_ffi.Array(
+    b = ffi.Array(
         [
             TestCompare(1, "x", 999),
             TestCompare(2, "y", 888),
@@ -908,8 +908,8 @@ def test_compare_off_inside_nested_object() -> None:
         v_i64=0,
         v_f64=0.0,
         v_str="",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array(
+        v_map=ffi.Map({}),
+        v_array=ffi.Array(
             [
                 TestCompare(1, "n", 100),
             ]
@@ -920,8 +920,8 @@ def test_compare_off_inside_nested_object() -> None:
         v_i64=0,
         v_f64=0.0,
         v_str="",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array(
+        v_map=ffi.Map({}),
+        v_array=ffi.Array(
             [
                 TestCompare(1, "n", 999),
             ]
@@ -942,25 +942,25 @@ def test_object_with_short_vs_long_string_field() -> None:
         v_i64=0,
         v_f64=0.0,
         v_str="hi",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([]),
     )
     b = create_object(
         "testing.TestObjectDerived",
         v_i64=0,
         v_f64=0.0,
         v_str="a_very_long_string",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([]),
     )
     assert not RecursiveEq(a, b)
 
 
 def test_array_of_mixed_length_strings() -> None:
     """Array mixing SmallStr (<=7 bytes) and Str (>7 bytes)."""
-    a = tvm_ffi.Array(["hi", "a_very_long_string", "ok"])
-    b = tvm_ffi.Array(["hi", "a_very_long_string", "ok"])
-    c = tvm_ffi.Array(["hi", "a_very_long_string", "zz"])
+    a = ffi.Array(["hi", "a_very_long_string", "ok"])
+    b = ffi.Array(["hi", "a_very_long_string", "ok"])
+    c = ffi.Array(["hi", "a_very_long_string", "zz"])
     assert RecursiveEq(a, b)
     assert not RecursiveEq(a, c)
     assert RecursiveLt(a, c)
@@ -972,25 +972,25 @@ def test_array_of_mixed_length_strings() -> None:
 
 
 def test_map_with_array_values_eq() -> None:
-    a = tvm_ffi.Map({"k": tvm_ffi.Array([1, 2])})
-    b = tvm_ffi.Map({"k": tvm_ffi.Array([1, 2])})
-    c = tvm_ffi.Map({"k": tvm_ffi.Array([1, 3])})
+    a = ffi.Map({"k": ffi.Array([1, 2])})
+    b = ffi.Map({"k": ffi.Array([1, 2])})
+    c = ffi.Map({"k": ffi.Array([1, 3])})
     assert RecursiveEq(a, b)
     assert not RecursiveEq(a, c)
 
 
 def test_dict_with_object_values_eq() -> None:
-    a = tvm_ffi.Dict(
+    a = ffi.Dict(
         {
             "k": TestIntPair(1, 2),
         }
     )
-    b = tvm_ffi.Dict(
+    b = ffi.Dict(
         {
             "k": TestIntPair(1, 2),
         }
     )
-    c = tvm_ffi.Dict(
+    c = ffi.Dict(
         {
             "k": TestIntPair(1, 3),
         }
@@ -1005,9 +1005,9 @@ def test_dict_with_object_values_eq() -> None:
 
 
 def test_array_with_none_elements() -> None:
-    a = tvm_ffi.Array([None, 1, None])
-    b = tvm_ffi.Array([None, 1, None])
-    c = tvm_ffi.Array([None, 2, None])
+    a = ffi.Array([None, 1, None])
+    b = ffi.Array([None, 1, None])
+    c = ffi.Array([None, 2, None])
     assert RecursiveEq(a, b)
     assert not RecursiveEq(a, c)
     assert RecursiveLt(a, c)  # element 1: 1 < 2
@@ -1019,16 +1019,16 @@ def test_object_with_none_in_array_field() -> None:
         v_i64=0,
         v_f64=0.0,
         v_str="",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([None, 1]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([None, 1]),
     )
     b = create_object(
         "testing.TestObjectDerived",
         v_i64=0,
         v_f64=0.0,
         v_str="",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([None, 1]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([None, 1]),
     )
     assert RecursiveEq(a, b)
 
@@ -1039,16 +1039,16 @@ def test_object_with_none_in_array_field() -> None:
 
 
 def test_array_list_type_mismatch() -> None:
-    arr = tvm_ffi.Array([1, 2])
-    lst = tvm_ffi.List([1, 2])
+    arr = ffi.Array([1, 2])
+    lst = ffi.List([1, 2])
     assert not RecursiveEq(arr, lst)
     with pytest.raises(TypeError):
         RecursiveLt(arr, lst)
 
 
 def test_map_dict_type_mismatch() -> None:
-    m = tvm_ffi.Map({"k": 1})
-    d = tvm_ffi.Dict({"k": 1})
+    m = ffi.Map({"k": 1})
+    d = ffi.Dict({"k": 1})
     assert not RecursiveEq(m, d)
     with pytest.raises(TypeError):
         RecursiveLt(m, d)
@@ -1060,14 +1060,14 @@ def test_function_objects_compare_equal() -> None:
     This is by design: reflection-based comparison only considers reflected fields,
     and Function has none.
     """
-    f_add_one = tvm_ffi.get_global_func("testing.add_one")
-    f_nop = tvm_ffi.get_global_func("testing.nop")
+    f_add_one = ffi.get_global_func("testing.add_one")
+    f_nop = ffi.get_global_func("testing.nop")
     assert RecursiveEq(f_add_one, f_nop)
 
 
 def test_function_same_pointer_eq() -> None:
     """Same function object compared with itself returns True via pointer identity."""
-    f = tvm_ffi.get_global_func("testing.add_one")
+    f = ffi.get_global_func("testing.add_one")
     assert RecursiveEq(f, f)
 
 
@@ -1078,7 +1078,7 @@ def test_function_same_pointer_eq() -> None:
 
 def test_cyclic_list_same_pointer_eq() -> None:
     """Same cyclic list compared with itself returns True via pointer identity."""
-    lst = tvm_ffi.List()
+    lst = ffi.List()
     lst.append(lst)
     assert RecursiveEq(lst, lst)
 
@@ -1089,8 +1089,8 @@ def test_cyclic_list_eq_returns_true() -> None:
     In eq-only mode, the cycle detector treats a re-encountered (lhs, rhs) pair
     as equal, allowing the recursion to terminate.
     """
-    a = tvm_ffi.List()
-    b = tvm_ffi.List()
+    a = ffi.List()
+    b = ffi.List()
     a.append(a)
     b.append(b)
     assert RecursiveEq(a, b)
@@ -1098,8 +1098,8 @@ def test_cyclic_list_eq_returns_true() -> None:
 
 def test_cyclic_list_ordering_raises() -> None:
     """Ordering two distinct cyclic lists raises ValueError."""
-    a = tvm_ffi.List()
-    b = tvm_ffi.List()
+    a = ffi.List()
+    b = ffi.List()
     a.append(a)
     b.append(b)
     with pytest.raises(ValueError, match="cyclic reference"):
@@ -1112,8 +1112,8 @@ def test_cyclic_dict_eq_returns_true() -> None:
     In eq-only mode, the cycle detector treats a re-encountered (lhs, rhs) pair
     as equal, allowing the recursion to terminate.
     """
-    a = tvm_ffi.Dict()
-    b = tvm_ffi.Dict()
+    a = ffi.Dict()
+    b = ffi.Dict()
     a["self"] = a
     b["self"] = b
     assert RecursiveEq(a, b)
@@ -1121,8 +1121,8 @@ def test_cyclic_dict_eq_returns_true() -> None:
 
 def test_cyclic_dict_ordering_raises() -> None:
     """Ordering two distinct cyclic dicts raises ValueError."""
-    a = tvm_ffi.Dict()
-    b = tvm_ffi.Dict()
+    a = ffi.Dict()
+    b = ffi.Dict()
     a["self"] = a
     b["self"] = b
     with pytest.raises(ValueError, match="cyclic reference"):
@@ -1176,7 +1176,7 @@ def test_ordering_laws_on_int_pairs() -> None:
 def _make_nested_singleton_array(depth: int) -> object:
     value: object = 0
     for _ in range(depth):
-        value = tvm_ffi.Array([value])
+        value = ffi.Array([value])
     return value
 
 
@@ -1215,13 +1215,13 @@ def test_custom_compare_ordering() -> None:
 
 def test_custom_eq_in_container() -> None:
     """Custom-hooked objects inside an Array."""
-    a = tvm_ffi.Array(
+    a = ffi.Array(
         [
             TestCustomCompare(1, "x"),
             TestCustomCompare(2, "y"),
         ]
     )
-    b = tvm_ffi.Array(
+    b = ffi.Array(
         [
             TestCustomCompare(1, "different"),
             TestCustomCompare(2, "labels"),

--- a/tests/python/test_dataclass_copy.py
+++ b/tests/python/test_dataclass_copy.py
@@ -26,7 +26,7 @@ import sys
 from typing import Dict, List, Optional
 
 import pytest
-import tvm_ffi
+import tvm_ffi as ffi
 import tvm_ffi.testing
 from tvm_ffi._ffi_api import DeepCopy
 from tvm_ffi.core import Object
@@ -48,18 +48,18 @@ class TestShallowCopy:
     """Tests for copy.copy() / __copy__."""
 
     def test_basic_fields(self) -> None:
-        pair = tvm_ffi.testing.TestIntPair(1, 2)
+        pair = ffi.testing.TestIntPair(1, 2)
         pair_copy = copy.copy(pair)
         assert pair_copy.a == 1
         assert pair_copy.b == 2
 
     def test_creates_new_object(self) -> None:
-        pair = tvm_ffi.testing.TestIntPair(3, 7)
+        pair = ffi.testing.TestIntPair(3, 7)
         pair_copy = copy.copy(pair)
         assert not pair.same_as(pair_copy)
 
     def test_mutable_fields(self) -> None:
-        obj = tvm_ffi.testing.create_object("testing.TestObjectBase", v_i64=42, v_str="hello")
+        obj = ffi.testing.create_object("testing.TestObjectBase", v_i64=42, v_str="hello")
         obj_copy = copy.copy(obj)
         assert obj_copy.v_i64 == 42  # ty: ignore[unresolved-attribute]
         assert obj_copy.v_str == "hello"  # ty: ignore[unresolved-attribute]
@@ -67,7 +67,7 @@ class TestShallowCopy:
         assert not obj.same_as(obj_copy)
 
     def test_mutating_copy_does_not_affect_original(self) -> None:
-        obj = tvm_ffi.testing.create_object("testing.TestObjectBase", v_i64=1, v_str="a")
+        obj = ffi.testing.create_object("testing.TestObjectBase", v_i64=1, v_str="a")
         obj_copy = copy.copy(obj)
         obj_copy.v_i64 = 99  # ty: ignore[unresolved-attribute]
         obj_copy.v_str = "z"  # ty: ignore[unresolved-attribute]
@@ -75,9 +75,9 @@ class TestShallowCopy:
         assert obj.v_str == "a"  # ty: ignore[unresolved-attribute]
 
     def test_derived_type_preserves_type(self) -> None:
-        v_map = tvm_ffi.convert({"k": 1})
-        v_array = tvm_ffi.convert([1, 2])
-        obj = tvm_ffi.testing.create_object(
+        v_map = ffi.convert({"k": 1})
+        v_array = ffi.convert([1, 2])
+        obj = ffi.testing.create_object(
             "testing.TestObjectDerived",
             v_i64=5,
             v_map=v_map,
@@ -85,7 +85,7 @@ class TestShallowCopy:
         )
         obj_copy = copy.copy(obj)
         assert not obj.same_as(obj_copy)
-        assert isinstance(obj_copy, tvm_ffi.testing.TestObjectDerived)
+        assert isinstance(obj_copy, ffi.testing.TestObjectDerived)
         assert obj_copy.v_i64 == 5
         # shallow copy shares sub-objects
         assert obj_copy.v_map.same_as(obj.v_map)  # ty: ignore[unresolved-attribute]
@@ -94,14 +94,14 @@ class TestShallowCopy:
     def test_auto_copy_for_cxx_class(self) -> None:
         # _TestCxxClassBase is copy-constructible, so copy is auto-enabled
         # Note: _TestCxxClassBase.__init__ adds 1 to v_i64 and 2 to v_i32
-        obj = tvm_ffi.testing._TestCxxClassBase(v_i64=1, v_i32=2)
+        obj = ffi.testing._TestCxxClassBase(v_i64=1, v_i32=2)
         obj_copy = copy.copy(obj)
         assert obj_copy.v_i64 == 2
         assert obj_copy.v_i32 == 4
         assert not obj.same_as(obj_copy)
 
     def test_non_copyable_type_raises(self) -> None:
-        obj = tvm_ffi.testing.TestNonCopyable(42)
+        obj = ffi.testing.TestNonCopyable(42)
         with pytest.raises(TypeError, match="does not support copy"):
             copy.copy(obj)
 
@@ -113,17 +113,17 @@ class TestDeepCopy:
     """Tests for copy.deepcopy() / __deepcopy__."""
 
     def test_basic_fields(self) -> None:
-        pair = tvm_ffi.testing.TestIntPair(5, 10)
+        pair = ffi.testing.TestIntPair(5, 10)
         pair_deep = copy.deepcopy(pair)
         assert pair_deep.a == 5
         assert pair_deep.b == 10
         assert not pair.same_as(pair_deep)
 
     def test_nested_objects_are_copied(self) -> None:
-        inner = tvm_ffi.testing.TestIntPair(1, 2)
-        v_array = tvm_ffi.convert([inner])
-        v_map = tvm_ffi.convert({"x": "y"})
-        obj = tvm_ffi.testing.create_object(
+        inner = ffi.testing.TestIntPair(1, 2)
+        v_array = ffi.convert([inner])
+        v_map = ffi.convert({"x": "y"})
+        obj = ffi.testing.create_object(
             "testing.TestObjectDerived",
             v_i64=10,
             v_map=v_map,
@@ -140,10 +140,10 @@ class TestDeepCopy:
 
     def test_shared_references_preserved(self) -> None:
         """Two array slots pointing to the same object should still share after deepcopy."""
-        shared = tvm_ffi.testing.TestIntPair(7, 8)
-        v_array = tvm_ffi.convert([shared, shared])
-        v_map = tvm_ffi.convert({"a": "b"})
-        obj = tvm_ffi.testing.create_object(
+        shared = ffi.testing.TestIntPair(7, 8)
+        v_array = ffi.convert([shared, shared])
+        v_map = ffi.convert({"a": "b"})
+        obj = ffi.testing.create_object(
             "testing.TestObjectDerived",
             v_i64=1,
             v_map=v_map,
@@ -159,10 +159,10 @@ class TestDeepCopy:
 
     def test_shared_containers_preserved(self) -> None:
         """Two array slots pointing to the same container should still share after deepcopy."""
-        inner = tvm_ffi.convert([1, 2, 3])
-        v_array = tvm_ffi.convert([inner, inner])
-        v_map = tvm_ffi.convert({"a": "b"})
-        obj = tvm_ffi.testing.create_object(
+        inner = ffi.convert([1, 2, 3])
+        v_array = ffi.convert([inner, inner])
+        v_map = ffi.convert({"a": "b"})
+        obj = ffi.testing.create_object(
             "testing.TestObjectDerived",
             v_i64=1,
             v_map=v_map,
@@ -177,7 +177,7 @@ class TestDeepCopy:
         assert not obj.v_array[0].same_as(obj_deep.v_array[0])  # ty: ignore[unresolved-attribute]
 
     def test_original_untouched(self) -> None:
-        obj = tvm_ffi.testing.create_object("testing.TestObjectBase", v_i64=42, v_str="original")
+        obj = ffi.testing.create_object("testing.TestObjectBase", v_i64=42, v_str="original")
         obj_deep = copy.deepcopy(obj)
         obj_deep.v_i64 = 0  # ty: ignore[unresolved-attribute]
         obj_deep.v_str = "modified"  # ty: ignore[unresolved-attribute]
@@ -186,15 +186,15 @@ class TestDeepCopy:
 
     def test_self_referencing_cycle(self) -> None:
         """An object whose array field contains itself should deepcopy correctly."""
-        v_map = tvm_ffi.convert({"a": "b"})
-        obj = tvm_ffi.testing.create_object(
+        v_map = ffi.convert({"a": "b"})
+        obj = ffi.testing.create_object(
             "testing.TestObjectDerived",
             v_i64=1,
             v_map=v_map,
-            v_array=tvm_ffi.convert([]),
+            v_array=ffi.convert([]),
         )
         # Create self-reference: obj.v_array = [obj]
-        obj.v_array = tvm_ffi.convert([obj])  # ty: ignore[unresolved-attribute]
+        obj.v_array = ffi.convert([obj])  # ty: ignore[unresolved-attribute]
 
         obj_deep = copy.deepcopy(obj)
         assert not obj.same_as(obj_deep)
@@ -203,21 +203,21 @@ class TestDeepCopy:
 
     def test_mutual_reference_cycle(self) -> None:
         """Two objects referencing each other should deepcopy with cycle preserved."""
-        v_map = tvm_ffi.convert({"a": "b"})
-        obj_a = tvm_ffi.testing.create_object(
+        v_map = ffi.convert({"a": "b"})
+        obj_a = ffi.testing.create_object(
             "testing.TestObjectDerived",
             v_i64=1,
             v_map=v_map,
-            v_array=tvm_ffi.convert([]),
+            v_array=ffi.convert([]),
         )
-        obj_b = tvm_ffi.testing.create_object(
+        obj_b = ffi.testing.create_object(
             "testing.TestObjectDerived",
             v_i64=2,
             v_map=v_map,
-            v_array=tvm_ffi.convert([obj_a]),
+            v_array=ffi.convert([obj_a]),
         )
         # Close the cycle: A -> B and B -> A
-        obj_a.v_array = tvm_ffi.convert([obj_b])  # ty: ignore[unresolved-attribute]
+        obj_a.v_array = ffi.convert([obj_b])  # ty: ignore[unresolved-attribute]
 
         deep_a = copy.deepcopy(obj_a)
         assert not obj_a.same_as(deep_a)
@@ -232,8 +232,8 @@ class TestDeepCopy:
 
     def test_array_root(self) -> None:
         """Deepcopy with a bare Array as root should create a new array."""
-        inner = tvm_ffi.testing.TestIntPair(1, 2)
-        arr = tvm_ffi.convert([inner, "hello", 42])
+        inner = ffi.testing.TestIntPair(1, 2)
+        arr = ffi.convert([inner, "hello", 42])
         arr_deep = copy.deepcopy(arr)
         assert not arr.same_as(arr_deep)
         # inner object is deep-copied
@@ -245,8 +245,8 @@ class TestDeepCopy:
 
     def test_map_root(self) -> None:
         """Deepcopy with a bare Map as root should create a new map."""
-        inner = tvm_ffi.testing.TestIntPair(3, 4)
-        m = tvm_ffi.convert({"key": inner})
+        inner = ffi.testing.TestIntPair(3, 4)
+        m = ffi.convert({"key": inner})
         m_deep = copy.deepcopy(m)
         assert not m.same_as(m_deep)
         # inner object is deep-copied
@@ -255,8 +255,8 @@ class TestDeepCopy:
 
     def test_dict_root(self) -> None:
         """Deepcopy with a bare Dict as root should create a new dict."""
-        inner = tvm_ffi.testing.TestIntPair(3, 4)
-        d = tvm_ffi.Dict({"key": inner})
+        inner = ffi.testing.TestIntPair(3, 4)
+        d = ffi.Dict({"key": inner})
         d_deep = copy.deepcopy(d)
         assert not d.same_as(d_deep)
         # inner object is deep-copied
@@ -266,14 +266,14 @@ class TestDeepCopy:
     def test_auto_deepcopy_for_cxx_class(self) -> None:
         # _TestCxxClassBase is copy-constructible, so deepcopy is auto-enabled
         # Note: _TestCxxClassBase.__init__ adds 1 to v_i64 and 2 to v_i32
-        obj = tvm_ffi.testing._TestCxxClassBase(v_i64=1, v_i32=2)
+        obj = ffi.testing._TestCxxClassBase(v_i64=1, v_i32=2)
         obj_deep = copy.deepcopy(obj)
         assert obj_deep.v_i64 == 2
         assert obj_deep.v_i32 == 4
         assert not obj.same_as(obj_deep)
 
     def test_non_copyable_type_raises(self) -> None:
-        obj = tvm_ffi.testing.TestNonCopyable(42)
+        obj = ffi.testing.TestNonCopyable(42)
         with pytest.raises(TypeError, match="does not support deepcopy"):
             copy.deepcopy(obj)
 
@@ -282,7 +282,7 @@ class TestDeepCopy:
         deepcopy must treat them as immutable terminals, not call CopyObject.
         """
         long_str = "a" * 100
-        arr = tvm_ffi.convert([long_str])
+        arr = ffi.convert([long_str])
         arr_deep = copy.deepcopy(arr)
         assert not arr.same_as(arr_deep)
         assert arr_deep[0] == long_str
@@ -290,14 +290,14 @@ class TestDeepCopy:
     def test_long_string_in_object_field(self) -> None:
         """Heap-allocated string as a field value should survive deepcopy."""
         long_str = "x" * 200
-        obj = tvm_ffi.testing.create_object("testing.TestObjectBase", v_i64=1, v_str=long_str)
+        obj = ffi.testing.create_object("testing.TestObjectBase", v_i64=1, v_str=long_str)
         obj_deep = copy.deepcopy(obj)
         assert obj_deep.v_str == long_str  # ty: ignore[unresolved-attribute]
 
     def test_any_field_with_object(self) -> None:
         """Any-typed field containing an object must be recursively copied."""
-        inner = tvm_ffi.testing.TestIntPair(3, 4)
-        obj = tvm_ffi.testing.create_object("testing.TestDeepCopyEdges", v_any=inner, v_obj=inner)
+        inner = ffi.testing.TestIntPair(3, 4)
+        obj = ffi.testing.create_object("testing.TestDeepCopyEdges", v_any=inner, v_obj=inner)
         obj_deep = copy.deepcopy(obj)
         assert not obj.same_as(obj_deep)
         assert not inner.same_as(obj_deep.v_any)  # ty: ignore[unresolved-attribute]
@@ -305,8 +305,8 @@ class TestDeepCopy:
 
     def test_any_field_with_array(self) -> None:
         """Any-typed field containing an Array must be recursively copied."""
-        inner_arr = tvm_ffi.convert([1, 2, 3])
-        obj = tvm_ffi.testing.create_object(
+        inner_arr = ffi.convert([1, 2, 3])
+        obj = ffi.testing.create_object(
             "testing.TestDeepCopyEdges", v_any=inner_arr, v_obj=inner_arr
         )
         obj_deep = copy.deepcopy(obj)
@@ -315,8 +315,8 @@ class TestDeepCopy:
 
     def test_any_field_with_map(self) -> None:
         """Any-typed field containing a Map must be recursively copied."""
-        inner_map = tvm_ffi.convert({"k": "v"})
-        obj = tvm_ffi.testing.create_object(
+        inner_map = ffi.convert({"k": "v"})
+        obj = ffi.testing.create_object(
             "testing.TestDeepCopyEdges", v_any=inner_map, v_obj=inner_map
         )
         obj_deep = copy.deepcopy(obj)
@@ -325,28 +325,24 @@ class TestDeepCopy:
 
     def test_objectref_field_with_array(self) -> None:
         """ObjectRef field holding runtime Array must go through Resolve."""
-        inner_arr = tvm_ffi.convert([10, 20])
-        obj = tvm_ffi.testing.create_object(
-            "testing.TestDeepCopyEdges", v_any=None, v_obj=inner_arr
-        )
+        inner_arr = ffi.convert([10, 20])
+        obj = ffi.testing.create_object("testing.TestDeepCopyEdges", v_any=None, v_obj=inner_arr)
         obj_deep = copy.deepcopy(obj)
         assert not inner_arr.same_as(obj_deep.v_obj)  # ty: ignore[unresolved-attribute]
         assert list(obj_deep.v_obj) == [10, 20]  # ty: ignore[unresolved-attribute]
 
     def test_objectref_field_with_map(self) -> None:
         """ObjectRef field holding runtime Map must go through Resolve."""
-        inner_map = tvm_ffi.convert({"a": 1})
-        obj = tvm_ffi.testing.create_object(
-            "testing.TestDeepCopyEdges", v_any=None, v_obj=inner_map
-        )
+        inner_map = ffi.convert({"a": 1})
+        obj = ffi.testing.create_object("testing.TestDeepCopyEdges", v_any=None, v_obj=inner_map)
         obj_deep = copy.deepcopy(obj)
         assert not inner_map.same_as(obj_deep.v_obj)  # ty: ignore[unresolved-attribute]
         assert obj_deep.v_obj["a"] == 1  # ty: ignore[unresolved-attribute]
 
     def test_any_field_sharing_preserved(self) -> None:
         """Shared references through Any and ObjectRef fields are preserved."""
-        shared = tvm_ffi.testing.TestIntPair(5, 6)
-        obj = tvm_ffi.testing.create_object("testing.TestDeepCopyEdges", v_any=shared, v_obj=shared)
+        shared = ffi.testing.TestIntPair(5, 6)
+        obj = ffi.testing.create_object("testing.TestDeepCopyEdges", v_any=shared, v_obj=shared)
         obj_deep = copy.deepcopy(obj)
         # Both fields should point to the same copied object
         assert obj_deep.v_any.same_as(obj_deep.v_obj)  # ty: ignore[unresolved-attribute]
@@ -356,7 +352,7 @@ class TestDeepCopy:
 # --------------------------------------------------------------------------- #
 #  Deep copy branch coverage (C++ dataclass.cc)
 # --------------------------------------------------------------------------- #
-_deep_copy = tvm_ffi.get_global_func("ffi.DeepCopy")
+_deep_copy = ffi.get_global_func("ffi.DeepCopy")
 
 
 class TestDeepCopyBranches:
@@ -385,19 +381,19 @@ class TestDeepCopyBranches:
 
     def test_array_all_ints(self) -> None:
         """All elements are primitives — Resolve() returns each as-is."""
-        arr = tvm_ffi.convert([1, 2, 3])
+        arr = ffi.convert([1, 2, 3])
         arr_deep = copy.deepcopy(arr)
         assert not arr.same_as(arr_deep)
         assert list(arr_deep) == [1, 2, 3]
 
     def test_array_all_strings(self) -> None:
-        arr = tvm_ffi.convert(["a", "bb", "ccc"])
+        arr = ffi.convert(["a", "bb", "ccc"])
         arr_deep = copy.deepcopy(arr)
         assert not arr.same_as(arr_deep)
         assert list(arr_deep) == ["a", "bb", "ccc"]
 
     def test_array_with_none_elements(self) -> None:
-        arr = tvm_ffi.convert([None, 1, None])
+        arr = ffi.convert([None, 1, None])
         arr_deep = copy.deepcopy(arr)
         assert arr_deep[0] is None
         assert arr_deep[1] == 1
@@ -405,7 +401,7 @@ class TestDeepCopyBranches:
 
     def test_array_mixed_primitive_types(self) -> None:
         """Array with int, float, str, bool, None — all primitives."""
-        arr = tvm_ffi.convert([42, 3.14, "hi", True, None])
+        arr = ffi.convert([42, 3.14, "hi", True, None])
         arr_deep = copy.deepcopy(arr)
         assert not arr.same_as(arr_deep)
         assert arr_deep[0] == 42
@@ -416,10 +412,10 @@ class TestDeepCopyBranches:
 
     def test_array_mixed_with_objects_and_containers(self) -> None:
         """Array with int, str, None, object, nested array, nested map."""
-        inner_obj = tvm_ffi.testing.TestIntPair(1, 2)
-        inner_arr = tvm_ffi.convert([10, 20])
-        inner_map = tvm_ffi.convert({"k": "v"})
-        arr = tvm_ffi.convert([42, "hello", None, inner_obj, inner_arr, inner_map])
+        inner_obj = ffi.testing.TestIntPair(1, 2)
+        inner_arr = ffi.convert([10, 20])
+        inner_map = ffi.convert({"k": "v"})
+        arr = ffi.convert([42, "hello", None, inner_obj, inner_arr, inner_map])
         arr_deep = copy.deepcopy(arr)
         # primitives pass through
         assert arr_deep[0] == 42
@@ -436,16 +432,16 @@ class TestDeepCopyBranches:
         assert arr_deep[5]["k"] == "v"
 
     def test_array_empty(self) -> None:
-        arr = tvm_ffi.convert([])
+        arr = ffi.convert([])
         arr_deep = copy.deepcopy(arr)
         assert not arr.same_as(arr_deep)
         assert len(arr_deep) == 0
 
     def test_array_nested_arrays(self) -> None:
         """Array of arrays — Resolve() recurses into each nested array."""
-        a = tvm_ffi.convert([1, 2])
-        b = tvm_ffi.convert([3, 4])
-        outer = tvm_ffi.convert([a, b])
+        a = ffi.convert([1, 2])
+        b = ffi.convert([3, 4])
+        outer = ffi.convert([a, b])
         outer_deep = copy.deepcopy(outer)
         assert not outer.same_as(outer_deep)
         assert not outer[0].same_as(outer_deep[0])
@@ -455,8 +451,8 @@ class TestDeepCopyBranches:
 
     def test_array_nested_maps(self) -> None:
         """Array of maps."""
-        m = tvm_ffi.convert({"x": 1})
-        arr = tvm_ffi.convert([m])
+        m = ffi.convert({"x": 1})
+        arr = ffi.convert([m])
         arr_deep = copy.deepcopy(arr)
         assert not arr[0].same_as(arr_deep[0])
         assert arr_deep[0]["x"] == 1
@@ -464,7 +460,7 @@ class TestDeepCopyBranches:
     # --- Resolve(): map with various key/value types ---
 
     def test_map_primitive_keys_and_values(self) -> None:
-        m = tvm_ffi.convert({"a": 1, "b": 2, "c": 3})
+        m = ffi.convert({"a": 1, "b": 2, "c": 3})
         m_deep = copy.deepcopy(m)
         assert not m.same_as(m_deep)
         assert m_deep["a"] == 1
@@ -472,21 +468,21 @@ class TestDeepCopyBranches:
         assert m_deep["c"] == 3
 
     def test_map_with_container_values(self) -> None:
-        inner_arr = tvm_ffi.convert([1, 2])
-        m = tvm_ffi.convert({"arr": inner_arr})
+        inner_arr = ffi.convert([1, 2])
+        m = ffi.convert({"arr": inner_arr})
         m_deep = copy.deepcopy(m)
         assert not m["arr"].same_as(m_deep["arr"])
         assert list(m_deep["arr"]) == [1, 2]
 
     def test_map_with_none_values(self) -> None:
-        m = tvm_ffi.convert({"a": None, "b": 1})
+        m = ffi.convert({"a": None, "b": 1})
         m_deep = copy.deepcopy(m)
         assert not m.same_as(m_deep)
         assert m_deep["a"] is None
         assert m_deep["b"] == 1
 
     def test_map_empty(self) -> None:
-        m = tvm_ffi.convert({})
+        m = ffi.convert({})
         m_deep = copy.deepcopy(m)
         assert not m.same_as(m_deep)
         assert len(m_deep) == 0
@@ -494,7 +490,7 @@ class TestDeepCopyBranches:
     # --- Resolve(): dict with various key/value types ---
 
     def test_dict_primitive_keys_and_values(self) -> None:
-        d = tvm_ffi.Dict({"a": 1, "b": 2, "c": 3})
+        d = ffi.Dict({"a": 1, "b": 2, "c": 3})
         d_deep = copy.deepcopy(d)
         assert not d.same_as(d_deep)
         assert d_deep["a"] == 1
@@ -502,21 +498,21 @@ class TestDeepCopyBranches:
         assert d_deep["c"] == 3
 
     def test_dict_with_container_values(self) -> None:
-        inner_arr = tvm_ffi.convert([1, 2])
-        d = tvm_ffi.Dict({"arr": inner_arr})
+        inner_arr = ffi.convert([1, 2])
+        d = ffi.Dict({"arr": inner_arr})
         d_deep = copy.deepcopy(d)
         assert not d["arr"].same_as(d_deep["arr"])
         assert list(d_deep["arr"]) == [1, 2]
 
     def test_dict_with_none_values(self) -> None:
-        d = tvm_ffi.Dict({"a": None, "b": 1})
+        d = ffi.Dict({"a": None, "b": 1})
         d_deep = copy.deepcopy(d)
         assert not d.same_as(d_deep)
         assert d_deep["a"] is None
         assert d_deep["b"] == 1
 
     def test_dict_empty(self) -> None:
-        d = tvm_ffi.Dict({})
+        d = ffi.Dict({})
         d_deep = copy.deepcopy(d)
         assert not d.same_as(d_deep)
         assert len(d_deep) == 0
@@ -525,33 +521,33 @@ class TestDeepCopyBranches:
 
     def test_shared_array_identity_in_outer_array(self) -> None:
         """Same array appears 3 times — all copies share identity."""
-        shared = tvm_ffi.convert([1, 2])
-        outer = tvm_ffi.convert([shared, shared, shared])
+        shared = ffi.convert([1, 2])
+        outer = ffi.convert([shared, shared, shared])
         outer_deep = copy.deepcopy(outer)
         assert outer_deep[0].same_as(outer_deep[1])
         assert outer_deep[1].same_as(outer_deep[2])
         assert not outer[0].same_as(outer_deep[0])
 
     def test_shared_map_identity_in_outer_array(self) -> None:
-        shared = tvm_ffi.convert({"x": 1})
-        outer = tvm_ffi.convert([shared, shared])
+        shared = ffi.convert({"x": 1})
+        outer = ffi.convert([shared, shared])
         outer_deep = copy.deepcopy(outer)
         assert outer_deep[0].same_as(outer_deep[1])
         assert not outer[0].same_as(outer_deep[0])
 
     def test_shared_dict_identity_in_outer_array(self) -> None:
-        shared = tvm_ffi.Dict({"x": 1})
-        outer = tvm_ffi.convert([shared, shared])
+        shared = ffi.Dict({"x": 1})
+        outer = ffi.convert([shared, shared])
         outer_deep = copy.deepcopy(outer)
         assert outer_deep[0].same_as(outer_deep[1])
         assert not outer[0].same_as(outer_deep[0])
 
     def test_shared_object_across_array_and_map(self) -> None:
         """Same object referenced from both v_array and v_map."""
-        pair = tvm_ffi.testing.TestIntPair(7, 8)
-        v_array = tvm_ffi.convert([pair])
-        v_map = tvm_ffi.convert({"p": pair})
-        obj = tvm_ffi.testing.create_object(
+        pair = ffi.testing.TestIntPair(7, 8)
+        v_array = ffi.convert([pair])
+        v_map = ffi.convert({"p": pair})
+        obj = ffi.testing.create_object(
             "testing.TestObjectDerived",
             v_i64=1,
             v_map=v_map,
@@ -568,9 +564,9 @@ class TestDeepCopyBranches:
     #     Resolve() always rebuilds the container, so setter is always called.
 
     def test_field_array_only_primitives(self) -> None:
-        v_array = tvm_ffi.convert([1, 2, 3])
-        v_map = tvm_ffi.convert({"k": "v"})
-        obj = tvm_ffi.testing.create_object(
+        v_array = ffi.convert([1, 2, 3])
+        v_map = ffi.convert({"k": "v"})
+        obj = ffi.testing.create_object(
             "testing.TestObjectDerived",
             v_i64=1,
             v_map=v_map,
@@ -581,9 +577,9 @@ class TestDeepCopyBranches:
         assert list(obj_deep.v_array) == [1, 2, 3]  # ty: ignore[unresolved-attribute]
 
     def test_field_map_only_primitives(self) -> None:
-        v_array = tvm_ffi.convert([])
-        v_map = tvm_ffi.convert({"x": 1, "y": 2})
-        obj = tvm_ffi.testing.create_object(
+        v_array = ffi.convert([])
+        v_map = ffi.convert({"x": 1, "y": 2})
+        obj = ffi.testing.create_object(
             "testing.TestObjectDerived",
             v_i64=1,
             v_map=v_map,
@@ -597,9 +593,9 @@ class TestDeepCopyBranches:
     # --- ResolveFields: empty container fields ---
 
     def test_field_empty_containers(self) -> None:
-        v_array = tvm_ffi.convert([])
-        v_map = tvm_ffi.convert({})
-        obj = tvm_ffi.testing.create_object(
+        v_array = ffi.convert([])
+        v_map = ffi.convert({})
+        obj = ffi.testing.create_object(
             "testing.TestObjectDerived",
             v_i64=1,
             v_map=v_map,
@@ -615,20 +611,20 @@ class TestDeepCopyBranches:
 
     def test_shared_container_field_across_objects(self) -> None:
         """Two objects share the same v_array — copy_map_ deduplicates."""
-        shared_arr = tvm_ffi.convert([1, 2, 3])
-        obj_a = tvm_ffi.testing.create_object(
+        shared_arr = ffi.convert([1, 2, 3])
+        obj_a = ffi.testing.create_object(
             "testing.TestObjectDerived",
             v_i64=1,
-            v_map=tvm_ffi.convert({}),
+            v_map=ffi.convert({}),
             v_array=shared_arr,
         )
-        obj_b = tvm_ffi.testing.create_object(
+        obj_b = ffi.testing.create_object(
             "testing.TestObjectDerived",
             v_i64=2,
-            v_map=tvm_ffi.convert({}),
+            v_map=ffi.convert({}),
             v_array=shared_arr,
         )
-        outer = tvm_ffi.convert([obj_a, obj_b])
+        outer = ffi.convert([obj_a, obj_b])
         outer_deep = copy.deepcopy(outer)
         deep_a = outer_deep[0]
         deep_b = outer_deep[1]
@@ -640,8 +636,8 @@ class TestDeepCopyBranches:
 
     def test_cxx_class_in_array(self) -> None:
         # Note: _TestCxxClassBase.__init__ adds 1 to v_i64 and 2 to v_i32
-        obj = tvm_ffi.testing._TestCxxClassBase(v_i64=1, v_i32=2)
-        arr = tvm_ffi.convert([obj])
+        obj = ffi.testing._TestCxxClassBase(v_i64=1, v_i32=2)
+        arr = ffi.convert([obj])
         arr_deep = copy.deepcopy(arr)
         assert not arr.same_as(arr_deep)
         assert not arr[0].same_as(arr_deep[0])
@@ -650,8 +646,8 @@ class TestDeepCopyBranches:
 
     def test_cxx_class_in_map_value(self) -> None:
         # Note: _TestCxxClassBase.__init__ adds 1 to v_i64 and 2 to v_i32
-        obj = tvm_ffi.testing._TestCxxClassBase(v_i64=1, v_i32=2)
-        m = tvm_ffi.convert({"k": obj})
+        obj = ffi.testing._TestCxxClassBase(v_i64=1, v_i32=2)
+        m = ffi.convert({"k": obj})
         m_deep = copy.deepcopy(m)
         assert not m.same_as(m_deep)
         assert not m["k"].same_as(m_deep["k"])
@@ -659,14 +655,14 @@ class TestDeepCopyBranches:
         assert m_deep["k"].v_i32 == 4
 
     def test_non_copyable_type_in_array(self) -> None:
-        obj = tvm_ffi.testing.TestNonCopyable(1)
-        arr = tvm_ffi.convert([obj])
+        obj = ffi.testing.TestNonCopyable(1)
+        arr = ffi.convert([obj])
         with pytest.raises(RuntimeError, match="not copy-constructible"):
             copy.deepcopy(arr)
 
     def test_non_copyable_type_in_map_value(self) -> None:
-        obj = tvm_ffi.testing.TestNonCopyable(1)
-        m = tvm_ffi.convert({"k": obj})
+        obj = ffi.testing.TestNonCopyable(1)
+        m = ffi.convert({"k": obj})
         with pytest.raises(RuntimeError, match="not copy-constructible"):
             copy.deepcopy(m)
 
@@ -674,10 +670,10 @@ class TestDeepCopyBranches:
 
     def test_deeply_nested_containers(self) -> None:
         """Array > Map > Array > object — all levels resolved."""
-        pair = tvm_ffi.testing.TestIntPair(9, 10)
-        inner_arr = tvm_ffi.convert([pair])
-        inner_map = tvm_ffi.convert({"items": inner_arr})
-        outer = tvm_ffi.convert([inner_map])
+        pair = ffi.testing.TestIntPair(9, 10)
+        inner_arr = ffi.convert([pair])
+        inner_map = ffi.convert({"items": inner_arr})
+        outer = ffi.convert([inner_map])
         outer_deep = copy.deepcopy(outer)
         deep_pair = outer_deep[0]["items"][0]
         assert not pair.same_as(deep_pair)
@@ -686,13 +682,13 @@ class TestDeepCopyBranches:
 
     def test_object_with_deeply_nested_field(self) -> None:
         """Object whose array field contains a map containing an object."""
-        pair = tvm_ffi.testing.TestIntPair(5, 6)
-        inner_map = tvm_ffi.convert({"pair": pair})
-        v_array = tvm_ffi.convert([inner_map])
-        obj = tvm_ffi.testing.create_object(
+        pair = ffi.testing.TestIntPair(5, 6)
+        inner_map = ffi.convert({"pair": pair})
+        v_array = ffi.convert([inner_map])
+        obj = ffi.testing.create_object(
             "testing.TestObjectDerived",
             v_i64=1,
-            v_map=tvm_ffi.convert({}),
+            v_map=ffi.convert({}),
             v_array=v_array,
         )
         obj_deep = copy.deepcopy(obj)
@@ -704,8 +700,8 @@ class TestDeepCopyBranches:
 
     def test_cycle_list_root_map_backref_preserved(self) -> None:
         """Control case: List root with Map back-reference should preserve cycle."""
-        root_list = tvm_ffi.List()
-        m = tvm_ffi.Map({"list": root_list})
+        root_list = ffi.List()
+        m = ffi.Map({"list": root_list})
         root_list.append(m)
 
         deep_list = copy.deepcopy(root_list)
@@ -714,8 +710,8 @@ class TestDeepCopyBranches:
 
     def test_cycle_map_root_list_backref_preserved(self) -> None:
         """Map root with List child pointing back should preserve cycle to root copy."""
-        l = tvm_ffi.List()
-        m = tvm_ffi.Map({"list": l})
+        l = ffi.List()
+        m = ffi.Map({"list": l})
         l.append(m)
 
         deep_map = copy.deepcopy(m)
@@ -725,8 +721,8 @@ class TestDeepCopyBranches:
 
     def test_cycle_array_root_list_backref_preserved(self) -> None:
         """Array root with List child pointing back should preserve cycle to root copy."""
-        l = tvm_ffi.List()
-        a = tvm_ffi.Array([l])
+        l = ffi.List()
+        a = ffi.Array([l])
         l.append(a)
 
         deep_arr = copy.deepcopy(a)
@@ -736,8 +732,8 @@ class TestDeepCopyBranches:
 
     def test_cycle_array_root_dict_backref_preserved(self) -> None:
         """Array root with Dict child pointing back should preserve cycle to root copy."""
-        d = tvm_ffi.Dict()
-        a = tvm_ffi.Array([d])
+        d = ffi.Dict()
+        a = ffi.Array([d])
         d["self"] = a
 
         deep_arr = copy.deepcopy(a)
@@ -747,8 +743,8 @@ class TestDeepCopyBranches:
 
     def test_cycle_map_root_dict_backref_preserved(self) -> None:
         """Map root with Dict child pointing back should preserve cycle to root copy."""
-        d = tvm_ffi.Dict()
-        m = tvm_ffi.Map({"dict": d})
+        d = ffi.Dict()
+        m = ffi.Map({"dict": d})
         d["self"] = m
 
         deep_map = copy.deepcopy(m)
@@ -758,8 +754,8 @@ class TestDeepCopyBranches:
 
     def test_cycle_map_root_backref_identity_not_duplicated(self) -> None:
         """Back-references in a map-root cycle should point to the root copied map."""
-        shared_list = tvm_ffi.List()
-        m = tvm_ffi.Map({"l1": shared_list, "l2": shared_list})
+        shared_list = ffi.List()
+        m = ffi.Map({"l1": shared_list, "l2": shared_list})
         shared_list.append(m)
 
         deep_map = copy.deepcopy(m)
@@ -768,30 +764,30 @@ class TestDeepCopyBranches:
 
     def test_cycle_map_root_list_key_backref_preserved(self) -> None:
         """Map-root cycles through keys should preserve back-reference to copied root."""
-        key_list = tvm_ffi.List()
-        m = tvm_ffi.Map({key_list: 1})
+        key_list = ffi.List()
+        m = ffi.Map({key_list: 1})
         key_list.append(m)
 
         deep_map = copy.deepcopy(m)
         deep_key = next(iter(deep_map.keys()))
-        assert isinstance(deep_key, tvm_ffi.List)
+        assert isinstance(deep_key, ffi.List)
         assert deep_key[0].same_as(deep_map)
 
     def test_cycle_map_root_dict_key_backref_preserved(self) -> None:
         """Map-root cycles through Dict keys should preserve back-reference to copied root."""
-        key_dict = tvm_ffi.Dict()
-        m = tvm_ffi.Map({key_dict: 1})
+        key_dict = ffi.Dict()
+        m = ffi.Map({key_dict: 1})
         key_dict["self"] = m
 
         deep_map = copy.deepcopy(m)
         deep_key = next(iter(deep_map.keys()))
-        assert isinstance(deep_key, tvm_ffi.Dict)
+        assert isinstance(deep_key, ffi.Dict)
         assert deep_key["self"].same_as(deep_map)
 
     def test_cycle_array_root_dict_contains_root_as_key(self) -> None:
         """Array root with Dict child using the root as key should fix key to copied root."""
-        d = tvm_ffi.Dict()
-        root = tvm_ffi.Array([d])
+        d = ffi.Dict()
+        root = ffi.Array([d])
         d[root] = 1
 
         deep_root = copy.deepcopy(root)
@@ -804,8 +800,8 @@ class TestDeepCopyBranches:
 
     def test_cycle_map_root_dict_contains_root_as_key(self) -> None:
         """Map root with Dict child using the root as key should fix key to copied root."""
-        d = tvm_ffi.Dict()
-        root = tvm_ffi.Map({"d": d})
+        d = ffi.Dict()
+        root = ffi.Map({"d": d})
         d[root] = 1
 
         deep_root = copy.deepcopy(root)
@@ -820,8 +816,8 @@ class TestDeepCopyBranches:
 
     def test_shape_root_python_deepcopy_matches_ffi_deepcopy(self) -> None:
         """copy.deepcopy(Shape) should be consistent with ffi.DeepCopy."""
-        deep_copy_fn = tvm_ffi.get_global_func("ffi.DeepCopy")
-        s = tvm_ffi.Shape((2, 3, 4))
+        deep_copy_fn = ffi.get_global_func("ffi.DeepCopy")
+        s = ffi.Shape((2, 3, 4))
         ffi_copied = deep_copy_fn(s)
         py_copied = copy.deepcopy(s)
         assert py_copied == ffi_copied
@@ -829,7 +825,7 @@ class TestDeepCopyBranches:
 
     def test_shape_inside_python_container_deepcopy(self) -> None:
         """Python container deepcopy should handle Shape payloads."""
-        s = tvm_ffi.Shape((1, 2))
+        s = ffi.Shape((1, 2))
         payload = [s, {"shape": s}]
         copied = copy.deepcopy(payload)
         assert copied[0] == s
@@ -839,13 +835,13 @@ class TestDeepCopyBranches:
 
     def test_cycle_array_root_object_backreference(self) -> None:
         """Array A → Object X, X.v_array = A.  Deep copy from A."""
-        obj = tvm_ffi.testing.create_object(
+        obj = ffi.testing.create_object(
             "testing.TestObjectDerived",
             v_i64=42,
-            v_map=tvm_ffi.Map({}),
-            v_array=tvm_ffi.Array([]),
+            v_map=ffi.Map({}),
+            v_array=ffi.Array([]),
         )
-        arr = tvm_ffi.Array([obj])
+        arr = ffi.Array([obj])
         obj.v_array = arr  # ty: ignore[unresolved-attribute]
 
         arr_deep = _deep_copy(arr)
@@ -859,13 +855,13 @@ class TestDeepCopyBranches:
 
     def test_cycle_map_root_object_backreference(self) -> None:
         """Map M → Object X, X.v_map = M.  Deep copy from M."""
-        obj = tvm_ffi.testing.create_object(
+        obj = ffi.testing.create_object(
             "testing.TestObjectDerived",
             v_i64=7,
-            v_map=tvm_ffi.Map({}),
-            v_array=tvm_ffi.Array([]),
+            v_map=ffi.Map({}),
+            v_array=ffi.Array([]),
         )
-        m = tvm_ffi.Map({"key": obj})
+        m = ffi.Map({"key": obj})
         obj.v_map = m  # ty: ignore[unresolved-attribute]
 
         m_deep = _deep_copy(m)
@@ -879,19 +875,19 @@ class TestDeepCopyBranches:
 
     def test_cycle_nested_array_object_array(self) -> None:
         """Array → Object → Array → Object → back to root Array."""
-        inner = tvm_ffi.testing.create_object(
+        inner = ffi.testing.create_object(
             "testing.TestObjectDerived",
             v_i64=1,
-            v_map=tvm_ffi.Map({}),
-            v_array=tvm_ffi.Array([]),
+            v_map=ffi.Map({}),
+            v_array=ffi.Array([]),
         )
-        outer = tvm_ffi.testing.create_object(
+        outer = ffi.testing.create_object(
             "testing.TestObjectDerived",
             v_i64=2,
-            v_map=tvm_ffi.Map({}),
-            v_array=tvm_ffi.Array([inner]),
+            v_map=ffi.Map({}),
+            v_array=ffi.Array([inner]),
         )
-        root_arr = tvm_ffi.Array([outer])
+        root_arr = ffi.Array([outer])
         inner.v_array = root_arr  # ty: ignore[unresolved-attribute]
 
         root_deep = _deep_copy(root_arr)
@@ -910,46 +906,46 @@ class TestReplace:
     """Tests for __replace__."""
 
     def test_replace_writable_fields(self) -> None:
-        obj = tvm_ffi.testing.create_object("testing.TestObjectBase", v_i64=1, v_str="a")
+        obj = ffi.testing.create_object("testing.TestObjectBase", v_i64=1, v_str="a")
         obj2 = obj.__replace__(v_i64=99)  # ty: ignore[unresolved-attribute]
         assert obj2.v_i64 == 99
         assert obj2.v_str == "a"
         assert not obj.same_as(obj2)
 
     def test_replace_multiple_fields(self) -> None:
-        obj = tvm_ffi.testing.create_object("testing.TestObjectBase", v_i64=1, v_str="a")
+        obj = ffi.testing.create_object("testing.TestObjectBase", v_i64=1, v_str="a")
         obj2 = obj.__replace__(v_i64=42, v_str="world")  # ty: ignore[unresolved-attribute]
         assert obj2.v_i64 == 42
         assert obj2.v_str == "world"
 
     def test_replace_no_kwargs_is_copy(self) -> None:
-        obj = tvm_ffi.testing.create_object("testing.TestObjectBase", v_i64=7, v_str="hi")
+        obj = ffi.testing.create_object("testing.TestObjectBase", v_i64=7, v_str="hi")
         obj2 = obj.__replace__()  # ty: ignore[unresolved-attribute]
         assert obj2.v_i64 == 7
         assert obj2.v_str == "hi"
         assert not obj.same_as(obj2)
 
     def test_original_unchanged(self) -> None:
-        obj = tvm_ffi.testing.create_object("testing.TestObjectBase", v_i64=5, v_str="x")
+        obj = ffi.testing.create_object("testing.TestObjectBase", v_i64=5, v_str="x")
         obj.__replace__(v_i64=100)  # ty: ignore[unresolved-attribute]
         assert obj.v_i64 == 5  # ty: ignore[unresolved-attribute]
 
     def test_replace_readonly_field_raises(self) -> None:
-        pair = tvm_ffi.testing.TestIntPair(3, 4)
+        pair = ffi.testing.TestIntPair(3, 4)
         with pytest.raises(AttributeError):
             pair.__replace__(a=10)  # ty: ignore[unresolved-attribute]
 
     def test_auto_replace_for_cxx_class(self) -> None:
         # _TestCxxClassBase is copy-constructible, so replace is auto-enabled
         # Note: _TestCxxClassBase.__init__ adds 1 to v_i64 and 2 to v_i32
-        obj = tvm_ffi.testing._TestCxxClassBase(v_i64=1, v_i32=2)
+        obj = ffi.testing._TestCxxClassBase(v_i64=1, v_i32=2)
         obj2 = obj.__replace__(v_i64=99)  # ty: ignore[unresolved-attribute]
         assert obj2.v_i64 == 99
         assert obj2.v_i32 == 4
         assert not obj.same_as(obj2)
 
     def test_non_copyable_type_raises(self) -> None:
-        obj = tvm_ffi.testing.TestNonCopyable(42)
+        obj = ffi.testing.TestNonCopyable(42)
         with pytest.raises(TypeError, match="does not support replace"):
             obj.__replace__()  # ty: ignore[unresolved-attribute]
 

--- a/tests/python/test_dataclass_hash.py
+++ b/tests/python/test_dataclass_hash.py
@@ -25,7 +25,7 @@ from collections.abc import Callable
 
 import numpy as np
 import pytest
-import tvm_ffi
+import tvm_ffi as ffi
 import tvm_ffi.testing
 from tvm_ffi._ffi_api import RecursiveEq, RecursiveHash
 from tvm_ffi.testing import (
@@ -112,8 +112,8 @@ def test_nan_payloads_hash_equal() -> None:
 def test_nan_payloads_in_nested_array_hash() -> None:
     nan1 = _make_nan_from_payload(0xA5)
     nan2 = _make_nan_from_payload(0x5A)
-    a = tvm_ffi.Array([1.0, nan1, 2.0])
-    b = tvm_ffi.Array([1.0, nan2, 2.0])
+    a = ffi.Array([1.0, nan1, 2.0])
+    b = ffi.Array([1.0, nan2, 2.0])
     assert RecursiveHash(a) == RecursiveHash(b)
 
 
@@ -195,11 +195,11 @@ def test_none_vs_other_hash() -> None:
 
 
 def test_dtype_hash_equal() -> None:
-    assert RecursiveHash(tvm_ffi.dtype("float32")) == RecursiveHash(tvm_ffi.dtype("float32"))
+    assert RecursiveHash(ffi.dtype("float32")) == RecursiveHash(ffi.dtype("float32"))
 
 
 def test_dtype_hash_different() -> None:
-    assert RecursiveHash(tvm_ffi.dtype("float32")) != RecursiveHash(tvm_ffi.dtype("float16"))
+    assert RecursiveHash(ffi.dtype("float32")) != RecursiveHash(ffi.dtype("float16"))
 
 
 # ---------------------------------------------------------------------------
@@ -208,11 +208,11 @@ def test_dtype_hash_different() -> None:
 
 
 def test_device_hash_equal() -> None:
-    assert RecursiveHash(tvm_ffi.Device("cpu", 0)) == RecursiveHash(tvm_ffi.Device("cpu", 0))
+    assert RecursiveHash(ffi.Device("cpu", 0)) == RecursiveHash(ffi.Device("cpu", 0))
 
 
 def test_device_hash_different() -> None:
-    assert RecursiveHash(tvm_ffi.Device("cpu", 0)) != RecursiveHash(tvm_ffi.Device("cpu", 1))
+    assert RecursiveHash(ffi.Device("cpu", 0)) != RecursiveHash(ffi.Device("cpu", 1))
 
 
 # ---------------------------------------------------------------------------
@@ -221,26 +221,26 @@ def test_device_hash_different() -> None:
 
 
 def test_array_hash_equal() -> None:
-    a = tvm_ffi.Array([1, 2, 3])
-    b = tvm_ffi.Array([1, 2, 3])
+    a = ffi.Array([1, 2, 3])
+    b = ffi.Array([1, 2, 3])
     assert RecursiveHash(a) == RecursiveHash(b)
 
 
 def test_array_hash_different() -> None:
-    a = tvm_ffi.Array([1, 2, 3])
-    c = tvm_ffi.Array([1, 2, 4])
+    a = ffi.Array([1, 2, 3])
+    c = ffi.Array([1, 2, 4])
     assert RecursiveHash(a) != RecursiveHash(c)
 
 
 def test_array_empty_hash() -> None:
-    empty1 = tvm_ffi.Array([])
-    empty2 = tvm_ffi.Array([])
+    empty1 = ffi.Array([])
+    empty2 = ffi.Array([])
     assert RecursiveHash(empty1) == RecursiveHash(empty2)
 
 
 def test_array_different_length_hash() -> None:
-    a = tvm_ffi.Array([1, 2])
-    b = tvm_ffi.Array([1, 2, 3])
+    a = ffi.Array([1, 2])
+    b = ffi.Array([1, 2, 3])
     assert RecursiveHash(a) != RecursiveHash(b)
 
 
@@ -250,14 +250,14 @@ def test_array_different_length_hash() -> None:
 
 
 def test_list_hash_equal() -> None:
-    a = tvm_ffi.List([1, 2, 3])
-    b = tvm_ffi.List([1, 2, 3])
+    a = ffi.List([1, 2, 3])
+    b = ffi.List([1, 2, 3])
     assert RecursiveHash(a) == RecursiveHash(b)
 
 
 def test_list_hash_different() -> None:
-    a = tvm_ffi.List([1, 2, 3])
-    c = tvm_ffi.List([1, 2, 4])
+    a = ffi.List([1, 2, 3])
+    c = ffi.List([1, 2, 4])
     assert RecursiveHash(a) != RecursiveHash(c)
 
 
@@ -267,14 +267,14 @@ def test_list_hash_different() -> None:
 
 
 def test_shape_hash_equal() -> None:
-    a = tvm_ffi.Shape((2, 3, 4))
-    b = tvm_ffi.Shape((2, 3, 4))
+    a = ffi.Shape((2, 3, 4))
+    b = ffi.Shape((2, 3, 4))
     assert RecursiveHash(a) == RecursiveHash(b)
 
 
 def test_shape_hash_different() -> None:
-    a = tvm_ffi.Shape((2, 3, 4))
-    c = tvm_ffi.Shape((2, 3, 5))
+    a = ffi.Shape((2, 3, 4))
+    c = ffi.Shape((2, 3, 5))
     assert RecursiveHash(a) != RecursiveHash(c)
 
 
@@ -284,39 +284,39 @@ def test_shape_hash_different() -> None:
 
 
 def test_map_hash_equal() -> None:
-    a = tvm_ffi.Map({"x": 1, "y": 2})
-    b = tvm_ffi.Map({"x": 1, "y": 2})
+    a = ffi.Map({"x": 1, "y": 2})
+    b = ffi.Map({"x": 1, "y": 2})
     assert RecursiveHash(a) == RecursiveHash(b)
 
 
 def test_map_hash_different_values() -> None:
-    a = tvm_ffi.Map({"x": 1, "y": 2})
-    c = tvm_ffi.Map({"x": 1, "y": 3})
+    a = ffi.Map({"x": 1, "y": 2})
+    c = ffi.Map({"x": 1, "y": 3})
     assert RecursiveHash(a) != RecursiveHash(c)
 
 
 def test_map_hash_different_size() -> None:
-    a = tvm_ffi.Map({"x": 1})
-    b = tvm_ffi.Map({"x": 1, "y": 2})
+    a = ffi.Map({"x": 1})
+    b = ffi.Map({"x": 1, "y": 2})
     assert RecursiveHash(a) != RecursiveHash(b)
 
 
 def test_map_hash_order_independent() -> None:
     """Map hash should be the same regardless of insertion order."""
-    a = tvm_ffi.Map({"x": 1, "y": 2, "z": 3})
-    b = tvm_ffi.Map({"z": 3, "x": 1, "y": 2})
+    a = ffi.Map({"x": 1, "y": 2, "z": 3})
+    b = ffi.Map({"z": 3, "x": 1, "y": 2})
     assert RecursiveHash(a) == RecursiveHash(b)
 
 
 def test_dict_hash_equal() -> None:
-    a = tvm_ffi.Dict({"x": 1, "y": 2})
-    b = tvm_ffi.Dict({"x": 1, "y": 2})
+    a = ffi.Dict({"x": 1, "y": 2})
+    b = ffi.Dict({"x": 1, "y": 2})
     assert RecursiveHash(a) == RecursiveHash(b)
 
 
 def test_dict_hash_different() -> None:
-    a = tvm_ffi.Dict({"x": 1})
-    b = tvm_ffi.Dict({"x": 2})
+    a = ffi.Dict({"x": 1})
+    b = ffi.Dict({"x": 2})
     assert RecursiveHash(a) != RecursiveHash(b)
 
 
@@ -400,33 +400,33 @@ def test_different_types_hash() -> None:
 
 
 def test_array_of_arrays_hash() -> None:
-    a = tvm_ffi.Array([tvm_ffi.Array([1, 2]), tvm_ffi.Array([3, 4])])
-    b = tvm_ffi.Array([tvm_ffi.Array([1, 2]), tvm_ffi.Array([3, 4])])
-    c = tvm_ffi.Array([tvm_ffi.Array([1, 2]), tvm_ffi.Array([3, 5])])
+    a = ffi.Array([ffi.Array([1, 2]), ffi.Array([3, 4])])
+    b = ffi.Array([ffi.Array([1, 2]), ffi.Array([3, 4])])
+    c = ffi.Array([ffi.Array([1, 2]), ffi.Array([3, 5])])
     assert RecursiveHash(a) == RecursiveHash(b)
     assert RecursiveHash(a) != RecursiveHash(c)
 
 
 def test_list_of_lists_hash() -> None:
-    a = tvm_ffi.List([tvm_ffi.List([1, 2]), tvm_ffi.List([3])])
-    b = tvm_ffi.List([tvm_ffi.List([1, 2]), tvm_ffi.List([3])])
-    c = tvm_ffi.List([tvm_ffi.List([1, 2]), tvm_ffi.List([4])])
+    a = ffi.List([ffi.List([1, 2]), ffi.List([3])])
+    b = ffi.List([ffi.List([1, 2]), ffi.List([3])])
+    c = ffi.List([ffi.List([1, 2]), ffi.List([4])])
     assert RecursiveHash(a) == RecursiveHash(b)
     assert RecursiveHash(a) != RecursiveHash(c)
 
 
 def test_three_level_nested_hash() -> None:
-    a = tvm_ffi.Array([tvm_ffi.Array([tvm_ffi.Array([1])])])
-    b = tvm_ffi.Array([tvm_ffi.Array([tvm_ffi.Array([1])])])
-    c = tvm_ffi.Array([tvm_ffi.Array([tvm_ffi.Array([2])])])
+    a = ffi.Array([ffi.Array([ffi.Array([1])])])
+    b = ffi.Array([ffi.Array([ffi.Array([1])])])
+    c = ffi.Array([ffi.Array([ffi.Array([2])])])
     assert RecursiveHash(a) == RecursiveHash(b)
     assert RecursiveHash(a) != RecursiveHash(c)
 
 
 def test_map_with_array_values_hash() -> None:
-    a = tvm_ffi.Map({"k": tvm_ffi.Array([1, 2])})
-    b = tvm_ffi.Map({"k": tvm_ffi.Array([1, 2])})
-    c = tvm_ffi.Map({"k": tvm_ffi.Array([1, 3])})
+    a = ffi.Map({"k": ffi.Array([1, 2])})
+    b = ffi.Map({"k": ffi.Array([1, 2])})
+    c = ffi.Map({"k": ffi.Array([1, 3])})
     assert RecursiveHash(a) == RecursiveHash(b)
     assert RecursiveHash(a) != RecursiveHash(c)
 
@@ -467,16 +467,16 @@ def test_object_with_array_field_hash() -> None:
         v_i64=1,
         v_f64=2.0,
         v_str="s",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([10, 20, 30]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([10, 20, 30]),
     )
     b = create_object(
         "testing.TestObjectDerived",
         v_i64=1,
         v_f64=2.0,
         v_str="s",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([10, 20, 30]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([10, 20, 30]),
     )
     assert RecursiveHash(a) == RecursiveHash(b)
 
@@ -487,16 +487,16 @@ def test_object_with_array_field_differ_hash() -> None:
         v_i64=1,
         v_f64=2.0,
         v_str="s",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([10, 20]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([10, 20]),
     )
     b = create_object(
         "testing.TestObjectDerived",
         v_i64=1,
         v_f64=2.0,
         v_str="s",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([10, 21]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([10, 21]),
     )
     assert RecursiveHash(a) != RecursiveHash(b)
 
@@ -507,14 +507,14 @@ def test_object_with_array_field_differ_hash() -> None:
 
 
 def test_array_vs_list_different_hash() -> None:
-    arr = tvm_ffi.Array([1, 2])
-    lst = tvm_ffi.List([1, 2])
+    arr = ffi.Array([1, 2])
+    lst = ffi.List([1, 2])
     assert RecursiveHash(arr) != RecursiveHash(lst)
 
 
 def test_map_vs_dict_different_hash() -> None:
-    m = tvm_ffi.Map({"k": 1})
-    d = tvm_ffi.Dict({"k": 1})
+    m = ffi.Map({"k": 1})
+    d = ffi.Dict({"k": 1})
     assert RecursiveHash(m) != RecursiveHash(d)
 
 
@@ -524,9 +524,9 @@ def test_map_vs_dict_different_hash() -> None:
 
 
 def test_array_with_none_elements_hash() -> None:
-    a = tvm_ffi.Array([None, 1, None])
-    b = tvm_ffi.Array([None, 1, None])
-    c = tvm_ffi.Array([None, 2, None])
+    a = ffi.Array([None, 1, None])
+    b = ffi.Array([None, 1, None])
+    c = ffi.Array([None, 2, None])
     assert RecursiveHash(a) == RecursiveHash(b)
     assert RecursiveHash(a) != RecursiveHash(c)
 
@@ -538,7 +538,7 @@ def test_array_with_none_elements_hash() -> None:
 
 def test_cyclic_list_same_pointer_hash() -> None:
     """Same cyclic list hashed with itself succeeds (pointer identity short-circuit)."""
-    lst = tvm_ffi.List()
+    lst = ffi.List()
     lst.append(lst)
     # Should not raise; same pointer returns a deterministic hash
     h = RecursiveHash(lst)
@@ -547,9 +547,9 @@ def test_cyclic_list_same_pointer_hash() -> None:
 
 def test_cyclic_list_handled() -> None:
     """Distinct cyclic lists are handled gracefully via on-stack cycle detection."""
-    a = tvm_ffi.List()
+    a = ffi.List()
     a.append(a)
-    b = tvm_ffi.List()
+    b = ffi.List()
     b.append(b)
     h_a = RecursiveHash(a)
     h_b = RecursiveHash(b)
@@ -558,7 +558,7 @@ def test_cyclic_list_handled() -> None:
 
 def test_cyclic_dict_handled() -> None:
     """Cyclic dict is handled gracefully via on-stack cycle detection."""
-    d = tvm_ffi.Dict()
+    d = ffi.Dict()
     d["self"] = d
     h = RecursiveHash(d)
     assert h == RecursiveHash(d)
@@ -602,11 +602,11 @@ def test_consistency_signed_zero() -> None:
 def test_consistency_containers() -> None:
     """Verify hash consistency for containers."""
     pairs = [
-        (tvm_ffi.Array([1, 2, 3]), tvm_ffi.Array([1, 2, 3])),
-        (tvm_ffi.List([1, 2, 3]), tvm_ffi.List([1, 2, 3])),
-        (tvm_ffi.Shape((2, 3, 4)), tvm_ffi.Shape((2, 3, 4))),
-        (tvm_ffi.Map({"x": 1, "y": 2}), tvm_ffi.Map({"x": 1, "y": 2})),
-        (tvm_ffi.Dict({"x": 1, "y": 2}), tvm_ffi.Dict({"x": 1, "y": 2})),
+        (ffi.Array([1, 2, 3]), ffi.Array([1, 2, 3])),
+        (ffi.List([1, 2, 3]), ffi.List([1, 2, 3])),
+        (ffi.Shape((2, 3, 4)), ffi.Shape((2, 3, 4))),
+        (ffi.Map({"x": 1, "y": 2}), ffi.Map({"x": 1, "y": 2})),
+        (ffi.Dict({"x": 1, "y": 2}), ffi.Dict({"x": 1, "y": 2})),
     ]
     for a, b in pairs:
         assert RecursiveEq(a, b), f"Expected RecursiveEq for {a!r} and {b!r}"
@@ -655,7 +655,7 @@ def test_consistency_law_on_int_pairs() -> None:
 def _make_nested_singleton_array(depth: int) -> object:
     value: object = 0
     for _ in range(depth):
-        value = tvm_ffi.Array([value])
+        value = ffi.Array([value])
     return value
 
 
@@ -666,8 +666,8 @@ def _make_nested_singleton_array(depth: int) -> object:
 
 def test_aliasing_consistency_array_of_reflected_objects() -> None:
     shared = TestIntPair(11, 22)
-    aliased = tvm_ffi.Array([shared, shared])
-    duplicated = tvm_ffi.Array(
+    aliased = ffi.Array([shared, shared])
+    duplicated = ffi.Array(
         [
             TestIntPair(11, 22),
             TestIntPair(11, 22),
@@ -679,8 +679,8 @@ def test_aliasing_consistency_array_of_reflected_objects() -> None:
 
 def test_aliasing_consistency_list_of_reflected_objects() -> None:
     shared = TestIntPair(13, 26)
-    aliased = tvm_ffi.List([shared, shared])
-    duplicated = tvm_ffi.List(
+    aliased = ffi.List([shared, shared])
+    duplicated = ffi.List(
         [
             TestIntPair(13, 26),
             TestIntPair(13, 26),
@@ -691,33 +691,33 @@ def test_aliasing_consistency_list_of_reflected_objects() -> None:
 
 
 def test_aliasing_consistency_array_of_arrays() -> None:
-    shared = tvm_ffi.Array([1, 2, 3])
-    aliased = tvm_ffi.Array([shared, shared])
-    duplicated = tvm_ffi.Array([tvm_ffi.Array([1, 2, 3]), tvm_ffi.Array([1, 2, 3])])
+    shared = ffi.Array([1, 2, 3])
+    aliased = ffi.Array([shared, shared])
+    duplicated = ffi.Array([ffi.Array([1, 2, 3]), ffi.Array([1, 2, 3])])
     assert RecursiveEq(aliased, duplicated)
     assert RecursiveHash(aliased) == RecursiveHash(duplicated)
 
 
 def test_aliasing_consistency_list_of_lists() -> None:
-    shared = tvm_ffi.List([1, 2, 3])
-    aliased = tvm_ffi.List([shared, shared])
-    duplicated = tvm_ffi.List([tvm_ffi.List([1, 2, 3]), tvm_ffi.List([1, 2, 3])])
+    shared = ffi.List([1, 2, 3])
+    aliased = ffi.List([shared, shared])
+    duplicated = ffi.List([ffi.List([1, 2, 3]), ffi.List([1, 2, 3])])
     assert RecursiveEq(aliased, duplicated)
     assert RecursiveHash(aliased) == RecursiveHash(duplicated)
 
 
 def test_aliasing_consistency_shape_objects() -> None:
-    shared = tvm_ffi.Shape((3, 4))
-    aliased = tvm_ffi.Array([shared, shared])
-    duplicated = tvm_ffi.Array([tvm_ffi.Shape((3, 4)), tvm_ffi.Shape((3, 4))])
+    shared = ffi.Shape((3, 4))
+    aliased = ffi.Array([shared, shared])
+    duplicated = ffi.Array([ffi.Shape((3, 4)), ffi.Shape((3, 4))])
     assert RecursiveEq(aliased, duplicated)
     assert RecursiveHash(aliased) == RecursiveHash(duplicated)
 
 
 def test_aliasing_consistency_map_shared_values() -> None:
     shared = TestIntPair(31, 41)
-    aliased = tvm_ffi.Map({"x": shared, "y": shared})
-    duplicated = tvm_ffi.Map(
+    aliased = ffi.Map({"x": shared, "y": shared})
+    duplicated = ffi.Map(
         {
             "x": TestIntPair(31, 41),
             "y": TestIntPair(31, 41),
@@ -728,9 +728,9 @@ def test_aliasing_consistency_map_shared_values() -> None:
 
 
 def test_aliasing_consistency_dict_shared_values() -> None:
-    shared = tvm_ffi.Array([7, 8, 9])
-    aliased = tvm_ffi.Dict({"x": shared, "y": shared})
-    duplicated = tvm_ffi.Dict({"x": tvm_ffi.Array([7, 8, 9]), "y": tvm_ffi.Array([7, 8, 9])})
+    shared = ffi.Array([7, 8, 9])
+    aliased = ffi.Dict({"x": shared, "y": shared})
+    duplicated = ffi.Dict({"x": ffi.Array([7, 8, 9]), "y": ffi.Array([7, 8, 9])})
     assert RecursiveEq(aliased, duplicated)
     assert RecursiveHash(aliased) == RecursiveHash(duplicated)
 
@@ -742,16 +742,16 @@ def test_aliasing_consistency_reflected_object_fields() -> None:
         v_i64=1,
         v_f64=2.0,
         v_str="shared",
-        v_map=tvm_ffi.Map({"k": shared}),
-        v_array=tvm_ffi.Array([shared]),
+        v_map=ffi.Map({"k": shared}),
+        v_array=ffi.Array([shared]),
     )
     duplicated = create_object(
         "testing.TestObjectDerived",
         v_i64=1,
         v_f64=2.0,
         v_str="shared",
-        v_map=tvm_ffi.Map({"k": TestIntPair(5, 6)}),
-        v_array=tvm_ffi.Array([TestIntPair(5, 6)]),
+        v_map=ffi.Map({"k": TestIntPair(5, 6)}),
+        v_array=ffi.Array([TestIntPair(5, 6)]),
     )
     assert RecursiveEq(aliased, duplicated)
     assert RecursiveHash(aliased) == RecursiveHash(duplicated)
@@ -764,16 +764,16 @@ def test_aliasing_consistency_reflected_object_fields() -> None:
 
 def test_map_hash_order_independent_with_shared_values() -> None:
     shared = TestIntPair(1, 2)
-    a = tvm_ffi.Map({"a": shared, "b": shared, "c": shared})
-    b = tvm_ffi.Map({"b": shared, "a": shared, "c": shared})
+    a = ffi.Map({"a": shared, "b": shared, "c": shared})
+    b = ffi.Map({"b": shared, "a": shared, "c": shared})
     assert RecursiveEq(a, b)
     assert RecursiveHash(a) == RecursiveHash(b)
 
 
 def test_dict_hash_order_independent_with_shared_values() -> None:
-    shared = tvm_ffi.Array([1, 2])
-    a = tvm_ffi.Dict({"a": shared, "b": shared, "c": shared})
-    b = tvm_ffi.Dict({"b": shared, "a": shared, "c": shared})
+    shared = ffi.Array([1, 2])
+    a = ffi.Dict({"a": shared, "b": shared, "c": shared})
+    b = ffi.Dict({"b": shared, "a": shared, "c": shared})
     assert RecursiveEq(a, b)
     assert RecursiveHash(a) == RecursiveHash(b)
 
@@ -799,16 +799,16 @@ def test_depth_1000_nested_arrays_works() -> None:
 
 def test_map_hash_collision_swap_values() -> None:
     """Swapping values across two keys should not trivially collide."""
-    a = tvm_ffi.Map({"a": 0, "b": 1})
-    b = tvm_ffi.Map({"a": 1, "b": 0})
+    a = ffi.Map({"a": 0, "b": 1})
+    b = ffi.Map({"a": 1, "b": 0})
     assert not RecursiveEq(a, b)
     assert RecursiveHash(a) != RecursiveHash(b)
 
 
 def test_array_hash_collision_small_int_pairs() -> None:
     """Distinct short arrays should not have obvious low-domain collisions."""
-    a = tvm_ffi.Array([1, 2])
-    b = tvm_ffi.Array([2, 61])
+    a = ffi.Array([1, 2])
+    b = ffi.Array([2, 61])
     assert not RecursiveEq(a, b)
     assert RecursiveHash(a) != RecursiveHash(b)
 
@@ -818,8 +818,8 @@ def test_function_hash_consistent_with_eq() -> None:
 
     Hash must be consistent: RecursiveEq(a, b) => RecursiveHash(a) == RecursiveHash(b).
     """
-    f_add_one = tvm_ffi.get_global_func("testing.add_one")
-    f_nop = tvm_ffi.get_global_func("testing.nop")
+    f_add_one = ffi.get_global_func("testing.add_one")
+    f_nop = ffi.get_global_func("testing.nop")
     assert RecursiveEq(f_add_one, f_nop)
     assert RecursiveHash(f_add_one) == RecursiveHash(f_nop)
 
@@ -829,8 +829,8 @@ def test_tensor_hash_consistent_with_eq() -> None:
 
     Hash must be consistent: RecursiveEq(a, b) => RecursiveHash(a) == RecursiveHash(b).
     """
-    t1 = tvm_ffi.from_dlpack(np.array([1, 2], dtype="int32"))
-    t2 = tvm_ffi.from_dlpack(np.array([[9, 8, 7]], dtype="int64"))
+    t1 = ffi.from_dlpack(np.array([1, 2], dtype="int32"))
+    t2 = ffi.from_dlpack(np.array([[9, 8, 7]], dtype="int64"))
     assert RecursiveEq(t1, t2)
     assert RecursiveHash(t1) == RecursiveHash(t2)
 
@@ -839,7 +839,7 @@ def _make_shared_binary_dag(depth: int) -> object:
     node: object = 1
     for _ in range(depth):
         # Two edges point to the same child object (DAG with heavy sharing).
-        node = tvm_ffi.Array([node, node])
+        node = ffi.Array([node, node])
     return node
 
 
@@ -886,13 +886,13 @@ def test_custom_hash_different_key() -> None:
 
 def test_custom_hash_in_container() -> None:
     """Custom-hooked objects inside an Array."""
-    a = tvm_ffi.Array(
+    a = ffi.Array(
         [
             TestCustomHash(1, "x"),
             TestCustomHash(2, "y"),
         ]
     )
-    b = tvm_ffi.Array(
+    b = ffi.Array(
         [
             TestCustomHash(1, "different"),
             TestCustomHash(2, "labels"),
@@ -929,14 +929,14 @@ def test_custom_compare_eq_implies_hash_same_direct(
 @pytest.mark.parametrize(
     "wrap",
     [
-        lambda obj: tvm_ffi.Array([obj]),
-        lambda obj: tvm_ffi.List([obj]),
-        lambda obj: tvm_ffi.Array([0, obj, 1]),
-        lambda obj: tvm_ffi.List([0, obj, 1]),
-        lambda obj: tvm_ffi.Map({"k": obj}),
-        lambda obj: tvm_ffi.Dict({"k": obj}),
-        lambda obj: tvm_ffi.Array([tvm_ffi.Array([obj])]),
-        lambda obj: tvm_ffi.List([tvm_ffi.List([obj])]),
+        lambda obj: ffi.Array([obj]),
+        lambda obj: ffi.List([obj]),
+        lambda obj: ffi.Array([0, obj, 1]),
+        lambda obj: ffi.List([0, obj, 1]),
+        lambda obj: ffi.Map({"k": obj}),
+        lambda obj: ffi.Dict({"k": obj}),
+        lambda obj: ffi.Array([ffi.Array([obj])]),
+        lambda obj: ffi.List([ffi.List([obj])]),
     ],
 )
 def test_custom_compare_eq_implies_hash_same_in_wrappers(
@@ -965,7 +965,7 @@ def test_eq_without_hash_raises() -> None:
 def test_eq_without_hash_inside_container_raises() -> None:
     """The guard also triggers when the object is nested inside a container."""
     obj = TestEqWithoutHash(1, "hello")
-    arr = tvm_ffi.Array([obj])
+    arr = ffi.Array([obj])
     with pytest.raises(ValueError, match="__ffi_eq__ or __ffi_compare__ but not __ffi_hash__"):
         RecursiveHash(arr)
 

--- a/tests/python/test_dataclass_py_class.py
+++ b/tests/python/test_dataclass_py_class.py
@@ -28,7 +28,7 @@ import sys
 from typing import Any, ClassVar, Dict, List, Optional
 
 import pytest
-import tvm_ffi
+import tvm_ffi as ffi
 from tvm_ffi import core
 from tvm_ffi._ffi_api import DeepCopy, RecursiveEq, RecursiveHash, ReprPrint
 from tvm_ffi.core import MISSING, Object, TypeInfo, TypeSchema, _to_py_class_value
@@ -1695,7 +1695,7 @@ class TestGetterSetter:
             ],
         )
         obj = Cls(arr=[1])
-        obj.arr = tvm_ffi.Array([4, 5, 6])
+        obj.arr = ffi.Array([4, 5, 6])
         assert len(obj.arr) == 3
         assert obj.arr[0] == 4
 
@@ -1717,7 +1717,7 @@ class TestObjectRefFields:
                 ),
             ],
         )
-        obj = Cls(arr=tvm_ffi.Array([1, 2, 3]))
+        obj = Cls(arr=ffi.Array([1, 2, 3]))
         assert len(obj.arr) == 3
         assert obj.arr[0] == 1
         assert obj.arr[2] == 3
@@ -1882,7 +1882,7 @@ class TestOptionalFields:
         )
         obj = Cls()
         assert obj.ref is None
-        obj.ref = tvm_ffi.Array([1])
+        obj.ref = ffi.Array([1])
         assert len(obj.ref) == 1
         obj.ref = None
         assert obj.ref is None
@@ -1977,7 +1977,7 @@ class TestAnyField:
             "AnyObj",
             [Field(name="val", ty=TypeSchema("Any"), default=None)],
         )
-        arr = tvm_ffi.Array([1, 2])
+        arr = ffi.Array([1, 2])
         assert len(Cls(val=arr).val) == 2
 
     def test_any_type_change(self) -> None:
@@ -1992,7 +1992,7 @@ class TestAnyField:
         assert obj.val == "hello"
         obj.val = None
         assert obj.val is None
-        obj.val = tvm_ffi.Array([1])
+        obj.val = ffi.Array([1])
         assert len(obj.val) == 1
 
 
@@ -2009,7 +2009,7 @@ class TestDefaultFactory:
                 Field(
                     name="data",
                     ty=TypeSchema("Array", (TypeSchema("int"),)),
-                    default_factory=lambda: tvm_ffi.Array([]),
+                    default_factory=lambda: ffi.Array([]),
                 ),
             ],
         )
@@ -2024,7 +2024,7 @@ class TestDefaultFactory:
                 Field(
                     name="items",
                     ty=TypeSchema("Array", (TypeSchema("int"),)),
-                    default_factory=lambda: tvm_ffi.Array([1, 2, 3]),
+                    default_factory=lambda: ffi.Array([1, 2, 3]),
                 ),
             ],
         )
@@ -3001,7 +3001,7 @@ class TestDeepCopy:
                 ),
             ],
         )
-        obj = Cls(items=tvm_ffi.Array([1, 2, 3]))
+        obj = Cls(items=ffi.Array([1, 2, 3]))
         obj_copy = DeepCopy(obj)
         assert not obj.items.same_as(obj_copy.items)
         assert len(obj_copy.items) == 3
@@ -3044,7 +3044,7 @@ class TestMemoryLifetime:
                 ),
             ],
         )
-        arr = tvm_ffi.Array([1, 2, 3])
+        arr = ffi.Array([1, 2, 3])
         obj = Cls(arr=arr)
         del arr
         gc.collect()
@@ -3061,7 +3061,7 @@ class TestMemoryLifetime:
                 ),
             ],
         )
-        shared = tvm_ffi.Array([10, 20])
+        shared = ffi.Array([10, 20])
         a = Cls(arr=shared)
         b = Cls(arr=shared)
         del a
@@ -3208,7 +3208,7 @@ class TestTypeConversionErrors:
                 ),
             ],
         )
-        obj = Cls(child=tvm_ffi.Array([1]))
+        obj = Cls(child=ffi.Array([1]))
         with pytest.raises((TypeError, RuntimeError)):
             obj.child = None
 
@@ -3241,7 +3241,7 @@ class TestTypeConversionErrors:
         )
         obj = Cls()
         assert obj.child is None
-        obj.child = tvm_ffi.Array([1, 2])
+        obj.child = ffi.Array([1, 2])
         assert len(obj.child) == 2
         obj.child = None
         assert obj.child is None
@@ -3405,7 +3405,7 @@ class TestSetterGetterCornerCases:
         )
         obj = Cls(arr=[0])
         for i in range(50):
-            obj.arr = tvm_ffi.Array([i])
+            obj.arr = ffi.Array([i])
         assert obj.arr[0] == 49
 
     # --- Nested object fields ---
@@ -3501,7 +3501,7 @@ class TestSetterGetterCornerCases:
         obj.f = -2.0
         obj.b = False
         obj.s = "bye"
-        obj.arr = tvm_ffi.Array([30])
+        obj.arr = ffi.Array([30])
         obj.opt = 42
         assert obj.i == -1
         assert obj.f == pytest.approx(-2.0)
@@ -3518,19 +3518,19 @@ class TestFFIGlobalFunctions:
     """Low-level FFI global function registration checks."""
 
     def test_make_ffi_new_exists(self) -> None:
-        assert tvm_ffi.get_global_func("ffi.MakeFFINew", allow_missing=True) is not None
+        assert ffi.get_global_func("ffi.MakeFFINew", allow_missing=True) is not None
 
     def test_register_auto_init_exists(self) -> None:
-        assert tvm_ffi.get_global_func("ffi.RegisterAutoInit", allow_missing=True) is not None
+        assert ffi.get_global_func("ffi.RegisterAutoInit", allow_missing=True) is not None
 
     def test_get_field_getter_exists(self) -> None:
-        assert tvm_ffi.get_global_func("ffi.GetFieldGetter", allow_missing=True) is not None
+        assert ffi.get_global_func("ffi.GetFieldGetter", allow_missing=True) is not None
 
     def test_make_field_setter_exists(self) -> None:
-        assert tvm_ffi.get_global_func("ffi.MakeFieldSetter", allow_missing=True) is not None
+        assert ffi.get_global_func("ffi.MakeFieldSetter", allow_missing=True) is not None
 
     def test_make_new_removed(self) -> None:
-        assert tvm_ffi.get_global_func("ffi.MakeNew", allow_missing=True) is None
+        assert ffi.get_global_func("ffi.MakeNew", allow_missing=True) is None
 
 
 # ###########################################################################
@@ -3722,19 +3722,19 @@ class TestFunctionField:
     def test_function_field(self) -> None:
         @py_class(_unique_key("FuncFld"))
         class FuncFld(Object):
-            func: tvm_ffi.Function
+            func: ffi.Function
 
-        fn = tvm_ffi.convert(lambda x: x + 1)
+        fn = ffi.convert(lambda x: x + 1)
         obj = FuncFld(func=fn)
         assert obj.func(1) == 2
 
     def test_function_field_set(self) -> None:
         @py_class(_unique_key("FuncSet"))
         class FuncSet(Object):
-            func: tvm_ffi.Function
+            func: ffi.Function
 
-        fn1 = tvm_ffi.convert(lambda x: x + 1)
-        fn2 = tvm_ffi.convert(lambda x: x + 2)
+        fn1 = ffi.convert(lambda x: x + 1)
+        fn2 = ffi.convert(lambda x: x + 2)
         obj = FuncSet(func=fn1)
         assert obj.func(1) == 2
         obj.func = fn2
@@ -3744,11 +3744,11 @@ class TestFunctionField:
     def test_optional_function_field(self) -> None:
         @py_class(_unique_key("OptFunc"))
         class OptFunc(Object):
-            func: Optional[tvm_ffi.Function]
+            func: Optional[ffi.Function]
 
         obj = OptFunc(func=None)
         assert obj.func is None
-        obj.func = tvm_ffi.convert(lambda x: x * 2)
+        obj.func = ffi.convert(lambda x: x * 2)
         assert obj.func(3) == 6
         obj.func = None
         assert obj.func is None
@@ -3799,7 +3799,7 @@ class TestAnyFieldDecorator:
         assert obj.val == 42
         obj.val = "hello"
         assert obj.val == "hello"
-        obj.val = tvm_ffi.Array([1, 2])
+        obj.val = ffi.Array([1, 2])
         assert len(obj.val) == 2
         obj.val = None
         assert obj.val is None
@@ -4153,11 +4153,11 @@ class TestOptionalFieldCycles:
     def test_opt_func_type_rejection(self) -> None:
         @py_class(_unique_key("OptFuncR"))
         class OptFuncR(Object):
-            func: Optional[tvm_ffi.Function]
+            func: Optional[ffi.Function]
 
         obj = OptFuncR(func=None)
         assert obj.func is None
-        obj.func = tvm_ffi.convert(lambda x: x + 2)
+        obj.func = ffi.convert(lambda x: x + 2)
         assert obj.func(1) == 3
         obj.func = None
         assert obj.func is None

--- a/tests/python/test_dataclass_repr.py
+++ b/tests/python/test_dataclass_repr.py
@@ -23,7 +23,7 @@ import re
 
 import numpy as np
 import pytest
-import tvm_ffi
+import tvm_ffi as ffi
 import tvm_ffi.testing
 from tvm_ffi._ffi_api import ReprPrint
 
@@ -68,27 +68,27 @@ def test_repr_string() -> None:
 
 def test_repr_array() -> None:
     """Test repr of FFI Array uses tuple format."""
-    assert ReprPrint(tvm_ffi.Array([1, 2, 3])) == "(1, 2, 3)"
+    assert ReprPrint(ffi.Array([1, 2, 3])) == "(1, 2, 3)"
 
 
 def test_repr_array_single() -> None:
     """Test repr of single-element Array has trailing comma."""
-    assert ReprPrint(tvm_ffi.Array([42])) == "(42,)"
+    assert ReprPrint(ffi.Array([42])) == "(42,)"
 
 
 def test_repr_array_empty() -> None:
     """Test repr of empty Array."""
-    assert ReprPrint(tvm_ffi.Array([])) == "()"
+    assert ReprPrint(ffi.Array([])) == "()"
 
 
 def test_repr_array_nested_strings() -> None:
     """Test repr of Array containing strings."""
-    assert ReprPrint(tvm_ffi.Array(["a", "b"])) == '("a", "b")'
+    assert ReprPrint(ffi.Array(["a", "b"])) == '("a", "b")'
 
 
 def test_repr_array_python_repr() -> None:
     """Test that Array.__repr__ uses the centralized repr."""
-    assert repr(tvm_ffi.Array([1, 2])) == "(1, 2)"
+    assert repr(ffi.Array([1, 2])) == "(1, 2)"
 
 
 # ---------- List ----------
@@ -96,22 +96,22 @@ def test_repr_array_python_repr() -> None:
 
 def test_repr_list() -> None:
     """Test repr of FFI List uses list format."""
-    assert ReprPrint(tvm_ffi.List([10, 20])) == "[10, 20]"
+    assert ReprPrint(ffi.List([10, 20])) == "[10, 20]"
 
 
 def test_repr_list_single() -> None:
     """Test repr of single-element List (no trailing comma)."""
-    assert ReprPrint(tvm_ffi.List([99])) == "[99]"
+    assert ReprPrint(ffi.List([99])) == "[99]"
 
 
 def test_repr_list_empty() -> None:
     """Test repr of empty List."""
-    assert ReprPrint(tvm_ffi.List([])) == "[]"
+    assert ReprPrint(ffi.List([])) == "[]"
 
 
 def test_repr_list_nested_strings() -> None:
     """Test repr of List containing strings."""
-    assert ReprPrint(tvm_ffi.List(["x", "y"])) == '["x", "y"]'
+    assert ReprPrint(ffi.List(["x", "y"])) == '["x", "y"]'
 
 
 # ---------- Map ----------
@@ -119,12 +119,12 @@ def test_repr_list_nested_strings() -> None:
 
 def test_repr_map() -> None:
     """Test repr of FFI Map."""
-    assert ReprPrint(tvm_ffi.Map({"key": "value"})) == '{"key": "value"}'
+    assert ReprPrint(ffi.Map({"key": "value"})) == '{"key": "value"}'
 
 
 def test_repr_map_empty() -> None:
     """Test repr of empty Map."""
-    assert ReprPrint(tvm_ffi.Map({})) == "{}"
+    assert ReprPrint(ffi.Map({})) == "{}"
 
 
 # ---------- Dict ----------
@@ -132,17 +132,17 @@ def test_repr_map_empty() -> None:
 
 def test_repr_dict() -> None:
     """Test repr of FFI Dict."""
-    assert ReprPrint(tvm_ffi.Dict({"key": "value"})) == '{"key": "value"}'
+    assert ReprPrint(ffi.Dict({"key": "value"})) == '{"key": "value"}'
 
 
 def test_repr_dict_empty() -> None:
     """Test repr of empty Dict."""
-    assert ReprPrint(tvm_ffi.Dict({})) == "{}"
+    assert ReprPrint(ffi.Dict({})) == "{}"
 
 
 def test_repr_dict_int_keys() -> None:
     """Test repr of Dict with integer keys."""
-    d = tvm_ffi.Dict({1: 2, 3: 4})
+    d = ffi.Dict({1: 2, 3: 4})
     result = ReprPrint(d)
     # Dict iteration order is hash-dependent; match either ordering.
     _check(result, r"(?:\{1: 2, 3: 4\}|\{3: 4, 1: 2\})")
@@ -150,13 +150,13 @@ def test_repr_dict_int_keys() -> None:
 
 def test_repr_dict_with_array_values() -> None:
     """Test repr of Dict with Array values."""
-    assert ReprPrint(tvm_ffi.Dict({1: tvm_ffi.Array([10, 20])})) == "{1: (10, 20)}"
+    assert ReprPrint(ffi.Dict({1: ffi.Array([10, 20])})) == "{1: (10, 20)}"
 
 
 def test_repr_dict_with_object_values() -> None:
     """Test repr of Dict with object values."""
-    pair = tvm_ffi.testing.create_object("testing.TestIntPair", a=1, b=2)
-    d = tvm_ffi.Dict({"obj": pair})
+    pair = ffi.testing.create_object("testing.TestIntPair", a=1, b=2)
+    d = ffi.Dict({"obj": pair})
     assert ReprPrint(d) == '{"obj": testing.TestIntPair(a=1, b=2)}'
 
 
@@ -165,13 +165,13 @@ def test_repr_dict_with_object_values() -> None:
 
 def test_repr_tensor() -> None:
     """Test repr of Tensor shows dtype, shape, device (no address by default)."""
-    x = tvm_ffi.from_dlpack(np.zeros((3, 4), dtype="float32"))
+    x = ffi.from_dlpack(np.zeros((3, 4), dtype="float32"))
     assert ReprPrint(x) == "float32[3, 4]@cpu:0"
 
 
 def test_repr_tensor_int8() -> None:
     """Test repr of Tensor with int8 dtype."""
-    x = tvm_ffi.from_dlpack(np.zeros((2,), dtype="int8"))
+    x = ffi.from_dlpack(np.zeros((2,), dtype="int8"))
     assert ReprPrint(x) == "int8[2]@cpu:0"
 
 
@@ -180,7 +180,7 @@ def test_repr_tensor_int8() -> None:
 
 def test_repr_shape() -> None:
     """Test repr of Shape."""
-    assert ReprPrint(tvm_ffi.Shape((5, 6))) == "Shape(5, 6)"
+    assert ReprPrint(ffi.Shape((5, 6))) == "Shape(5, 6)"
 
 
 # ---------- User-defined objects ----------
@@ -188,20 +188,20 @@ def test_repr_shape() -> None:
 
 def test_repr_user_object_all_fields() -> None:
     """Test repr of user-defined object with all fields shown (no address by default)."""
-    obj = tvm_ffi.testing.create_object("testing.TestIntPair", a=10, b=20)
+    obj = ffi.testing.create_object("testing.TestIntPair", a=10, b=20)
     assert ReprPrint(obj) == "testing.TestIntPair(a=10, b=20)"
 
 
 def test_repr_user_object_repr_off() -> None:
     """Test repr of object with Repr(false) fields excluded."""
     # Positional order: required first (v_i64, v_i32, v_f64), then optional (v_f32)
-    obj = tvm_ffi.testing._TestCxxClassDerived(1, 2, 3.5, 4.5)
+    obj = ffi.testing._TestCxxClassDerived(1, 2, 3.5, 4.5)
     assert ReprPrint(obj) == "testing.TestCxxClassDerived(v_f64=3.5, v_f32=4.5)"
 
 
 def test_repr_python_repr() -> None:
     """Test that Python __repr__ delegates to ReprPrint."""
-    obj = tvm_ffi.testing.create_object("testing.TestIntPair", a=5, b=6)
+    obj = ffi.testing.create_object("testing.TestIntPair", a=5, b=6)
     assert repr(obj) == "testing.TestIntPair(a=5, b=6)"
 
 
@@ -210,16 +210,16 @@ def test_repr_python_repr() -> None:
 
 def test_repr_duplicate_reference() -> None:
     """Test that duplicate object references use full form on every occurrence."""
-    inner = tvm_ffi.testing.create_object("testing.TestIntPair", a=1, b=2)
-    arr = tvm_ffi.Array([inner, inner])
+    inner = ffi.testing.create_object("testing.TestIntPair", a=1, b=2)
+    arr = ffi.Array([inner, inner])
     result = ReprPrint(arr)
     assert result == "(testing.TestIntPair(a=1, b=2), testing.TestIntPair(a=1, b=2))"
 
 
 def test_repr_shared_in_map_values() -> None:
     """Test that the same Array shared in Map values uses full form on both."""
-    shared = tvm_ffi.Array([1, 2])
-    m = tvm_ffi.Map({"a": shared, "b": shared})
+    shared = ffi.Array([1, 2])
+    m = ffi.Map({"a": shared, "b": shared})
     result = ReprPrint(m)
     # Map iteration order is hash-dependent; match either ordering.
     pat_ab = r'\{"a": \(1, 2\), "b": \(1, 2\)\}'
@@ -229,16 +229,16 @@ def test_repr_shared_in_map_values() -> None:
 
 def test_repr_shared_across_nesting_levels() -> None:
     """Test shared object across different nesting levels uses full form everywhere."""
-    leaf = tvm_ffi.testing.create_object("testing.TestIntPair", a=7, b=8)
-    arr = tvm_ffi.Array([leaf, tvm_ffi.Array([leaf])])
+    leaf = ffi.testing.create_object("testing.TestIntPair", a=7, b=8)
+    arr = ffi.Array([leaf, ffi.Array([leaf])])
     result = ReprPrint(arr)
     assert result == "(testing.TestIntPair(a=7, b=8), (testing.TestIntPair(a=7, b=8),))"
 
 
 def test_repr_triple_shared_reference() -> None:
     """Test object appearing three times -- full form every time."""
-    inner = tvm_ffi.testing.create_object("testing.TestIntPair", a=0, b=0)
-    arr = tvm_ffi.Array([inner, inner, inner])
+    inner = ffi.testing.create_object("testing.TestIntPair", a=0, b=0)
+    arr = ffi.Array([inner, inner, inner])
     result = ReprPrint(arr)
     assert result == (
         "(testing.TestIntPair(a=0, b=0), "
@@ -252,21 +252,21 @@ def test_repr_triple_shared_reference() -> None:
 
 def test_repr_array_of_arrays() -> None:
     """Test repr of Array containing Arrays."""
-    inner = tvm_ffi.Array([1, 2])
-    outer = tvm_ffi.Array([inner, tvm_ffi.Array([3])])
+    inner = ffi.Array([1, 2])
+    outer = ffi.Array([inner, ffi.Array([3])])
     assert ReprPrint(outer) == "((1, 2), (3,))"
 
 
 def test_repr_map_of_containers() -> None:
     """Test repr of Map containing Array values."""
-    m = tvm_ffi.Map({"a": tvm_ffi.Array([1, 2])})
+    m = ffi.Map({"a": ffi.Array([1, 2])})
     assert ReprPrint(m) == '{"a": (1, 2)}'
 
 
 def test_repr_list_of_lists() -> None:
     """Test repr of List containing Lists."""
-    inner = tvm_ffi.List([1, 2])
-    outer = tvm_ffi.List([inner, tvm_ffi.List([3])])
+    inner = ffi.List([1, 2])
+    outer = ffi.List([inner, ffi.List([3])])
     assert ReprPrint(outer) == "[[1, 2], [3]]"
 
 
@@ -275,14 +275,14 @@ def test_repr_list_of_lists() -> None:
 
 def test_repr_nested_dataclass() -> None:
     """Test repr of object with object-typed fields."""
-    inner = tvm_ffi.testing.create_object("testing.TestIntPair", a=10, b=20)
-    obj = tvm_ffi.testing.create_object(
+    inner = ffi.testing.create_object("testing.TestIntPair", a=10, b=20)
+    obj = ffi.testing.create_object(
         "testing.TestObjectDerived",
         v_i64=1,
         v_f64=2.5,
         v_str="hi",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([inner]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([inner]),
     )
     assert ReprPrint(obj) == (
         'testing.TestObjectDerived(v_i64=1, v_f64=2.5, v_str="hi", '
@@ -293,13 +293,13 @@ def test_repr_nested_dataclass() -> None:
 
 def test_repr_object_with_none_field() -> None:
     """Test repr of object where container fields are empty."""
-    obj = tvm_ffi.testing.create_object(
+    obj = ffi.testing.create_object(
         "testing.TestObjectDerived",
         v_i64=0,
         v_f64=0.0,
         v_str="",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([]),
     )
     assert (
         ReprPrint(obj)
@@ -312,25 +312,25 @@ def test_repr_object_with_none_field() -> None:
 
 def test_repr_deeply_nested_arrays() -> None:
     """Test repr of deeply nested Arrays (4 levels)."""
-    a = tvm_ffi.Array([1])
+    a = ffi.Array([1])
     for _ in range(3):
-        a = tvm_ffi.Array([a])
+        a = ffi.Array([a])
     assert ReprPrint(a) == "((((1,),),),)"
 
 
 def test_repr_deeply_nested_lists() -> None:
     """Test repr of deeply nested Lists (4 levels)."""
-    lst = tvm_ffi.List([1])
+    lst = ffi.List([1])
     for _ in range(3):
-        lst = tvm_ffi.List([lst])
+        lst = ffi.List([lst])
     assert ReprPrint(lst) == "[[[[1]]]]"
 
 
 def test_repr_mixed_container_nesting() -> None:
     """Test repr of mixed Array/List/Map nesting."""
-    inner_list = tvm_ffi.List([1, 2])
-    inner_arr = tvm_ffi.Array([inner_list])
-    m = tvm_ffi.Map({"nested": inner_arr})
+    inner_list = ffi.List([1, 2])
+    inner_arr = ffi.Array([inner_list])
+    m = ffi.Map({"nested": inner_arr})
     assert ReprPrint(m) == '{"nested": ([1, 2],)}'
 
 
@@ -339,24 +339,24 @@ def test_repr_mixed_container_nesting() -> None:
 
 def test_repr_dataclass_shared_subobject() -> None:
     """Test repr of two dataclasses sharing the same sub-object (full form in both)."""
-    shared = tvm_ffi.testing.create_object("testing.TestIntPair", a=5, b=5)
-    obj1 = tvm_ffi.testing.create_object(
+    shared = ffi.testing.create_object("testing.TestIntPair", a=5, b=5)
+    obj1 = ffi.testing.create_object(
         "testing.TestObjectDerived",
         v_i64=1,
         v_f64=0.0,
         v_str="",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([shared]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([shared]),
     )
-    obj2 = tvm_ffi.testing.create_object(
+    obj2 = ffi.testing.create_object(
         "testing.TestObjectDerived",
         v_i64=2,
         v_f64=0.0,
         v_str="",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([shared]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([shared]),
     )
-    arr = tvm_ffi.Array([obj1, obj2])
+    arr = ffi.Array([obj1, obj2])
     result = ReprPrint(arr)
     assert result == (
         "("
@@ -373,8 +373,8 @@ def test_repr_dataclass_shared_subobject() -> None:
 
 def test_repr_array_of_dataclasses() -> None:
     """Test repr of Array of user-defined objects."""
-    objs = [tvm_ffi.testing.create_object("testing.TestIntPair", a=i, b=i * 10) for i in range(3)]
-    arr = tvm_ffi.Array(objs)
+    objs = [ffi.testing.create_object("testing.TestIntPair", a=i, b=i * 10) for i in range(3)]
+    arr = ffi.Array(objs)
     assert ReprPrint(arr) == (
         "(testing.TestIntPair(a=0, b=0), "
         "testing.TestIntPair(a=1, b=10), "
@@ -384,8 +384,8 @@ def test_repr_array_of_dataclasses() -> None:
 
 def test_repr_map_with_object_values() -> None:
     """Test repr of Map with object values."""
-    pair = tvm_ffi.testing.create_object("testing.TestIntPair", a=1, b=2)
-    m = tvm_ffi.Map({"obj": pair})
+    pair = ffi.testing.create_object("testing.TestIntPair", a=1, b=2)
+    m = ffi.Map({"obj": pair})
     assert ReprPrint(m) == '{"obj": testing.TestIntPair(a=1, b=2)}'
 
 
@@ -395,7 +395,7 @@ def test_repr_map_with_object_values() -> None:
 def test_repr_derived_derived_shows_all_own_fields() -> None:
     """TestCxxClassDerivedDerived should show v_f64, v_f32, v_str, v_bool (not v_i64, v_i32)."""
     # Positional order: required (v_i64, v_i32, v_f64, v_bool), then optional (v_f32, v_str)
-    obj = tvm_ffi.testing._TestCxxClassDerivedDerived(1, 2, 3.0, True, 4.0, "test")
+    obj = ffi.testing._TestCxxClassDerivedDerived(1, 2, 3.0, True, 4.0, "test")
     assert (
         ReprPrint(obj)
         == 'testing.TestCxxClassDerivedDerived(v_f64=3, v_f32=4, v_str="test", v_bool=True)'
@@ -428,22 +428,22 @@ def test_repr_string_with_spaces() -> None:
 
 def test_repr_array_of_none() -> None:
     """Test repr of Array containing None values."""
-    assert ReprPrint(tvm_ffi.Array([None, None])) == "(None, None)"
+    assert ReprPrint(ffi.Array([None, None])) == "(None, None)"
 
 
 def test_repr_array_of_booleans() -> None:
     """Test repr of Array containing boolean values."""
-    assert ReprPrint(tvm_ffi.Array([True, False])) == "(True, False)"
+    assert ReprPrint(ffi.Array([True, False])) == "(True, False)"
 
 
 def test_repr_array_of_mixed_types() -> None:
     """Test repr of Array containing mixed primitive types."""
-    assert ReprPrint(tvm_ffi.Array([1, "hello", True, None])) == '(1, "hello", True, None)'
+    assert ReprPrint(ffi.Array([1, "hello", True, None])) == '(1, "hello", True, None)'
 
 
 def test_repr_map_int_keys() -> None:
     """Test repr of Map with integer keys."""
-    m = tvm_ffi.Map({1: 2, 3: 4})
+    m = ffi.Map({1: 2, 3: 4})
     result = ReprPrint(m)
     # Map iteration order is hash-dependent; match either ordering.
     _check(result, r"(?:\{1: 2, 3: 4\}|\{3: 4, 1: 2\})")
@@ -451,7 +451,7 @@ def test_repr_map_int_keys() -> None:
 
 def test_repr_map_with_array_values() -> None:
     """Test repr of Map with Array values."""
-    assert ReprPrint(tvm_ffi.Map({1: tvm_ffi.Array([10, 20])})) == "{1: (10, 20)}"
+    assert ReprPrint(ffi.Map({1: ffi.Array([10, 20])})) == "{1: (10, 20)}"
 
 
 # ---------- Nested dataclass edge cases ----------
@@ -459,15 +459,15 @@ def test_repr_map_with_array_values() -> None:
 
 def test_repr_dataclass_with_array_field() -> None:
     """Test repr of dataclass whose field is an Array of objects."""
-    pair1 = tvm_ffi.testing.create_object("testing.TestIntPair", a=1, b=2)
-    pair2 = tvm_ffi.testing.create_object("testing.TestIntPair", a=3, b=4)
-    obj = tvm_ffi.testing.create_object(
+    pair1 = ffi.testing.create_object("testing.TestIntPair", a=1, b=2)
+    pair2 = ffi.testing.create_object("testing.TestIntPair", a=3, b=4)
+    obj = ffi.testing.create_object(
         "testing.TestObjectDerived",
         v_i64=0,
         v_f64=0.0,
         v_str="test",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([pair1, pair2]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([pair1, pair2]),
     )
     assert ReprPrint(obj) == (
         'testing.TestObjectDerived(v_i64=0, v_f64=0, v_str="test", '
@@ -478,13 +478,13 @@ def test_repr_dataclass_with_array_field() -> None:
 
 def test_repr_dataclass_with_map_field() -> None:
     """Test repr of dataclass whose field is a Map."""
-    obj = tvm_ffi.testing.create_object(
+    obj = ffi.testing.create_object(
         "testing.TestObjectDerived",
         v_i64=42,
         v_f64=1.0,
         v_str="s",
-        v_map=tvm_ffi.Map({"x": 10}),
-        v_array=tvm_ffi.Array([]),
+        v_map=ffi.Map({"x": 10}),
+        v_array=ffi.Array([]),
     )
     assert ReprPrint(obj) == (
         'testing.TestObjectDerived(v_i64=42, v_f64=1, v_str="s", v_map={"x": 10}, v_array=())'
@@ -496,15 +496,15 @@ def test_repr_dataclass_with_map_field() -> None:
 
 def test_repr_self_reference_cycle() -> None:
     """Test that self-referencing cycles show '...' marker."""
-    obj = tvm_ffi.testing.create_object(
+    obj = ffi.testing.create_object(
         "testing.TestObjectDerived",
         v_i64=1,
         v_f64=2.0,
         v_str="hi",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([]),
     )
-    obj.v_array = tvm_ffi.Array([obj])  # type: ignore[unresolved-attribute]
+    obj.v_array = ffi.Array([obj])  # type: ignore[unresolved-attribute]
     result = ReprPrint(obj)
     assert result == (
         'testing.TestObjectDerived(v_i64=1, v_f64=2, v_str="hi", v_map={}, v_array=(...,))'
@@ -513,24 +513,24 @@ def test_repr_self_reference_cycle() -> None:
 
 def test_repr_mutual_reference_cycle() -> None:
     """Test that mutual reference cycles show '...' marker."""
-    v_map = tvm_ffi.Map({})
-    obj_a = tvm_ffi.testing.create_object(
+    v_map = ffi.Map({})
+    obj_a = ffi.testing.create_object(
         "testing.TestObjectDerived",
         v_i64=1,
         v_f64=0.0,
         v_str="a",
         v_map=v_map,
-        v_array=tvm_ffi.Array([]),
+        v_array=ffi.Array([]),
     )
-    obj_b = tvm_ffi.testing.create_object(
+    obj_b = ffi.testing.create_object(
         "testing.TestObjectDerived",
         v_i64=2,
         v_f64=0.0,
         v_str="b",
         v_map=v_map,
-        v_array=tvm_ffi.Array([obj_a]),
+        v_array=ffi.Array([obj_a]),
     )
-    obj_a.v_array = tvm_ffi.Array([obj_b])  # type: ignore[unresolved-attribute]
+    obj_a.v_array = ffi.Array([obj_b])  # type: ignore[unresolved-attribute]
     result = ReprPrint(obj_a)
     assert result == (
         'testing.TestObjectDerived(v_i64=1, v_f64=0, v_str="a", v_map={}, '
@@ -545,36 +545,36 @@ def test_repr_mutual_reference_cycle() -> None:
 def test_repr_with_addr_user_object(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that user objects show address when TVM_FFI_REPR_WITH_ADDR is set."""
     monkeypatch.setenv("TVM_FFI_REPR_WITH_ADDR", "1")
-    obj = tvm_ffi.testing.create_object("testing.TestIntPair", a=1, b=2)
+    obj = ffi.testing.create_object("testing.TestIntPair", a=1, b=2)
     _check(ReprPrint(obj), rf"testing\.TestIntPair@{A}\(a=1, b=2\)")
 
 
 def test_repr_with_addr_array(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that Array shows address suffix when TVM_FFI_REPR_WITH_ADDR is set."""
     monkeypatch.setenv("TVM_FFI_REPR_WITH_ADDR", "1")
-    arr = tvm_ffi.Array([1, 2, 3])
+    arr = ffi.Array([1, 2, 3])
     _check(ReprPrint(arr), rf"\(1, 2, 3\)@{A}")
 
 
 def test_repr_with_addr_list(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that List shows address suffix when TVM_FFI_REPR_WITH_ADDR is set."""
     monkeypatch.setenv("TVM_FFI_REPR_WITH_ADDR", "1")
-    lst = tvm_ffi.List([10, 20])
+    lst = ffi.List([10, 20])
     _check(ReprPrint(lst), rf"\[10, 20\]@{A}")
 
 
 def test_repr_with_addr_dict(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that Dict shows address suffix when TVM_FFI_REPR_WITH_ADDR is set."""
     monkeypatch.setenv("TVM_FFI_REPR_WITH_ADDR", "1")
-    d = tvm_ffi.Dict({"a": 1})
+    d = ffi.Dict({"a": 1})
     _check(ReprPrint(d), rf'\{{"a": 1\}}@{A}')
 
 
 def test_repr_with_addr_dag(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test DAG with addresses: both occurrences show full form with same address."""
     monkeypatch.setenv("TVM_FFI_REPR_WITH_ADDR", "1")
-    inner = tvm_ffi.testing.create_object("testing.TestIntPair", a=1, b=2)
-    arr = tvm_ffi.Array([inner, inner])
+    inner = ffi.testing.create_object("testing.TestIntPair", a=1, b=2)
+    arr = ffi.Array([inner, inner])
     result = ReprPrint(arr)
     _check(
         result,
@@ -586,15 +586,15 @@ def test_repr_with_addr_dag(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_repr_with_addr_cycle(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test cycle with addresses: '...@ADDR' points back to the cyclic object."""
     monkeypatch.setenv("TVM_FFI_REPR_WITH_ADDR", "1")
-    obj = tvm_ffi.testing.create_object(
+    obj = ffi.testing.create_object(
         "testing.TestObjectDerived",
         v_i64=1,
         v_f64=0.0,
         v_str="",
-        v_map=tvm_ffi.Map({}),
-        v_array=tvm_ffi.Array([]),
+        v_map=ffi.Map({}),
+        v_array=ffi.Array([]),
     )
-    obj.v_array = tvm_ffi.Array([obj])  # type: ignore[unresolved-attribute]
+    obj.v_array = ffi.Array([obj])  # type: ignore[unresolved-attribute]
     result = ReprPrint(obj)
     _check(
         result,
@@ -608,7 +608,7 @@ def test_repr_with_addr_cycle(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_repr_with_addr_tensor(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that Tensor shows address suffix when TVM_FFI_REPR_WITH_ADDR is set."""
     monkeypatch.setenv("TVM_FFI_REPR_WITH_ADDR", "1")
-    x = tvm_ffi.from_dlpack(np.zeros((3, 4), dtype="float32"))
+    x = ffi.from_dlpack(np.zeros((3, 4), dtype="float32"))
     _check(ReprPrint(x), rf"float32\[3, 4\]@cpu:0@{A}")
 
 
@@ -616,7 +616,7 @@ def test_repr_with_addr_no_fields(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that object with no visible fields shows TypeKey@ADDR with env var."""
     monkeypatch.setenv("TVM_FFI_REPR_WITH_ADDR", "1")
     # TestCxxClassBase has v_i64 and v_i32, both with Repr(false)
-    obj = tvm_ffi.testing._TestCxxClassBase(v_i64=1, v_i32=2)
+    obj = ffi.testing._TestCxxClassBase(v_i64=1, v_i32=2)
     _check(ReprPrint(obj), rf"testing\.TestCxxClassBase@{A}")
 
 
@@ -644,11 +644,11 @@ def test_repr_string_literal_roundtrip_special_chars(value: str) -> None:
 @pytest.mark.parametrize(
     ("value", "expected"),
     [
-        (tvm_ffi.Array(['a"b']), ('a"b',)),
-        (tvm_ffi.List(["a\\b"]), ["a\\b"]),
-        (tvm_ffi.Array(["\\"]), ("\\",)),
-        (tvm_ffi.Dict({"k": "a\nb"}), {"k": "a\nb"}),
-        (tvm_ffi.Map({"k": "a\x00b"}), {"k": "a\x00b"}),
+        (ffi.Array(['a"b']), ('a"b',)),
+        (ffi.List(["a\\b"]), ["a\\b"]),
+        (ffi.Array(["\\"]), ("\\",)),
+        (ffi.Dict({"k": "a\nb"}), {"k": "a\nb"}),
+        (ffi.Map({"k": "a\x00b"}), {"k": "a\x00b"}),
     ],
 )
 def test_repr_container_literal_roundtrip_special_strings(value: object, expected: object) -> None:
@@ -658,12 +658,12 @@ def test_repr_container_literal_roundtrip_special_strings(value: object, expecte
 
 def test_repr_device_trn_name() -> None:
     """DLDeviceType.kDLTrn should print as trn:<id>, not unknown:<id>."""
-    assert ReprPrint(tvm_ffi.Device("trn", 0)) == "trn:0"
+    assert ReprPrint(ffi.Device("trn", 0)) == "trn:0"
 
 
 def test_repr_unregistered_object_no_duplicate_field_names() -> None:
     """Inherited fields should not appear twice in generic repr."""
-    obj = tvm_ffi.testing.make_unregistered_object()
+    obj = ffi.testing.make_unregistered_object()
     result = ReprPrint(obj)
     assert result.count("v1=") == 1
 
@@ -723,7 +723,7 @@ def test_repr_py_class_in_array() -> None:
     class ReprInArr(_Object_repr):
         x: int
 
-    r = repr(tvm_ffi.Array([ReprInArr(x=1), ReprInArr(x=2)]))
+    r = repr(ffi.Array([ReprInArr(x=1), ReprInArr(x=2)]))
     assert "1" in r
     assert "2" in r
 

--- a/tests/python/test_device.py
+++ b/tests/python/test_device.py
@@ -22,21 +22,21 @@ import pickle
 
 import numpy
 import pytest
-import tvm_ffi
+import tvm_ffi as ffi
 from tvm_ffi import DLDeviceType
 
 
 def test_device() -> None:
-    device = tvm_ffi.Device("cuda", 0)
-    assert device.dlpack_device_type() == tvm_ffi.DLDeviceType.kDLCUDA
+    device = ffi.Device("cuda", 0)
+    assert device.dlpack_device_type() == ffi.DLDeviceType.kDLCUDA
     assert device.index == 0
     assert str(device) == "cuda:0"
     assert device.__repr__() == "device(type='cuda', index=0)"
 
 
 def test_device_from_str() -> None:
-    device = tvm_ffi.device("ext_dev:0")
-    assert device.dlpack_device_type() == tvm_ffi.DLDeviceType.kDLExtDev
+    device = ffi.device("ext_dev:0")
+    assert device.dlpack_device_type() == ffi.DLDeviceType.kDLExtDev
     assert device.index == 0
     assert str(device) == "ext_dev:0"
     assert device.__repr__() == "device(type='ext_dev', index=0)"
@@ -57,7 +57,7 @@ def test_device_dlpack_device_type(
     expected_device_type: DLDeviceType,
     expect_device_id: int,
 ) -> None:
-    dev = tvm_ffi.device(dev_str)
+    dev = ffi.device(dev_str)
     assert dev.dlpack_device_type() == expected_device_type
     assert dev.index == expect_device_id
 
@@ -82,7 +82,7 @@ def test_device_with_dev_id(
     expected_device_type: DLDeviceType,
     expect_device_id: int,
 ) -> None:
-    dev = tvm_ffi.device(dev_type, dev_id)
+    dev = ffi.device(dev_type, dev_id)
     assert dev.dlpack_device_type() == expected_device_type
     assert dev.index == expect_device_id
 
@@ -90,31 +90,31 @@ def test_device_with_dev_id(
 @pytest.mark.parametrize("dev_type, dev_id", [("cpu:0:0", None), ("cpu:?", None), ("cpu:", None)])
 def test_deive_type_error(dev_type: str, dev_id: int | None) -> None:
     with pytest.raises(ValueError):
-        tvm_ffi.device(dev_type, dev_id)
+        ffi.device(dev_type, dev_id)
 
 
 def test_deive_id_error() -> None:
     with pytest.raises(TypeError):
-        tvm_ffi.device("cpu", "?")  # ty: ignore[invalid-argument-type]
+        ffi.device("cpu", "?")  # ty: ignore[invalid-argument-type]
 
 
 def test_device_pickle() -> None:
-    device = tvm_ffi.device("cuda", 0)
+    device = ffi.device("cuda", 0)
     device_pickled = pickle.loads(pickle.dumps(device))
     assert device_pickled.dlpack_device_type() == device.dlpack_device_type()
     assert device_pickled.index == device.index
 
 
 def test_device_class_override() -> None:
-    class MyDevice(tvm_ffi.Device):
+    class MyDevice(ffi.Device):
         pass
 
-    old_device = tvm_ffi.core._CLASS_DEVICE
-    tvm_ffi.core._set_class_device(MyDevice)
+    old_device = ffi.core._CLASS_DEVICE
+    ffi.core._set_class_device(MyDevice)
 
-    device = tvm_ffi.device("cuda", 0)
+    device = ffi.device("cuda", 0)
     assert isinstance(device, MyDevice)
-    tvm_ffi.core._set_class_device(old_device)
+    ffi.core._set_class_device(old_device)
 
 
 def test_cuda_stream_handling() -> None:
@@ -126,7 +126,7 @@ def test_cuda_stream_handling() -> None:
             return ("cuda", self.stream)
 
     stream = MyDummyStream(1)
-    echo = tvm_ffi.get_global_func("testing.echo")
+    echo = ffi.get_global_func("testing.echo")
     y = echo(stream)
     assert isinstance(y, ctypes.c_void_p)
     assert y.value == 1

--- a/tests/python/test_dlpack_exchange_api.py
+++ b/tests/python/test_dlpack_exchange_api.py
@@ -28,7 +28,7 @@ try:
 
     # Import tvm_ffi to load the DLPack exchange API extension
     # This sets torch.Tensor.__dlpack_c_exchange_api__
-    import tvm_ffi
+    import tvm_ffi as ffi
     from torch.utils import cpp_extension
     from tvm_ffi import libinfo
 except ImportError:
@@ -219,9 +219,9 @@ def test_from_dlpack_torch() -> None:
     # Covers from_dlpack to use fallback fastpath
     assert torch is not None
     tensor = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4)
-    tensor_from_dlpack = tvm_ffi.from_dlpack(tensor)
+    tensor_from_dlpack = ffi.from_dlpack(tensor)
     assert tensor_from_dlpack.shape == tensor.shape
-    assert tensor_from_dlpack.dtype == tvm_ffi.float32
+    assert tensor_from_dlpack.dtype == ffi.float32
 
 
 if __name__ == "__main__":

--- a/tests/python/test_dtype.py
+++ b/tests/python/test_dtype.py
@@ -20,14 +20,14 @@ from typing import Any
 
 import numpy as np
 import pytest
-import tvm_ffi
+import tvm_ffi as ffi
 from packaging.version import Version
 
 
 def test_dtype() -> None:
-    float32 = tvm_ffi.dtype("float32")
+    float32 = ffi.dtype("float32")
     assert float32.__repr__() == "dtype('float32')"
-    assert type(float32) == tvm_ffi.dtype
+    assert type(float32) == ffi.dtype
     x = np.array([1, 2, 3], dtype=float32)
     assert x.dtype == float32
 
@@ -45,14 +45,14 @@ def test_dtype() -> None:
     ],
 )
 def test_dtype_itemsize(dtype_str: str, expected_size: int) -> None:
-    dtype = tvm_ffi.dtype(dtype_str)
+    dtype = ffi.dtype(dtype_str)
     assert dtype.itemsize == expected_size
 
 
 @pytest.mark.parametrize("dtype_str", ["int32xvscalex4"])
 def test_dtype_itemmize_error(dtype_str: str) -> None:
     with pytest.raises(ValueError):
-        tvm_ffi.dtype(dtype_str).itemsize
+        ffi.dtype(dtype_str).itemsize
 
 
 @pytest.mark.parametrize(
@@ -68,7 +68,7 @@ def test_dtype_itemmize_error(dtype_str: str) -> None:
     ],
 )
 def test_dtype_pickle(dtype_str: str) -> None:
-    dtype = tvm_ffi.dtype(dtype_str)
+    dtype = ffi.dtype(dtype_str)
     dtype_pickled = pickle.loads(pickle.dumps(dtype))
     assert dtype_pickled.type_code == dtype.type_code
     assert dtype_pickled.bits == dtype.bits
@@ -77,24 +77,24 @@ def test_dtype_pickle(dtype_str: str) -> None:
 
 @pytest.mark.parametrize("dtype_str", ["float32", "bool"])
 def test_dtype_with_lanes(dtype_str: str) -> None:
-    dtype = tvm_ffi.dtype(dtype_str)
+    dtype = ffi.dtype(dtype_str)
     dtype_with_lanes = dtype.with_lanes(4)
     assert dtype_with_lanes.type_code == dtype.type_code
     assert dtype_with_lanes.bits == dtype.bits
     assert dtype_with_lanes.lanes == 4
 
 
-_fecho = tvm_ffi.get_global_func("testing.echo")
+_fecho = ffi.get_global_func("testing.echo")
 
 
 def _check_dtype(dtype: Any, code: int, bits: int, lanes: int) -> None:
     echo_dtype = _fecho(dtype)
-    assert isinstance(echo_dtype, tvm_ffi.dtype)
+    assert isinstance(echo_dtype, ffi.dtype)
     assert echo_dtype.type_code == code
     assert echo_dtype.bits == bits
     assert echo_dtype.lanes == lanes
-    converted_dtype = tvm_ffi.convert(dtype)
-    assert isinstance(converted_dtype, tvm_ffi.dtype)
+    converted_dtype = ffi.convert(dtype)
+    assert isinstance(converted_dtype, ffi.dtype)
     assert converted_dtype.type_code == code
     assert converted_dtype.bits == bits
     assert converted_dtype.lanes == lanes
@@ -169,36 +169,36 @@ def test_ml_dtypes_dtype_conversion() -> None:
 
 
 def test_builtin_dtype_conversion() -> None:
-    _check_dtype(tvm_ffi.bool, 6, 8, 1)
-    _check_dtype(tvm_ffi.int8, 0, 8, 1)
-    _check_dtype(tvm_ffi.int16, 0, 16, 1)
-    _check_dtype(tvm_ffi.int32, 0, 32, 1)
-    _check_dtype(tvm_ffi.int64, 0, 64, 1)
-    _check_dtype(tvm_ffi.uint8, 1, 8, 1)
-    _check_dtype(tvm_ffi.uint16, 1, 16, 1)
-    _check_dtype(tvm_ffi.uint32, 1, 32, 1)
-    _check_dtype(tvm_ffi.uint64, 1, 64, 1)
-    _check_dtype(tvm_ffi.float16, 2, 16, 1)
-    _check_dtype(tvm_ffi.float32, 2, 32, 1)
-    _check_dtype(tvm_ffi.float64, 2, 64, 1)
-    _check_dtype(tvm_ffi.bfloat16, 4, 16, 1)
-    _check_dtype(tvm_ffi.float8_e4m3fn, 10, 8, 1)
-    _check_dtype(tvm_ffi.float8_e4m3fnuz, 11, 8, 1)
-    _check_dtype(tvm_ffi.float8_e5m2, 12, 8, 1)
-    _check_dtype(tvm_ffi.float8_e5m2fnuz, 13, 8, 1)
-    _check_dtype(tvm_ffi.float8_e8m0fnu, 14, 8, 1)
-    _check_dtype(tvm_ffi.float4_e2m1fnx2, 17, 4, 2)
+    _check_dtype(ffi.bool, 6, 8, 1)
+    _check_dtype(ffi.int8, 0, 8, 1)
+    _check_dtype(ffi.int16, 0, 16, 1)
+    _check_dtype(ffi.int32, 0, 32, 1)
+    _check_dtype(ffi.int64, 0, 64, 1)
+    _check_dtype(ffi.uint8, 1, 8, 1)
+    _check_dtype(ffi.uint16, 1, 16, 1)
+    _check_dtype(ffi.uint32, 1, 32, 1)
+    _check_dtype(ffi.uint64, 1, 64, 1)
+    _check_dtype(ffi.float16, 2, 16, 1)
+    _check_dtype(ffi.float32, 2, 32, 1)
+    _check_dtype(ffi.float64, 2, 64, 1)
+    _check_dtype(ffi.bfloat16, 4, 16, 1)
+    _check_dtype(ffi.float8_e4m3fn, 10, 8, 1)
+    _check_dtype(ffi.float8_e4m3fnuz, 11, 8, 1)
+    _check_dtype(ffi.float8_e5m2, 12, 8, 1)
+    _check_dtype(ffi.float8_e5m2fnuz, 13, 8, 1)
+    _check_dtype(ffi.float8_e8m0fnu, 14, 8, 1)
+    _check_dtype(ffi.float4_e2m1fnx2, 17, 4, 2)
 
 
 def test_dtype_from_dlpack_data_type() -> None:
-    dtype = tvm_ffi.dtype.from_dlpack_data_type((0, 8, 1))
+    dtype = ffi.dtype.from_dlpack_data_type((0, 8, 1))
     assert dtype.type_code == 0
     assert dtype.bits == 8
     assert dtype.lanes == 1
 
 
 def test_dtype_bool() -> None:
-    dtype = tvm_ffi.dtype("bool")
+    dtype = ffi.dtype("bool")
     assert dtype.type_code == 6
     assert dtype.bits == 8
     assert dtype.lanes == 1

--- a/tests/python/test_error.py
+++ b/tests/python/test_error.py
@@ -21,7 +21,7 @@ import weakref
 from typing import NoReturn
 
 import pytest
-import tvm_ffi
+import tvm_ffi as ffi
 
 
 def test_parse_backtrace() -> None:
@@ -29,14 +29,14 @@ def test_parse_backtrace() -> None:
     File "test.py", line 1, in <module>
     File "test.py", line 3, in run_test
     """
-    parsed = tvm_ffi.error._parse_backtrace(backtrace)
+    parsed = ffi.error._parse_backtrace(backtrace)
     assert len(parsed) == 2
     assert parsed[0] == ("test.py", 1, "<module>")
     assert parsed[1] == ("test.py", 3, "run_test")
 
 
 def test_error_from_cxx() -> None:
-    test_raise_error = tvm_ffi.get_global_func("testing.test_raise_error")
+    test_raise_error = ffi.get_global_func("testing.test_raise_error")
 
     try:
         test_raise_error("ValueError", "error XYZ")
@@ -45,20 +45,20 @@ def test_error_from_cxx() -> None:
         assert e.__tvm_ffi_error__.message == "error XYZ"  # ty: ignore[unresolved-attribute]
         assert e.__tvm_ffi_error__.backtrace.find("TestRaiseError") != -1  # ty: ignore[unresolved-attribute]
 
-    fapply = tvm_ffi.convert(lambda f, *args: f(*args))
+    fapply = ffi.convert(lambda f, *args: f(*args))
 
     with pytest.raises(TypeError):
         fapply(test_raise_error, "TypeError", "error XYZ")
 
     # wrong number of arguments
     with pytest.raises(TypeError):
-        tvm_ffi.convert(lambda x: x)()
+        ffi.convert(lambda x: x)()
 
 
 def test_error_from_nested_pyfunc() -> None:
-    fapply = tvm_ffi.convert(lambda f, *args: f(*args))
-    cxx_test_raise_error = tvm_ffi.get_global_func("testing.test_raise_error")
-    cxx_test_apply = tvm_ffi.get_global_func("testing.apply")
+    fapply = ffi.convert(lambda f, *args: f(*args))
+    cxx_test_raise_error = ffi.get_global_func("testing.test_raise_error")
+    cxx_test_apply = ffi.get_global_func("testing.apply")
 
     record_object = []
 
@@ -92,7 +92,7 @@ def test_error_from_nested_pyfunc() -> None:
 
 
 def test_error_traceback_update() -> None:
-    fecho = tvm_ffi.get_global_func("testing.echo")
+    fecho = ffi.get_global_func("testing.echo")
 
     def raise_error() -> NoReturn:
         raise ValueError("error XYZ")
@@ -100,18 +100,18 @@ def test_error_traceback_update() -> None:
     try:
         raise_error()
     except ValueError as e:
-        ffi_error = tvm_ffi.convert(e)
+        ffi_error = ffi.convert(e)
         assert ffi_error.backtrace.find("raise_error") != -1
 
     def raise_cxx_error() -> None:
-        cxx_test_raise_error = tvm_ffi.get_global_func("testing.test_raise_error")
+        cxx_test_raise_error = ffi.get_global_func("testing.test_raise_error")
         cxx_test_raise_error("ValueError", "error XYZ")
 
     try:
         raise_cxx_error()
     except ValueError as e:
         assert e.__tvm_ffi_error__.backtrace.find("raise_cxx_error") == -1  # ty: ignore[unresolved-attribute]
-        ffi_error1 = tvm_ffi.convert(e)
+        ffi_error1 = ffi.convert(e)
         ffi_error2 = fecho(e)
         assert ffi_error1.backtrace.find("raise_cxx_error") != -1
         assert ffi_error2.backtrace.find("raise_cxx_error") != -1
@@ -133,7 +133,7 @@ def test_error_no_cyclic_reference() -> None:
         # trigger a C++ side KeyError by accessing a non-existent key
         def trigger_cpp_side_error() -> None:
             try:
-                tmp_map: tvm_ffi.Map = tvm_ffi.Map(dict())
+                tmp_map: ffi.Map = ffi.Map(dict())
                 tmp_map["a"]
             except KeyError:
                 pass

--- a/tests/python/test_examples.py
+++ b/tests/python/test_examples.py
@@ -17,33 +17,33 @@
 # testcases appearing in example docstrings
 from typing import Any
 
-import tvm_ffi
+import tvm_ffi as ffi
 
 
 def test_register_global_func() -> None:
     # we can use decorator to register a function
-    @tvm_ffi.register_global_func("example.echo")
+    @ffi.register_global_func("example.echo")
     def echo(x: Any) -> Any:
         return x
 
     # After registering, we can get the function by its name
-    f = tvm_ffi.get_global_func("example.echo")
+    f = ffi.get_global_func("example.echo")
     assert f(1) == 1
     # we can also directly register a function
-    tvm_ffi.register_global_func("example.add_one", lambda x: x + 1)
-    f = tvm_ffi.get_global_func("example.add_one")
+    ffi.register_global_func("example.add_one", lambda x: x + 1)
+    f = ffi.get_global_func("example.add_one")
     assert f(1) == 2
 
 
 def test_array() -> None:
-    a = tvm_ffi.convert([1, 2, 3])
-    assert isinstance(a, tvm_ffi.Array)
+    a = ffi.convert([1, 2, 3])
+    assert isinstance(a, ffi.Array)
     assert len(a) == 3
 
 
 def test_map() -> None:
-    amap = tvm_ffi.convert({"a": 1, "b": 2})
-    assert isinstance(amap, tvm_ffi.Map)
+    amap = ffi.convert({"a": 1, "b": 2})
+    assert isinstance(amap, ffi.Map)
     assert len(amap) == 2
     assert amap["a"] == 1
     assert amap["b"] == 2

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -23,12 +23,12 @@ from typing import Any
 
 import numpy as np
 import pytest
-import tvm_ffi
+import tvm_ffi as ffi
 
 
 def test_echo() -> None:
-    fecho = tvm_ffi.get_global_func("testing.echo")
-    assert isinstance(fecho, tvm_ffi.Function)
+    fecho = ffi.get_global_func("testing.echo")
+    assert isinstance(fecho, ffi.Function)
     # test each type
     assert fecho(None) is None
 
@@ -55,14 +55,14 @@ def test_echo() -> None:
     assert bytes_result == b"abc"
 
     # test dtype
-    dtype_result = fecho(tvm_ffi.dtype("float32"))
-    assert isinstance(dtype_result, tvm_ffi.dtype)
-    assert dtype_result == tvm_ffi.dtype("float32")
+    dtype_result = fecho(ffi.dtype("float32"))
+    assert isinstance(dtype_result, ffi.dtype)
+    assert dtype_result == ffi.dtype("float32")
 
     # test device
-    device_result = fecho(tvm_ffi.device("cuda:1"))
-    assert isinstance(device_result, tvm_ffi.Device)
-    assert device_result.dlpack_device_type() == tvm_ffi.DLDeviceType.kDLCUDA
+    device_result = fecho(ffi.device("cuda:1"))
+    assert isinstance(device_result, ffi.Device)
+    assert device_result.dlpack_device_type() == ffi.DLDeviceType.kDLCUDA
     assert device_result.index == 1
     assert str(device_result) == "cuda:1"
     assert device_result.__repr__() == "device(type='cuda', index=1)"
@@ -77,7 +77,7 @@ def test_echo() -> None:
     c_void_p_nullptr_result is None
 
     # test function: aka object
-    fadd = tvm_ffi.convert(lambda a, b: a + b)
+    fadd = ffi.convert(lambda a, b: a + b)
     fadd1 = fecho(fadd)
     assert fadd1(1, 2) == 3
     assert fadd1.same_as(fadd)
@@ -87,27 +87,27 @@ def test_echo() -> None:
         if not hasattr(np_data, "__dlpack__"):
             return
         # test Tensor
-        x = tvm_ffi.from_dlpack(np_data)
-        assert isinstance(x, tvm_ffi.Tensor)
+        x = ffi.from_dlpack(np_data)
+        assert isinstance(x, ffi.Tensor)
         tensor_result = fecho(x)
-        assert isinstance(tensor_result, tvm_ffi.Tensor)
+        assert isinstance(tensor_result, ffi.Tensor)
         assert tensor_result.shape == (10,)
-        assert tensor_result.dtype == tvm_ffi.dtype("int32")
-        assert tensor_result.device.dlpack_device_type() == tvm_ffi.DLDeviceType.kDLCPU
+        assert tensor_result.dtype == ffi.dtype("int32")
+        assert tensor_result.device.dlpack_device_type() == ffi.DLDeviceType.kDLCPU
         assert tensor_result.device.index == 0
 
     check_tensor()
 
 
 def test_return_raw_str_bytes() -> None:
-    assert tvm_ffi.convert(lambda: "hello")() == "hello"
-    assert tvm_ffi.convert(lambda: b"hello")() == b"hello"
-    assert tvm_ffi.convert(lambda: bytearray(b"hello"))() == b"hello"
+    assert ffi.convert(lambda: "hello")() == "hello"
+    assert ffi.convert(lambda: b"hello")() == b"hello"
+    assert ffi.convert(lambda: bytearray(b"hello"))() == b"hello"
 
 
 def test_string_bytes_passing() -> None:
-    fecho = tvm_ffi.get_global_func("testing.echo")
-    use_count = tvm_ffi.get_global_func("testing.object_use_count")
+    fecho = ffi.get_global_func("testing.echo")
+    use_count = ffi.get_global_func("testing.object_use_count")
     # small string
     assert fecho("hello") == "hello"
     # large string
@@ -128,9 +128,9 @@ def test_string_bytes_passing() -> None:
 
 def test_nested_container_passing() -> None:
     # test and make sure our ref counting is correct
-    fecho = tvm_ffi.get_global_func("testing.echo")
-    use_count = tvm_ffi.get_global_func("testing.object_use_count")
-    obj = tvm_ffi.convert((1, 2, 3))
+    fecho = ffi.get_global_func("testing.echo")
+    use_count = ffi.get_global_func("testing.object_use_count")
+    obj = ffi.convert((1, 2, 3))
     assert use_count(obj) == 1
     y = fecho([obj, {"a": 1, "b": obj}])
     assert use_count(y) == 1
@@ -142,35 +142,35 @@ def test_pyfunc_convert() -> None:
     def add(a: int, b: int) -> int:
         return a + b
 
-    fadd = tvm_ffi.convert(add)
-    assert isinstance(fadd, tvm_ffi.Function)
+    fadd = ffi.convert(add)
+    assert isinstance(fadd, ffi.Function)
     assert fadd(1, 2) == 3
 
     def fapply(f: Any, *args: Any) -> Any:
         return f(*args)
 
-    fapply = tvm_ffi.convert(fapply)
+    fapply = ffi.convert(fapply)
     assert fapply(add, 1, 3.3) == 4.3
 
 
 def test_global_func() -> None:
-    @tvm_ffi.register_global_func("mytest.echo")
+    @ffi.register_global_func("mytest.echo")
     def echo(x: Any) -> Any:
         return x
 
-    f = tvm_ffi.get_global_func("mytest.echo")
+    f = ffi.get_global_func("mytest.echo")
     assert f.same_as(echo)
     assert f(1) == 1
 
-    assert "mytest.echo" in tvm_ffi.registry.list_global_func_names()
+    assert "mytest.echo" in ffi.registry.list_global_func_names()
 
-    tvm_ffi.registry.remove_global_func("mytest.echo")
-    assert "mytest.echo" not in tvm_ffi.registry.list_global_func_names()
-    assert tvm_ffi.get_global_func("mytest.echo", allow_missing=True) is None
+    ffi.registry.remove_global_func("mytest.echo")
+    assert "mytest.echo" not in ffi.registry.list_global_func_names()
+    assert ffi.get_global_func("mytest.echo", allow_missing=True) is None
 
 
 def test_rvalue_ref() -> None:
-    use_count = tvm_ffi.get_global_func("testing.object_use_count")
+    use_count = ffi.get_global_func("testing.object_use_count")
 
     def callback(x: Any, expected_count: int) -> Any:
         # The use count of TVM FFI objects is decremented as part of
@@ -184,17 +184,17 @@ def test_rvalue_ref() -> None:
         assert expected_count == use_count(x)
         return x._move()
 
-    f = tvm_ffi.convert(callback)
+    f = ffi.convert(callback)
 
     def check0() -> None:
-        x = tvm_ffi.convert([1, 2])
+        x = ffi.convert([1, 2])
         assert use_count(x) == 1
         f(x, 2)
         f(x._move(), 1)
         assert x.__ctypes_handle__().value is None
 
     def check1() -> None:
-        x = tvm_ffi.convert([1, 2])
+        x = ffi.convert([1, 2])
         assert use_count(x) == 1
         y = f(x, 2)
         f(x._move(), 2)
@@ -210,7 +210,7 @@ def test_echo_with_opaque_object() -> None:
         def __init__(self, value: Any) -> None:
             self.value = value
 
-    fecho = tvm_ffi.get_global_func("testing.echo")
+    fecho = ffi.get_global_func("testing.echo")
     x = MyObject("hello")
     assert sys.getrefcount(x) == 2
     y = fecho(x)
@@ -223,15 +223,15 @@ def test_echo_with_opaque_object() -> None:
         assert z is x
         return z
 
-    fcallback = tvm_ffi.convert(py_callback)
+    fcallback = ffi.convert(py_callback)
     z = fcallback(x)
     assert z is x
     assert sys.getrefcount(x) == 4
 
 
 def test_function_from_c_symbol() -> None:
-    add_one_c_symbol = tvm_ffi.get_global_func("testing.get_add_one_c_symbol")()
-    fadd_one = tvm_ffi.Function.__from_extern_c__(add_one_c_symbol)
+    add_one_c_symbol = ffi.get_global_func("testing.get_add_one_c_symbol")()
+    fadd_one = ffi.Function.__from_extern_c__(add_one_c_symbol)
     assert fadd_one(1) == 2
     assert fadd_one(2) == 3
 
@@ -240,7 +240,7 @@ def test_function_from_c_symbol() -> None:
 
     keep_alive = [1, 2, 3]
     base_ref_count = sys.getrefcount(keep_alive)
-    fadd_one = tvm_ffi.Function.__from_extern_c__(add_one_c_symbol, keep_alive_object=keep_alive)
+    fadd_one = ffi.Function.__from_extern_c__(add_one_c_symbol, keep_alive_object=keep_alive)
     assert fadd_one(1) == 2
     assert fadd_one(2) == 3
     assert sys.getrefcount(keep_alive) == base_ref_count + 1
@@ -249,14 +249,14 @@ def test_function_from_c_symbol() -> None:
 
 
 def test_function_from_mlir_packed_safe_call() -> None:
-    add_one_c_symbol = tvm_ffi.get_global_func("testing.get_mlir_add_one_c_symbol")()
-    fadd_one = tvm_ffi.Function.__from_mlir_packed_safe_call__(add_one_c_symbol)
+    add_one_c_symbol = ffi.get_global_func("testing.get_mlir_add_one_c_symbol")()
+    fadd_one = ffi.Function.__from_mlir_packed_safe_call__(add_one_c_symbol)
     assert fadd_one(1) == 2
     assert fadd_one(2) == 3
 
     keep_alive = [1, 2, 3]
     base_ref_count = sys.getrefcount(keep_alive)
-    fadd_one = tvm_ffi.Function.__from_mlir_packed_safe_call__(
+    fadd_one = ffi.Function.__from_mlir_packed_safe_call__(
         add_one_c_symbol, keep_alive_object=keep_alive
     )
 
@@ -275,19 +275,19 @@ def test_function_subclass() -> None:
         def __init__(self, metadata: Any) -> None:
             self.metadata = metadata
 
-    class MyFunction(tvm_ffi.Function, JitFunction):
+    class MyFunction(ffi.Function, JitFunction):
         def __init__(self, metadata: Any) -> None:
-            # Explicitly initialize the mixin. `super()` is not used because `tvm_ffi.Function`
+            # Explicitly initialize the mixin. `super()` is not used because `ffi.Function`
             # is an extension type without a standard `__init__`.
             JitFunction.__init__(self, metadata)
 
         # When subclassing a Cython cdef class and overriding `__init__`,
         # special methods like `__call__` may not be inherited automatically.
         # This explicit assignment ensures the subclass remains callable.
-        __call__ = tvm_ffi.Function.__call__
+        __call__ = ffi.Function.__call__
 
-    f = tvm_ffi.convert(lambda x: x)
-    assert isinstance(f, tvm_ffi.Function)
+    f = ffi.convert(lambda x: x)
+    assert isinstance(f, ffi.Function)
     f_sub = MyFunction(128)
     # move handle from f to f_sub an existing function
     f_sub.__move_handle_from__(f)
@@ -297,9 +297,9 @@ def test_function_subclass() -> None:
 
     y: int = f_sub(2)
     assert y == 2
-    echo = tvm_ffi.get_global_func("testing.echo")
+    echo = ffi.get_global_func("testing.echo")
     fechoed = echo(f_sub)
-    assert isinstance(fechoed, tvm_ffi.Function)
+    assert isinstance(fechoed, ffi.Function)
     assert fechoed.__chandle__() == f_sub.__chandle__()
     assert fechoed(10) == 10
 
@@ -312,7 +312,7 @@ def test_function_with_opaque_ptr_protocol() -> None:
         def __tvm_ffi_opaque_ptr__(self) -> Any:
             return self.value
 
-    fecho = tvm_ffi.get_global_func("testing.echo")
+    fecho = ffi.get_global_func("testing.echo")
     x = MyObject(10)
     y = fecho(x)
     assert isinstance(y, ctypes.c_void_p)
@@ -327,33 +327,33 @@ def test_function_with_dlpack_data_type_protocol() -> None:
         def __dlpack_data_type__(self) -> tuple[int, int, int]:
             return self.dlpack_data_type
 
-    dtype = tvm_ffi.dtype("float32")
-    fecho = tvm_ffi.get_global_func("testing.echo")
+    dtype = ffi.dtype("float32")
+    fecho = ffi.get_global_func("testing.echo")
     x = DLPackDataTypeProtocol((dtype.type_code, dtype.bits, dtype.lanes))
     y = fecho(x)
     assert y == dtype
-    converted_y = tvm_ffi.convert(x)
+    converted_y = ffi.convert(x)
     assert converted_y == dtype
 
 
 def test_function_with_dlpack_device_protocol() -> None:
-    device = tvm_ffi.device("cuda:1")
+    device = ffi.device("cuda:1")
 
     class DLPackDeviceProtocol:
-        def __init__(self, device: tvm_ffi.Device) -> None:
+        def __init__(self, device: ffi.Device) -> None:
             self.device = device
 
         def __dlpack_device__(self) -> tuple[int, int]:
             return (self.device.dlpack_device_type(), self.device.index)
 
-    fecho = tvm_ffi.get_global_func("testing.echo")
+    fecho = ffi.get_global_func("testing.echo")
     x = DLPackDeviceProtocol(device)
     y = fecho(x)
     assert y == device
 
 
 def test_integral_float_variants_passing() -> None:
-    fecho = tvm_ffi.get_global_func("testing.echo")
+    fecho = ffi.get_global_func("testing.echo")
     y = fecho(np.int32(1))
     assert isinstance(y, int)
     assert y == 1
@@ -393,7 +393,7 @@ def test_function_with_value_protocol() -> None:
         def __tvm_ffi_value__(self) -> Any:
             return self.value
 
-    fecho = tvm_ffi.get_global_func("testing.echo")
+    fecho = ffi.get_global_func("testing.echo")
     assert fecho(ValueProtocol(10)) == 10
     assert tuple(fecho(ValueProtocol([1, 2, 3]))) == (1, 2, 3)
     assert tuple(fecho(ValueProtocol([1, 2, ValueProtocol(3)]))) == (1, 2, 3)

--- a/tests/python/test_load_inline.py
+++ b/tests/python/test_load_inline.py
@@ -25,12 +25,13 @@ try:
 except ImportError:
     torch = None  # ty: ignore[invalid-assignment]
 
+import tvm_ffi as ffi
 import tvm_ffi.cpp
 from tvm_ffi.module import Module
 
 
 def test_load_inline_cpp() -> None:
-    mod: Module = tvm_ffi.cpp.load_inline(
+    mod: Module = ffi.cpp.load_inline(
         name="hello",
         cpp_sources=r"""
             void add_one_cpu(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
@@ -56,7 +57,7 @@ def test_load_inline_cpp() -> None:
 
 
 def test_load_inline_cpp_with_docstrings() -> None:
-    mod: Module = tvm_ffi.cpp.load_inline(
+    mod: Module = ffi.cpp.load_inline(
         name="hello",
         cpp_sources=r"""
             void add_one_cpu(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
@@ -82,7 +83,7 @@ def test_load_inline_cpp_with_docstrings() -> None:
 
 
 def test_load_inline_cpp_multiple_sources() -> None:
-    mod: Module = tvm_ffi.cpp.load_inline(
+    mod: Module = ffi.cpp.load_inline(
         name="hello",
         cpp_sources=[
             r"""
@@ -124,7 +125,7 @@ def test_load_inline_cpp_multiple_sources() -> None:
 
 
 def test_load_inline_cpp_build_dir() -> None:
-    mod: Module = tvm_ffi.cpp.load_inline(
+    mod: Module = ffi.cpp.load_inline(
         name="hello",
         cpp_sources=r"""
             void add_one_cpu(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
@@ -154,7 +155,7 @@ def test_load_inline_cpp_build_dir() -> None:
     torch is None or not torch.cuda.is_available(), reason="Requires torch and CUDA"
 )
 def test_load_inline_cuda() -> None:
-    mod: Module = tvm_ffi.cpp.load_inline(
+    mod: Module = ffi.cpp.load_inline(
         name="hello",
         cuda_sources=r"""
             __global__ void AddOneKernel(float* x, float* y, int n) {
@@ -212,7 +213,7 @@ def test_load_inline_with_env_tensor_allocator() -> None:
     assert torch is not None
     if not hasattr(torch.Tensor, "__dlpack_c_exchange_api__"):
         pytest.skip("Torch does not support __dlpack_c_exchange_api__")
-    mod: Module = tvm_ffi.cpp.load_inline(
+    mod: Module = ffi.cpp.load_inline(
         name="hello",
         cpp_sources=r"""
             #include <tvm/ffi/container/tensor.h>
@@ -265,7 +266,7 @@ def test_load_inline_with_env_tensor_allocator() -> None:
 )
 def test_load_inline_both() -> None:
     assert torch is not None
-    mod: Module = tvm_ffi.cpp.load_inline(
+    mod: Module = ffi.cpp.load_inline(
         name="hello",
         cpp_sources=r"""
             void add_one_cpu(tvm::ffi::TensorView x, tvm::ffi::TensorView y) {
@@ -332,7 +333,7 @@ def test_load_inline_both() -> None:
 )
 def test_cuda_memory_alloc_noleak() -> None:
     assert torch is not None
-    mod = tvm_ffi.cpp.load_inline(
+    mod = ffi.cpp.load_inline(
         name="hello",
         cuda_sources=r"""
             #include <tvm/ffi/function.h>

--- a/tests/python/test_object.py
+++ b/tests/python/test_object.py
@@ -20,36 +20,36 @@ import sys
 from typing import Any, Sequence
 
 import pytest
-import tvm_ffi
+import tvm_ffi as ffi
 import tvm_ffi.testing
 from tvm_ffi.core import TypeInfo
 
 
 def test_make_object() -> None:
     # with default values
-    obj0 = tvm_ffi.testing.create_object("testing.TestObjectBase")
-    assert isinstance(obj0, tvm_ffi.testing.TestObjectBase)
+    obj0 = ffi.testing.create_object("testing.TestObjectBase")
+    assert isinstance(obj0, ffi.testing.TestObjectBase)
     assert obj0.v_i64 == 10
     assert obj0.v_f64 == 10.0
     assert obj0.v_str == "hello"
 
 
 def test_make_object_via_init() -> None:
-    obj0 = tvm_ffi.testing.TestIntPair(1, 2)
+    obj0 = ffi.testing.TestIntPair(1, 2)
     assert obj0.a == 1
     assert obj0.b == 2
 
 
 def test_method() -> None:
-    obj0 = tvm_ffi.testing.create_object("testing.TestObjectBase", v_i64=12)
-    assert isinstance(obj0, tvm_ffi.testing.TestObjectBase)
+    obj0 = ffi.testing.create_object("testing.TestObjectBase", v_i64=12)
+    assert isinstance(obj0, ffi.testing.TestObjectBase)
     assert obj0.add_i64(1) == 13
     assert type(obj0).add_i64.__doc__ == "add_i64 method"
     assert type(obj0).v_i64.__doc__ == "i64 field"
 
 
 def test_attribute() -> None:
-    obj = tvm_ffi.testing.TestIntPair(3, 4)
+    obj = ffi.testing.TestIntPair(3, 4)
     assert obj.a == 3
     assert obj.b == 4
     assert type(obj).a.__doc__ == "Field `a`"
@@ -67,8 +67,8 @@ def test_attribute_no_doc() -> None:
 
 def test_setter() -> None:
     # test setter
-    obj0 = tvm_ffi.testing.create_object("testing.TestObjectBase", v_i64=10, v_str="hello")
-    assert isinstance(obj0, tvm_ffi.testing.TestObjectBase)
+    obj0 = ffi.testing.create_object("testing.TestObjectBase", v_i64=10, v_str="hello")
+    assert isinstance(obj0, ffi.testing.TestObjectBase)
     assert obj0.v_i64 == 10
     obj0.v_i64 = 11
     assert obj0.v_i64 == 11
@@ -84,15 +84,15 @@ def test_setter() -> None:
 
 def test_derived_object() -> None:
     with pytest.raises(TypeError):
-        obj0 = tvm_ffi.testing.create_object("testing.TestObjectDerived")
+        obj0 = ffi.testing.create_object("testing.TestObjectDerived")
 
-    v_map = tvm_ffi.convert({"a": 1})
-    v_array = tvm_ffi.convert([1, 2, 3])
+    v_map = ffi.convert({"a": 1})
+    v_array = ffi.convert([1, 2, 3])
 
-    obj0 = tvm_ffi.testing.create_object(
+    obj0 = ffi.testing.create_object(
         "testing.TestObjectDerived", v_i64=20, v_map=v_map, v_array=v_array
     )
-    assert isinstance(obj0, tvm_ffi.testing.TestObjectDerived)
+    assert isinstance(obj0, ffi.testing.TestObjectDerived)
     assert obj0.v_map.same_as(v_map)  # ty: ignore[unresolved-attribute]
     assert obj0.v_array.same_as(v_array)  # ty: ignore[unresolved-attribute]
     assert obj0.v_i64 == 20
@@ -111,12 +111,12 @@ class MyObject:
 def test_opaque_object() -> None:
     obj0 = MyObject("hello")
     base_count = sys.getrefcount(obj0)
-    ref_count = tvm_ffi.get_global_func("testing.object_use_count")
+    ref_count = ffi.get_global_func("testing.object_use_count")
     assert sys.getrefcount(obj0) == base_count
-    obj0_converted = tvm_ffi.convert(obj0)
+    obj0_converted = ffi.convert(obj0)
     assert ref_count(obj0_converted) == 1
     assert sys.getrefcount(obj0) == base_count + 1
-    assert isinstance(obj0_converted, tvm_ffi.core.OpaquePyObject)
+    assert isinstance(obj0_converted, ffi.core.OpaquePyObject)
     obj0_cpy = obj0_converted.pyobject()
     assert obj0_cpy is obj0
     assert sys.getrefcount(obj0) == base_count + 2
@@ -129,7 +129,7 @@ def test_opaque_object() -> None:
 def test_opaque_type_error() -> None:
     obj0 = MyObject("hello")
     with pytest.raises(TypeError) as e:
-        tvm_ffi.testing.add_one(obj0)  # ty: ignore[invalid-argument-type]
+        ffi.testing.add_one(obj0)  # ty: ignore[invalid-argument-type]
     assert (
         "Mismatched type on argument #0 when calling: `testing.add_one(0: int) -> int`. Expected `int` but got `ffi.OpaquePyObject`"
         in str(e.value)
@@ -138,17 +138,17 @@ def test_opaque_type_error() -> None:
 
 def test_object_init() -> None:
     # Registered class with auto-generated __ffi_init__ (all fields have defaults)
-    obj = tvm_ffi.testing.TestObjectBase()
+    obj = ffi.testing.TestObjectBase()
     assert obj.v_i64 == 10
     assert obj.v_f64 == 10.0
     assert obj.v_str == "hello"
 
     # Registered class with __c_ffi_init__ should work fine
-    pair = tvm_ffi.testing.TestIntPair(3, 4)
+    pair = ffi.testing.TestIntPair(3, 4)
     assert pair.a == 3 and pair.b == 4
 
     # FFI-returned objects should work fine
-    obj = tvm_ffi.testing.create_object("testing.TestObjectBase", v_i64=7)
+    obj = ffi.testing.create_object("testing.TestObjectBase", v_i64=7)
     assert obj.__chandle__() != 0
     assert obj.v_i64 == 7  # ty: ignore[unresolved-attribute]
 
@@ -163,13 +163,13 @@ def test_register_object_wires_init() -> None:
     chandle + offset → segfault.
     """
     # Construction must produce a live handle, not NULL.
-    pair = tvm_ffi.testing.TestIntPair(3, 7)
+    pair = ffi.testing.TestIntPair(3, 7)
     assert pair.__chandle__() != 0
     assert pair.a == 3
     assert pair.b == 7
 
     # __new__ alone must NOT produce a usable object (chandle stays NULL).
-    bare = tvm_ffi.testing.TestIntPair.__new__(tvm_ffi.testing.TestIntPair)
+    bare = ffi.testing.TestIntPair.__new__(ffi.testing.TestIntPair)
     assert bare.__chandle__() == 0
 
 
@@ -181,10 +181,10 @@ def test_object_protocol() -> None:
         def __tvm_ffi_object__(self) -> Any:
             return self.backend_obj
 
-    x = tvm_ffi.convert([])
-    assert isinstance(x, tvm_ffi.Object)
+    x = ffi.convert([])
+    assert isinstance(x, ffi.Object)
     x_compact = CompactObject(x)
-    test_echo = tvm_ffi.get_global_func("testing.echo")
+    test_echo = ffi.get_global_func("testing.echo")
     y = test_echo(x_compact)
     assert y.__chandle__() == x.__chandle__()
 
@@ -204,10 +204,10 @@ def test_unregistered_object_fallback() -> None:
         assert "Get (v1 + 1) from TestUnregisteredBaseObject" in type(x).get_v1_plus_one.__doc__
         assert "Get (v2 + 2) from TestUnregisteredObject" in type(x).get_v2_plus_two.__doc__
 
-    obj = tvm_ffi.testing.make_unregistered_object()
+    obj = ffi.testing.make_unregistered_object()
     _check_type(obj)
     for _ in range(5):
-        obj = tvm_ffi.testing.make_unregistered_object()
+        obj = ffi.testing.make_unregistered_object()
         _check_type(obj)
 
 
@@ -215,20 +215,20 @@ def test_unregistered_object_fallback() -> None:
     ("test_cls", "make_instance"),
     [
         (
-            tvm_ffi.testing.TestObjectBase,
-            lambda: tvm_ffi.testing.create_object("testing.TestObjectBase"),
+            ffi.testing.TestObjectBase,
+            lambda: ffi.testing.create_object("testing.TestObjectBase"),
         ),
         (
-            tvm_ffi.testing.TestIntPair,
-            lambda: tvm_ffi.testing.TestIntPair(1, 2),
+            ffi.testing.TestIntPair,
+            lambda: ffi.testing.TestIntPair(1, 2),
         ),
         (
-            tvm_ffi.testing.TestObjectDerived,
-            lambda: tvm_ffi.testing.create_object(
+            ffi.testing.TestObjectDerived,
+            lambda: ffi.testing.create_object(
                 "testing.TestObjectDerived",
                 v_i64=20,
-                v_map=tvm_ffi.convert({"a": 1}),
-                v_array=tvm_ffi.convert([1, 2]),
+                v_map=ffi.convert({"a": 1}),
+                v_array=ffi.convert([1, 2]),
             ),
         ),
     ],
@@ -246,46 +246,46 @@ def test_object_subclass_slots(test_cls: type, make_instance: Any) -> None:
 @pytest.mark.parametrize(
     "test_cls, type_key, parent_cls",
     [
-        (tvm_ffi.Object, "ffi.Object", None),
-        (tvm_ffi.Tensor, "ffi.Tensor", tvm_ffi.Object),
-        (tvm_ffi.core.DataType, "DataType", None),
-        (tvm_ffi.Device, "Device", None),
-        (tvm_ffi.Shape, "ffi.Shape", tvm_ffi.Object),
-        (tvm_ffi.Module, "ffi.Module", tvm_ffi.Object),
-        (tvm_ffi.Function, "ffi.Function", tvm_ffi.Object),
-        (tvm_ffi.core.Error, "ffi.Error", tvm_ffi.Object),
-        (tvm_ffi.core.String, "ffi.String", tvm_ffi.Object),
-        (tvm_ffi.core.Bytes, "ffi.Bytes", tvm_ffi.Object),
-        (tvm_ffi.Tensor, "ffi.Tensor", tvm_ffi.Object),
-        (tvm_ffi.Array, "ffi.Array", tvm_ffi.Object),
-        (tvm_ffi.List, "ffi.List", tvm_ffi.Object),
-        (tvm_ffi.Map, "ffi.Map", tvm_ffi.Object),
-        (tvm_ffi.access_path.AccessStep, "ffi.reflection.AccessStep", tvm_ffi.Object),
-        (tvm_ffi.access_path.AccessPath, "ffi.reflection.AccessPath", tvm_ffi.Object),
-        (tvm_ffi.testing.TestIntPair, "testing.TestIntPair", tvm_ffi.Object),
-        (tvm_ffi.testing.TestObjectBase, "testing.TestObjectBase", tvm_ffi.Object),
+        (ffi.Object, "ffi.Object", None),
+        (ffi.Tensor, "ffi.Tensor", ffi.Object),
+        (ffi.core.DataType, "DataType", None),
+        (ffi.Device, "Device", None),
+        (ffi.Shape, "ffi.Shape", ffi.Object),
+        (ffi.Module, "ffi.Module", ffi.Object),
+        (ffi.Function, "ffi.Function", ffi.Object),
+        (ffi.core.Error, "ffi.Error", ffi.Object),
+        (ffi.core.String, "ffi.String", ffi.Object),
+        (ffi.core.Bytes, "ffi.Bytes", ffi.Object),
+        (ffi.Tensor, "ffi.Tensor", ffi.Object),
+        (ffi.Array, "ffi.Array", ffi.Object),
+        (ffi.List, "ffi.List", ffi.Object),
+        (ffi.Map, "ffi.Map", ffi.Object),
+        (ffi.access_path.AccessStep, "ffi.reflection.AccessStep", ffi.Object),
+        (ffi.access_path.AccessPath, "ffi.reflection.AccessPath", ffi.Object),
+        (ffi.testing.TestIntPair, "testing.TestIntPair", ffi.Object),
+        (ffi.testing.TestObjectBase, "testing.TestObjectBase", ffi.Object),
         (
-            tvm_ffi.testing.TestObjectDerived,
+            ffi.testing.TestObjectDerived,
             "testing.TestObjectDerived",
-            tvm_ffi.testing.TestObjectBase,
+            ffi.testing.TestObjectBase,
         ),
-        (tvm_ffi.testing._TestCxxClassBase, "testing.TestCxxClassBase", tvm_ffi.Object),
+        (ffi.testing._TestCxxClassBase, "testing.TestCxxClassBase", ffi.Object),
         (
-            tvm_ffi.testing._TestCxxClassDerived,
+            ffi.testing._TestCxxClassDerived,
             "testing.TestCxxClassDerived",
-            tvm_ffi.testing._TestCxxClassBase,
+            ffi.testing._TestCxxClassBase,
         ),
         (
-            tvm_ffi.testing._TestCxxClassDerivedDerived,
+            ffi.testing._TestCxxClassDerivedDerived,
             "testing.TestCxxClassDerivedDerived",
-            tvm_ffi.testing._TestCxxClassDerived,
+            ffi.testing._TestCxxClassDerived,
         ),
-        (tvm_ffi.testing._TestCxxInitSubset, "testing.TestCxxInitSubset", tvm_ffi.Object),
-        (tvm_ffi.testing._SchemaAllTypes, "testing.SchemaAllTypes", tvm_ffi.Object),
+        (ffi.testing._TestCxxInitSubset, "testing.TestCxxInitSubset", ffi.Object),
+        (ffi.testing._SchemaAllTypes, "testing.SchemaAllTypes", ffi.Object),
     ],
 )
 def test_type_info_attachment(test_cls: type, type_key: str, parent_cls: type | None) -> None:
-    type_info = tvm_ffi.core._type_cls_to_type_info(test_cls)
+    type_info = ffi.core._type_cls_to_type_info(test_cls)
     assert type_info is not None
     assert type_info.type_cls is test_cls
     assert type_info.type_key == type_key, (
@@ -301,7 +301,7 @@ def test_type_info_attachment(test_cls: type, type_key: str, parent_cls: type | 
 
 
 def test_get_registered_type_keys() -> None:
-    keys = tvm_ffi.registry.get_registered_type_keys()
+    keys = ffi.registry.get_registered_type_keys()
     assert isinstance(keys, Sequence)
     assert all(isinstance(k, str) for k in keys)
     keys = set(keys)
@@ -345,123 +345,123 @@ class TestIsinstanceIssubclass:
 
     def test_map_not_isinstance_array(self) -> None:
         """Map instance should not pass isinstance check for Array."""
-        m = tvm_ffi.Map({"a": 1})
-        assert not isinstance(m, tvm_ffi.Array)
+        m = ffi.Map({"a": 1})
+        assert not isinstance(m, ffi.Array)
 
     def test_array_not_isinstance_map(self) -> None:
         """Array instance should not pass isinstance check for Map."""
-        a = tvm_ffi.Array([1, 2])
-        assert not isinstance(a, tvm_ffi.Map)
+        a = ffi.Array([1, 2])
+        assert not isinstance(a, ffi.Map)
 
     def test_list_not_isinstance_dict(self) -> None:
         """List instance should not pass isinstance check for Dict."""
-        lst = tvm_ffi.List([1, 2])
-        assert not isinstance(lst, tvm_ffi.Dict)
+        lst = ffi.List([1, 2])
+        assert not isinstance(lst, ffi.Dict)
 
     def test_dict_not_isinstance_list(self) -> None:
         """Dict instance should not pass isinstance check for List."""
-        d = tvm_ffi.Dict({"k": 1})
-        assert not isinstance(d, tvm_ffi.List)
+        d = ffi.Dict({"k": 1})
+        assert not isinstance(d, ffi.List)
 
     def test_array_not_isinstance_list(self) -> None:
         """Array instance should not pass isinstance check for List."""
-        a = tvm_ffi.Array([1])
-        assert not isinstance(a, tvm_ffi.List)
+        a = ffi.Array([1])
+        assert not isinstance(a, ffi.List)
 
     def test_map_not_isinstance_dict(self) -> None:
         """Map instance should not pass isinstance check for Dict."""
-        m = tvm_ffi.Map({"a": 1})
-        assert not isinstance(m, tvm_ffi.Dict)
+        m = ffi.Map({"a": 1})
+        assert not isinstance(m, ffi.Dict)
 
     # -- containers: positive isinstance ------------------------------------
 
     def test_array_isinstance_object(self) -> None:
         """Array instance should pass isinstance check for Object."""
-        a = tvm_ffi.Array([1])
-        assert isinstance(a, tvm_ffi.Object)
+        a = ffi.Array([1])
+        assert isinstance(a, ffi.Object)
 
     def test_map_isinstance_object(self) -> None:
         """Map instance should pass isinstance check for Object."""
-        m = tvm_ffi.Map({"a": 1})
-        assert isinstance(m, tvm_ffi.Object)
+        m = ffi.Map({"a": 1})
+        assert isinstance(m, ffi.Object)
 
     def test_list_isinstance_object(self) -> None:
         """List instance should pass isinstance check for Object."""
-        lst = tvm_ffi.List([1])
-        assert isinstance(lst, tvm_ffi.Object)
+        lst = ffi.List([1])
+        assert isinstance(lst, ffi.Object)
 
     def test_dict_isinstance_object(self) -> None:
         """Dict instance should pass isinstance check for Object."""
-        d = tvm_ffi.Dict({"k": 1})
-        assert isinstance(d, tvm_ffi.Object)
+        d = ffi.Dict({"k": 1})
+        assert isinstance(d, ffi.Object)
 
     # -- registered user types: parent / child ------------------------------
 
     def test_derived_isinstance_base(self) -> None:
         """Derived object should pass isinstance check for its base class."""
-        obj = tvm_ffi.testing.TestObjectDerived(
+        obj = ffi.testing.TestObjectDerived(
             v_map={"a": 1},
             v_array=[1],
         )
-        assert isinstance(obj, tvm_ffi.testing.TestObjectBase)
-        assert isinstance(obj, tvm_ffi.Object)
+        assert isinstance(obj, ffi.testing.TestObjectBase)
+        assert isinstance(obj, ffi.Object)
 
     def test_base_not_isinstance_derived(self) -> None:
         """Base object should not pass isinstance check for a derived class."""
-        obj = tvm_ffi.testing.TestObjectBase()
-        assert not isinstance(obj, tvm_ffi.testing.TestObjectDerived)
+        obj = ffi.testing.TestObjectBase()
+        assert not isinstance(obj, ffi.testing.TestObjectDerived)
 
     def test_derived_isinstance_own_class(self) -> None:
         """Derived object should pass isinstance check for its own class."""
-        obj = tvm_ffi.testing.TestObjectDerived(
+        obj = ffi.testing.TestObjectDerived(
             v_map={"a": 1},
             v_array=[1],
         )
-        assert isinstance(obj, tvm_ffi.testing.TestObjectDerived)
+        assert isinstance(obj, ffi.testing.TestObjectDerived)
 
     # -- cross-hierarchy: user object vs container --------------------------
 
     def test_user_object_not_isinstance_array(self) -> None:
         """User-defined object should not pass isinstance check for Array."""
-        obj = tvm_ffi.testing.TestObjectBase()
-        assert not isinstance(obj, tvm_ffi.Array)
+        obj = ffi.testing.TestObjectBase()
+        assert not isinstance(obj, ffi.Array)
 
     def test_array_not_isinstance_user_object(self) -> None:
         """Array should not pass isinstance check for a user-defined type."""
-        a = tvm_ffi.Array([1])
-        assert not isinstance(a, tvm_ffi.testing.TestObjectBase)
+        a = ffi.Array([1])
+        assert not isinstance(a, ffi.testing.TestObjectBase)
 
     # -- issubclass mirrors isinstance --------------------------------------
 
     def test_issubclass_derived_base(self) -> None:
         """Derived class should be a subclass of its base."""
-        assert issubclass(tvm_ffi.testing.TestObjectDerived, tvm_ffi.testing.TestObjectBase)
+        assert issubclass(ffi.testing.TestObjectDerived, ffi.testing.TestObjectBase)
 
     def test_issubclass_base_not_derived(self) -> None:
         """Base class should not be a subclass of its derived class."""
-        assert not issubclass(tvm_ffi.testing.TestObjectBase, tvm_ffi.testing.TestObjectDerived)
+        assert not issubclass(ffi.testing.TestObjectBase, ffi.testing.TestObjectDerived)
 
     def test_issubclass_array_not_map(self) -> None:
         """Array should not be a subclass of Map."""
-        assert not issubclass(tvm_ffi.Array, tvm_ffi.Map)
+        assert not issubclass(ffi.Array, ffi.Map)
 
     def test_issubclass_map_not_array(self) -> None:
         """Map should not be a subclass of Array."""
-        assert not issubclass(tvm_ffi.Map, tvm_ffi.Array)
+        assert not issubclass(ffi.Map, ffi.Array)
 
     def test_issubclass_all_containers_are_object(self) -> None:
         """All container types should be subclasses of Object."""
-        for cls in (tvm_ffi.Array, tvm_ffi.List, tvm_ffi.Map, tvm_ffi.Dict):
-            assert issubclass(cls, tvm_ffi.Object)
+        for cls in (ffi.Array, ffi.List, ffi.Map, ffi.Dict):
+            assert issubclass(cls, ffi.Object)
 
     def test_issubclass_user_type_is_object(self) -> None:
         """User-defined types should be subclasses of Object."""
-        assert issubclass(tvm_ffi.testing.TestObjectBase, tvm_ffi.Object)
-        assert issubclass(tvm_ffi.testing.TestObjectDerived, tvm_ffi.Object)
+        assert issubclass(ffi.testing.TestObjectBase, ffi.Object)
+        assert issubclass(ffi.testing.TestObjectDerived, ffi.Object)
 
     def test_issubclass_sibling_containers(self) -> None:
         """Sibling container types should not be subclasses of each other."""
-        assert not issubclass(tvm_ffi.List, tvm_ffi.Array)
-        assert not issubclass(tvm_ffi.Dict, tvm_ffi.Map)
-        assert not issubclass(tvm_ffi.Array, tvm_ffi.List)
-        assert not issubclass(tvm_ffi.Map, tvm_ffi.Dict)
+        assert not issubclass(ffi.List, ffi.Array)
+        assert not issubclass(ffi.Dict, ffi.Map)
+        assert not issubclass(ffi.Array, ffi.List)
+        assert not issubclass(ffi.Map, ffi.Dict)

--- a/tests/python/test_optional_torch_c_dlpack.py
+++ b/tests/python/test_optional_torch_c_dlpack.py
@@ -29,7 +29,7 @@ except ImportError:
     torch = None  # ty: ignore[invalid-assignment]
 
 
-import tvm_ffi
+import tvm_ffi as ffi
 
 IS_WINDOWS = sys.platform.startswith("win")
 
@@ -37,7 +37,7 @@ IS_WINDOWS = sys.platform.startswith("win")
 @pytest.mark.skipif(torch is None, reason="torch is not installed")
 def test_build_torch_c_dlpack_extension() -> None:
     assert torch is not None
-    build_script = Path(tvm_ffi.__file__).parent / "utils" / "_build_optional_torch_c_dlpack.py"
+    build_script = Path(ffi.__file__).parent / "utils" / "_build_optional_torch_c_dlpack.py"
     args = [
         sys.executable,
         str(build_script),
@@ -69,7 +69,7 @@ def test_build_torch_c_dlpack_extension() -> None:
 
 @pytest.mark.skipif(torch is None, reason="torch is not installed")
 def test_parallel_build() -> None:
-    build_script = Path(tvm_ffi.__file__).parent / "utils" / "_build_optional_torch_c_dlpack.py"
+    build_script = Path(ffi.__file__).parent / "utils" / "_build_optional_torch_c_dlpack.py"
     num_processes = 4
     output_dir = "./output-dir-parallel"
     libname = "libtorch_c_dlpack_addon_test.so"

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -22,7 +22,7 @@ import json
 from typing import Any, Callable
 
 import pytest
-import tvm_ffi
+import tvm_ffi as ffi
 import tvm_ffi.testing
 from tvm_ffi.serialization import from_json_graph_str, to_json_graph_str
 
@@ -51,15 +51,15 @@ def _assert_roundtrip_eq(obj: Any, cmp: Callable[..., Any] | None = None) -> Non
 
 def _assert_any_equal(a: Any, b: Any) -> None:
     """Recursively compare two tvm_ffi values for equality."""
-    if isinstance(b, tvm_ffi.Array):
+    if isinstance(b, ffi.Array):
         assert len(a) == len(b)
         for x, y in zip(a, b):
             _assert_any_equal(x, y)
-    elif isinstance(b, (tvm_ffi.Map, tvm_ffi.Dict)):
+    elif isinstance(b, (ffi.Map, ffi.Dict)):
         assert len(a) == len(b)
         for k in b:
             _assert_any_equal(a[k], b[k])
-    elif isinstance(b, tvm_ffi.Shape):
+    elif isinstance(b, ffi.Shape):
         assert list(a) == list(b)
     elif isinstance(b, str):
         # tvm_ffi String inherits from str
@@ -157,23 +157,23 @@ class TestString:
 
     def test_empty(self) -> None:
         """Empty string roundtrips correctly."""
-        _assert_roundtrip_eq(tvm_ffi.convert(""))
+        _assert_roundtrip_eq(ffi.convert(""))
 
     def test_short(self) -> None:
         """Short string roundtrips correctly."""
-        _assert_roundtrip_eq(tvm_ffi.convert("hello"))
+        _assert_roundtrip_eq(ffi.convert("hello"))
 
     def test_long(self) -> None:
         """Long string roundtrips correctly."""
-        _assert_roundtrip_eq(tvm_ffi.convert("x" * 1000))
+        _assert_roundtrip_eq(ffi.convert("x" * 1000))
 
     def test_special_chars(self) -> None:
         """String with special characters roundtrips correctly."""
-        _assert_roundtrip_eq(tvm_ffi.convert('hello\nworld\t"quotes"'))
+        _assert_roundtrip_eq(ffi.convert('hello\nworld\t"quotes"'))
 
     def test_unicode(self) -> None:
         """Unicode string roundtrips correctly."""
-        _assert_roundtrip_eq(tvm_ffi.convert("hello 世界"))
+        _assert_roundtrip_eq(ffi.convert("hello 世界"))
 
 
 # ---------------------------------------------------------------------------
@@ -184,25 +184,25 @@ class TestDataType:
 
     def test_int32(self) -> None:
         """int32 dtype roundtrips correctly."""
-        s = to_json_graph_str(tvm_ffi.dtype("int32"))
+        s = to_json_graph_str(ffi.dtype("int32"))
         result = from_json_graph_str(s)
         assert str(result) == "int32"
 
     def test_float64(self) -> None:
         """float64 dtype roundtrips correctly."""
-        s = to_json_graph_str(tvm_ffi.dtype("float64"))
+        s = to_json_graph_str(ffi.dtype("float64"))
         result = from_json_graph_str(s)
         assert str(result) == "float64"
 
     def test_bool(self) -> None:
         """Bool dtype roundtrips correctly."""
-        s = to_json_graph_str(tvm_ffi.dtype("bool"))
+        s = to_json_graph_str(ffi.dtype("bool"))
         result = from_json_graph_str(s)
         assert str(result) == "bool"
 
     def test_vector(self) -> None:
         """Vector dtype roundtrips correctly."""
-        s = to_json_graph_str(tvm_ffi.dtype("float32x4"))
+        s = to_json_graph_str(ffi.dtype("float32x4"))
         result = from_json_graph_str(s)
         assert str(result) == "float32x4"
 
@@ -215,16 +215,16 @@ class TestDevice:
 
     def test_cpu(self) -> None:
         """CPU device roundtrips correctly."""
-        s = to_json_graph_str(tvm_ffi.Device("cpu", 0))
+        s = to_json_graph_str(ffi.Device("cpu", 0))
         result = from_json_graph_str(s)
-        assert result.dlpack_device_type() == tvm_ffi.Device("cpu", 0).dlpack_device_type()
+        assert result.dlpack_device_type() == ffi.Device("cpu", 0).dlpack_device_type()
         assert result.index == 0
 
     def test_cuda(self) -> None:
         """CUDA device roundtrips correctly."""
-        s = to_json_graph_str(tvm_ffi.Device("cuda", 1))
+        s = to_json_graph_str(ffi.Device("cuda", 1))
         result = from_json_graph_str(s)
-        assert result.dlpack_device_type() == tvm_ffi.Device("cuda", 1).dlpack_device_type()
+        assert result.dlpack_device_type() == ffi.Device("cuda", 1).dlpack_device_type()
         assert result.index == 1
 
 
@@ -236,26 +236,26 @@ class TestArray:
 
     def test_empty(self) -> None:
         """Empty array roundtrips correctly."""
-        arr = tvm_ffi.convert([])
+        arr = ffi.convert([])
         _assert_roundtrip_eq(arr)
 
     def test_single_element(self) -> None:
         """Single-element array roundtrips correctly."""
-        arr = tvm_ffi.convert([42])
+        arr = ffi.convert([42])
         result = _roundtrip(arr)
         assert len(result) == 1
         assert result[0] == 42
 
     def test_multiple_elements(self) -> None:
         """Multi-element array roundtrips correctly."""
-        arr = tvm_ffi.convert([1, 2, 3])
+        arr = ffi.convert([1, 2, 3])
         result = _roundtrip(arr)
         assert len(result) == 3
         assert list(result) == [1, 2, 3]
 
     def test_mixed_types(self) -> None:
         """Array with mixed types roundtrips correctly."""
-        arr = tvm_ffi.convert([42, "hello", True, None])
+        arr = ffi.convert([42, "hello", True, None])
         result = _roundtrip(arr)
         assert len(result) == 4
         assert result[0] == 42
@@ -265,9 +265,9 @@ class TestArray:
 
     def test_nested_arrays(self) -> None:
         """Nested arrays roundtrip correctly."""
-        inner1 = tvm_ffi.convert([1, 2])
-        inner2 = tvm_ffi.convert([3])
-        outer = tvm_ffi.convert([inner1, inner2])
+        inner1 = ffi.convert([1, 2])
+        inner2 = ffi.convert([3])
+        outer = ffi.convert([inner1, inner2])
         result = _roundtrip(outer)
         assert len(result) == 2
         assert list(result[0]) == [1, 2]
@@ -275,7 +275,7 @@ class TestArray:
 
     def test_duplicated_elements(self) -> None:
         """Array with duplicated elements roundtrips correctly."""
-        arr = tvm_ffi.convert([42, 42, 42])
+        arr = ffi.convert([42, 42, 42])
         result = _roundtrip(arr)
         assert len(result) == 3
         assert all(x == 42 for x in result)
@@ -286,19 +286,19 @@ class TestMap:
 
     def test_empty(self) -> None:
         """Empty map roundtrips correctly."""
-        m = tvm_ffi.convert({})
+        m = ffi.convert({})
         _assert_roundtrip_eq(m)
 
     def test_single_entry(self) -> None:
         """Single-entry map roundtrips correctly."""
-        m = tvm_ffi.convert({"key": 42})
+        m = ffi.convert({"key": 42})
         result = _roundtrip(m)
         assert len(result) == 1
         assert result["key"] == 42
 
     def test_multiple_entries(self) -> None:
         """Multi-entry map roundtrips correctly."""
-        m = tvm_ffi.convert({"a": 1, "b": 2, "c": 3})
+        m = ffi.convert({"a": 1, "b": 2, "c": 3})
         result = _roundtrip(m)
         assert len(result) == 3
         assert result["a"] == 1
@@ -307,7 +307,7 @@ class TestMap:
 
     def test_mixed_value_types(self) -> None:
         """Map with mixed value types roundtrips correctly."""
-        m = tvm_ffi.convert({"int": 42, "str": "hello", "bool": True, "none": None})
+        m = ffi.convert({"int": 42, "str": "hello", "bool": True, "none": None})
         result = _roundtrip(m)
         assert result["int"] == 42
         assert result["str"] == "hello"
@@ -316,15 +316,15 @@ class TestMap:
 
     def test_nested_map(self) -> None:
         """Nested maps roundtrip correctly."""
-        inner = tvm_ffi.convert({"x": 1})
-        outer = tvm_ffi.convert({"inner": inner})
+        inner = ffi.convert({"x": 1})
+        outer = ffi.convert({"inner": inner})
         result = _roundtrip(outer)
         assert result["inner"]["x"] == 1
 
     def test_map_with_array_value(self) -> None:
         """Map with array values roundtrips correctly."""
-        arr = tvm_ffi.convert([10, 20])
-        m = tvm_ffi.convert({"nums": arr})
+        arr = ffi.convert([10, 20])
+        m = ffi.convert({"nums": arr})
         result = _roundtrip(m)
         assert list(result["nums"]) == [10, 20]
 
@@ -334,19 +334,19 @@ class TestDict:
 
     def test_empty(self) -> None:
         """Empty dict roundtrips correctly."""
-        d = tvm_ffi.Dict({})
+        d = ffi.Dict({})
         _assert_roundtrip_eq(d)
 
     def test_single_entry(self) -> None:
         """Single-entry dict roundtrips correctly."""
-        d = tvm_ffi.Dict({"key": 42})
+        d = ffi.Dict({"key": 42})
         result = _roundtrip(d)
         assert len(result) == 1
         assert result["key"] == 42
 
     def test_multiple_entries(self) -> None:
         """Multi-entry dict roundtrips correctly."""
-        d = tvm_ffi.Dict({"a": 1, "b": 2, "c": 3})
+        d = ffi.Dict({"a": 1, "b": 2, "c": 3})
         result = _roundtrip(d)
         assert len(result) == 3
         assert result["a"] == 1
@@ -355,7 +355,7 @@ class TestDict:
 
     def test_mixed_value_types(self) -> None:
         """Dict with mixed value types roundtrips correctly."""
-        d = tvm_ffi.Dict({"int": 42, "str": "hello", "bool": True, "none": None})
+        d = ffi.Dict({"int": 42, "str": "hello", "bool": True, "none": None})
         result = _roundtrip(d)
         assert result["int"] == 42
         assert result["str"] == "hello"
@@ -364,15 +364,15 @@ class TestDict:
 
     def test_nested_dict(self) -> None:
         """Nested dicts roundtrip correctly."""
-        inner = tvm_ffi.Dict({"x": 1})
-        outer = tvm_ffi.Dict({"inner": inner})
+        inner = ffi.Dict({"x": 1})
+        outer = ffi.Dict({"inner": inner})
         result = _roundtrip(outer)
         assert result["inner"]["x"] == 1
 
     def test_dict_with_array_value(self) -> None:
         """Dict with array values roundtrips correctly."""
-        arr = tvm_ffi.convert([10, 20])
-        d = tvm_ffi.Dict({"nums": arr})
+        arr = ffi.convert([10, 20])
+        d = ffi.Dict({"nums": arr})
         result = _roundtrip(d)
         assert list(result["nums"]) == [10, 20]
 
@@ -382,18 +382,18 @@ class TestShape:
 
     def test_empty(self) -> None:
         """Empty shape roundtrips correctly."""
-        shape = tvm_ffi.Shape(())
+        shape = ffi.Shape(())
         _assert_roundtrip_eq(shape)
 
     def test_1d(self) -> None:
         """1D shape roundtrips correctly."""
-        shape = tvm_ffi.Shape((10,))
+        shape = ffi.Shape((10,))
         result = _roundtrip(shape)
         assert list(result) == [10]
 
     def test_nd(self) -> None:
         """N-D shape roundtrips correctly."""
-        shape = tvm_ffi.Shape((1, 2, 3, 4))
+        shape = ffi.Shape((1, 2, 3, 4))
         result = _roundtrip(shape)
         assert list(result) == [1, 2, 3, 4]
 
@@ -406,7 +406,7 @@ class TestObjectSerialization:
 
     def test_int_pair_roundtrip(self) -> None:
         """TestIntPair has refl::init and POD int64 fields."""
-        pair = tvm_ffi.testing.TestIntPair(3, 7)
+        pair = ffi.testing.TestIntPair(3, 7)
         s = to_json_graph_str(pair)
         result = from_json_graph_str(s)
         assert result.a == 3
@@ -414,21 +414,21 @@ class TestObjectSerialization:
 
     def test_int_pair_zero_values(self) -> None:
         """TestIntPair with zero values roundtrips correctly."""
-        pair = tvm_ffi.testing.TestIntPair(0, 0)
+        pair = ffi.testing.TestIntPair(0, 0)
         result = _roundtrip(pair)
         assert result.a == 0
         assert result.b == 0
 
     def test_int_pair_negative_values(self) -> None:
         """TestIntPair with negative values roundtrips correctly."""
-        pair = tvm_ffi.testing.TestIntPair(-100, -200)
+        pair = ffi.testing.TestIntPair(-100, -200)
         result = _roundtrip(pair)
         assert result.a == -100
         assert result.b == -200
 
     def test_int_pair_large_values(self) -> None:
         """TestIntPair with large values roundtrips correctly."""
-        pair = tvm_ffi.testing.TestIntPair(10**15, -(10**15))
+        pair = ffi.testing.TestIntPair(10**15, -(10**15))
         result = _roundtrip(pair)
         assert result.a == 10**15
         assert result.b == -(10**15)
@@ -471,14 +471,14 @@ class TestJSONStructure:
 
     def test_string_json_structure(self) -> None:
         """String produces a node with type 'ffi.String'."""
-        s = to_json_graph_str(tvm_ffi.convert("hello"))
+        s = to_json_graph_str(ffi.convert("hello"))
         parsed = json.loads(s)
         assert parsed["nodes"][parsed["root_index"]]["type"] == "ffi.String"
         assert parsed["nodes"][parsed["root_index"]]["data"] == "hello"
 
     def test_array_json_structure(self) -> None:
         """Array data contains node index references."""
-        s = to_json_graph_str(tvm_ffi.convert([1, 2]))
+        s = to_json_graph_str(ffi.convert([1, 2]))
         parsed = json.loads(s)
         root = parsed["nodes"][parsed["root_index"]]
         assert root["type"] == "ffi.Array"
@@ -488,7 +488,7 @@ class TestJSONStructure:
 
     def test_map_json_structure(self) -> None:
         """Map data contains flattened key-value node index pairs."""
-        s = to_json_graph_str(tvm_ffi.convert({"a": 1}))
+        s = to_json_graph_str(ffi.convert({"a": 1}))
         parsed = json.loads(s)
         root = parsed["nodes"][parsed["root_index"]]
         assert root["type"] == "ffi.Map"
@@ -498,7 +498,7 @@ class TestJSONStructure:
 
     def test_dict_json_structure(self) -> None:
         """Dict data contains flattened key-value node index pairs."""
-        s = to_json_graph_str(tvm_ffi.Dict({"a": 1}))
+        s = to_json_graph_str(ffi.Dict({"a": 1}))
         parsed = json.loads(s)
         root = parsed["nodes"][parsed["root_index"]]
         assert root["type"] == "ffi.Dict"
@@ -508,7 +508,7 @@ class TestJSONStructure:
 
     def test_node_dedup(self) -> None:
         """Duplicate values should share the same node index."""
-        s = to_json_graph_str(tvm_ffi.convert([42, 42, 42]))
+        s = to_json_graph_str(ffi.convert([42, 42, 42]))
         parsed = json.loads(s)
         root = parsed["nodes"][parsed["root_index"]]
         # all three elements should reference the same node
@@ -516,7 +516,7 @@ class TestJSONStructure:
 
     def test_object_pod_fields_are_inlined(self) -> None:
         """POD fields (int, bool, float) are inlined directly via field_static_type_index."""
-        pair = tvm_ffi.testing.TestIntPair(3, 7)
+        pair = ffi.testing.TestIntPair(3, 7)
         s = to_json_graph_str(pair)
         parsed = json.loads(s)
         root = parsed["nodes"][parsed["root_index"]]

--- a/tests/python/test_stl.py
+++ b/tests/python/test_stl.py
@@ -17,18 +17,19 @@
 import pathlib
 
 import pytest
+import tvm_ffi as ffi
 import tvm_ffi.cpp
 from tvm_ffi.module import Module
 
 
 def test_stl() -> None:
     cpp_path = pathlib.Path(__file__).parent.resolve() / "cpp_src" / "test_stl.cc"
-    output_lib_path = tvm_ffi.cpp.build(
+    output_lib_path = ffi.cpp.build(
         name="test_stl",
         cpp_files=[str(cpp_path)],
     )
 
-    mod: Module = tvm_ffi.load_module(output_lib_path)
+    mod: Module = ffi.load_module(output_lib_path)
 
     assert list(mod.test_tuple([1, 2.5])) == [2.5, 1]
     assert mod.test_vector(None) is None

--- a/tests/python/test_stream.py
+++ b/tests/python/test_stream.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import ctypes
 
 import pytest
-import tvm_ffi
+import tvm_ffi as ffi
 import tvm_ffi.cpp
 
 try:
@@ -38,7 +38,7 @@ except ImportError:
 @pytest.mark.skipif(cuda_driver is None, reason="Requires cuda-python")
 def test_cuda_driver_stream() -> None:
     assert cuda_driver is not None
-    echo = tvm_ffi.get_global_func("testing.echo")
+    echo = ffi.get_global_func("testing.echo")
     stream = cuda_driver.CUstream(0)
     y = echo(stream)
     assert y is not None
@@ -47,8 +47,8 @@ def test_cuda_driver_stream() -> None:
     assert z.value == 1
 
 
-def gen_check_stream_mod() -> tvm_ffi.Module:
-    return tvm_ffi.cpp.load_inline(
+def gen_check_stream_mod() -> ffi.Module:
+    return ffi.cpp.load_inline(
         name="check_stream",
         cpp_sources="""
         void check_stream(int device_type, int device_id, uint64_t stream) {
@@ -62,19 +62,19 @@ def gen_check_stream_mod() -> tvm_ffi.Module:
 
 def test_raw_stream() -> None:
     mod = gen_check_stream_mod()
-    device = tvm_ffi.device("cuda:0")
+    device = ffi.device("cuda:0")
     stream_1 = 123456789
     stream_2 = 987654321
-    with tvm_ffi.use_raw_stream(device, stream_1):
+    with ffi.use_raw_stream(device, stream_1):
         mod.check_stream(device.dlpack_device_type(), device.index, stream_1)
-        assert tvm_ffi.get_raw_stream(device) == stream_1
+        assert ffi.get_raw_stream(device) == stream_1
 
-        with tvm_ffi.use_raw_stream(device, stream_2):
+        with ffi.use_raw_stream(device, stream_2):
             mod.check_stream(device.dlpack_device_type(), device.index, stream_2)
-            assert tvm_ffi.get_raw_stream(device) == stream_2
+            assert ffi.get_raw_stream(device) == stream_2
 
         mod.check_stream(device.dlpack_device_type(), device.index, stream_1)
-        assert tvm_ffi.get_raw_stream(device) == stream_1
+        assert ffi.get_raw_stream(device) == stream_1
 
 
 @pytest.mark.skipif(
@@ -84,15 +84,15 @@ def test_torch_stream() -> None:
     assert torch is not None
     mod = gen_check_stream_mod()
     device_id = torch.cuda.current_device()
-    device = tvm_ffi.device("cuda", device_id)
+    device = ffi.device("cuda", device_id)
     device_type = device.dlpack_device_type()
     stream_1 = torch.cuda.Stream(device_id)
     stream_2 = torch.cuda.Stream(device_id)
-    with tvm_ffi.use_torch_stream(torch.cuda.stream(stream_1)):
+    with ffi.use_torch_stream(torch.cuda.stream(stream_1)):
         assert torch.cuda.current_stream() == stream_1
         mod.check_stream(device_type, device_id, stream_1.cuda_stream)
 
-        with tvm_ffi.use_torch_stream(torch.cuda.stream(stream_2)):
+        with ffi.use_torch_stream(torch.cuda.stream(stream_2)):
             assert torch.cuda.current_stream() == stream_2
             mod.check_stream(device_type, device_id, stream_2.cuda_stream)
 
@@ -107,22 +107,22 @@ def test_torch_current_stream() -> None:
     assert torch is not None
     mod = gen_check_stream_mod()
     device_id = torch.cuda.current_device()
-    device = tvm_ffi.device("cuda", device_id)
+    device = ffi.device("cuda", device_id)
     device_type = device.dlpack_device_type()
     stream_1 = torch.cuda.Stream(device_id)
     stream_2 = torch.cuda.Stream(device_id)
     with torch.cuda.stream(stream_1):
         assert torch.cuda.current_stream() == stream_1
-        with tvm_ffi.use_torch_stream():
+        with ffi.use_torch_stream():
             mod.check_stream(device_type, device_id, stream_1.cuda_stream)
 
         with torch.cuda.stream(stream_2):
             assert torch.cuda.current_stream() == stream_2
-            with tvm_ffi.use_torch_stream():
+            with ffi.use_torch_stream():
                 mod.check_stream(device_type, device_id, stream_2.cuda_stream)
 
         assert torch.cuda.current_stream() == stream_1
-        with tvm_ffi.use_torch_stream():
+        with ffi.use_torch_stream():
             mod.check_stream(device_type, device_id, stream_1.cuda_stream)
 
 
@@ -133,12 +133,12 @@ def test_torch_graph() -> None:
     assert torch is not None
     mod = gen_check_stream_mod()
     device_id = torch.cuda.current_device()
-    device = tvm_ffi.device("cuda", device_id)
+    device = ffi.device("cuda", device_id)
     device_type = device.dlpack_device_type()
     graph = torch.cuda.CUDAGraph()
     stream = torch.cuda.Stream(device_id)
     x = torch.zeros(1, device="cuda")
-    with tvm_ffi.use_torch_stream(torch.cuda.graph(graph, stream=stream)):
+    with ffi.use_torch_stream(torch.cuda.graph(graph, stream=stream)):
         assert torch.cuda.current_stream() == stream
         mod.check_stream(device_type, device_id, stream.cuda_stream)
         # avoid cuda graph no capture warning

--- a/tests/python/test_string.py
+++ b/tests/python/test_string.py
@@ -17,15 +17,15 @@
 
 import pickle
 
-import tvm_ffi
+import tvm_ffi as ffi
 
 
 def test_string() -> None:
-    fecho = tvm_ffi.get_global_func("testing.echo")
-    s = tvm_ffi.core.String("hello")
+    fecho = ffi.get_global_func("testing.echo")
+    s = ffi.core.String("hello")
     s2 = fecho(s)
     assert s2 == "hello"
-    s3 = tvm_ffi.convert("hello")
+    s3 = ffi.convert("hello")
     assert isinstance(s3, str)
 
     x = "hello long string"
@@ -36,27 +36,27 @@ def test_string() -> None:
 
 
 def test_bytes() -> None:
-    fecho = tvm_ffi.get_global_func("testing.echo")
-    b = tvm_ffi.core.Bytes(b"hello")
-    assert isinstance(b, tvm_ffi.core.Bytes)
+    fecho = ffi.get_global_func("testing.echo")
+    b = ffi.core.Bytes(b"hello")
+    assert isinstance(b, ffi.core.Bytes)
     b2 = fecho(b)
     assert b2 == b"hello"
 
-    b3 = tvm_ffi.convert(b"hello")
-    assert isinstance(b3, tvm_ffi.core.Bytes)
+    b3 = ffi.convert(b"hello")
+    assert isinstance(b3, ffi.core.Bytes)
     assert isinstance(b3, bytes)
 
-    b4 = tvm_ffi.convert(bytearray(b"hello"))
-    assert isinstance(b4, tvm_ffi.core.Bytes)
+    b4 = ffi.convert(bytearray(b"hello"))
+    assert isinstance(b4, ffi.core.Bytes)
     assert isinstance(b4, bytes)
 
     b5 = pickle.loads(pickle.dumps(b))
     assert b5 == b"hello"
-    assert isinstance(b5, tvm_ffi.core.Bytes)
+    assert isinstance(b5, ffi.core.Bytes)
 
 
 def test_string_find_substr() -> None:
-    s = tvm_ffi.core.String("hello world")
+    s = ffi.core.String("hello world")
     assert s.find("world") == 6
     assert s.find("hello") == 0
     assert s.find("o") == 4

--- a/tests/python/test_structural.py
+++ b/tests/python/test_structural.py
@@ -16,25 +16,25 @@
 # under the License.
 
 import numpy as np
-import tvm_ffi
+import tvm_ffi as ffi
 import tvm_ffi.testing
 
-_recursive_eq = tvm_ffi.get_global_func("ffi.RecursiveEq")
+_recursive_eq = ffi.get_global_func("ffi.RecursiveEq")
 
 
 def test_structural_key_basic() -> None:
-    k1 = tvm_ffi.StructuralKey({"a": [1, 2], "b": [3, {"c": 4}]})
-    k2 = tvm_ffi.StructuralKey({"b": [3, {"c": 4}], "a": [1, 2]})
-    k3 = tvm_ffi.StructuralKey({"a": [1, 2], "b": [3, {"c": 5}]})
+    k1 = ffi.StructuralKey({"a": [1, 2], "b": [3, {"c": 4}]})
+    k2 = ffi.StructuralKey({"b": [3, {"c": 4}], "a": [1, 2]})
+    k3 = ffi.StructuralKey({"a": [1, 2], "b": [3, {"c": 5}]})
 
-    assert tvm_ffi.structural_hash(k1.key) == k1.__hash__()
-    assert tvm_ffi.structural_hash(k2.key) == k2.__hash__()
+    assert ffi.structural_hash(k1.key) == k1.__hash__()
+    assert ffi.structural_hash(k2.key) == k2.__hash__()
 
     assert k1 == k2
     assert k1 != k3
     assert hash(k1) == hash(k2)
-    assert tvm_ffi.structural_equal(k1.key, k2.key)
-    assert not tvm_ffi.structural_equal(k1.key, k3.key)
+    assert ffi.structural_equal(k1.key, k2.key)
+    assert not ffi.structural_equal(k1.key, k3.key)
 
 
 def test_structural_helpers() -> None:
@@ -42,20 +42,20 @@ def test_structural_helpers() -> None:
     rhs = {"meta": {"tag": "x"}, "items": [1, 2, {"k": 3}]}
     other = {"items": [1, 2, {"k": 4}], "meta": {"tag": "x"}}
 
-    assert tvm_ffi.structural_equal(lhs, rhs)
-    assert not tvm_ffi.structural_equal(lhs, other)
-    assert tvm_ffi.structural_hash(lhs) == tvm_ffi.structural_hash(rhs)
-    assert tvm_ffi.structural_hash(lhs) != tvm_ffi.structural_hash(other)
-    assert tvm_ffi.get_first_structural_mismatch(lhs, rhs) is None
-    assert tvm_ffi.get_first_structural_mismatch(lhs, other) is not None
+    assert ffi.structural_equal(lhs, rhs)
+    assert not ffi.structural_equal(lhs, other)
+    assert ffi.structural_hash(lhs) == ffi.structural_hash(rhs)
+    assert ffi.structural_hash(lhs) != ffi.structural_hash(other)
+    assert ffi.get_first_structural_mismatch(lhs, rhs) is None
+    assert ffi.get_first_structural_mismatch(lhs, other) is not None
 
 
 def test_structural_key_in_map() -> None:
-    k1 = tvm_ffi.StructuralKey({"x": [1, 2], "y": [3]})
-    k2 = tvm_ffi.StructuralKey({"y": [3], "x": [1, 2]})
-    k3 = tvm_ffi.StructuralKey({"x": [1, 2], "y": [5]})
+    k1 = ffi.StructuralKey({"x": [1, 2], "y": [3]})
+    k2 = ffi.StructuralKey({"y": [3], "x": [1, 2]})
+    k3 = ffi.StructuralKey({"x": [1, 2], "y": [5]})
 
-    m = tvm_ffi.Map({k1: 1, k2: 2, k3: 3})
+    m = ffi.Map({k1: 1, k2: 2, k3: 3})
     assert len(m) == 2
     assert m[k1] == 2
     assert m[k2] == 2
@@ -63,30 +63,30 @@ def test_structural_key_in_map() -> None:
 
 
 def test_structural_equal_dict() -> None:
-    d1 = tvm_ffi.Dict({"a": 1, "b": 2, "c": 3})
-    d2 = tvm_ffi.Dict({"c": 3, "b": 2, "a": 1})
-    d3 = tvm_ffi.Dict({"a": 1, "b": 2, "c": 4})
+    d1 = ffi.Dict({"a": 1, "b": 2, "c": 3})
+    d2 = ffi.Dict({"c": 3, "b": 2, "a": 1})
+    d3 = ffi.Dict({"a": 1, "b": 2, "c": 4})
 
-    assert tvm_ffi.structural_equal(d1, d2)
-    assert tvm_ffi.structural_hash(d1) == tvm_ffi.structural_hash(d2)
-    assert not tvm_ffi.structural_equal(d1, d3)
-    assert tvm_ffi.structural_hash(d1) != tvm_ffi.structural_hash(d3)
-    assert tvm_ffi.get_first_structural_mismatch(d1, d2) is None
-    assert tvm_ffi.get_first_structural_mismatch(d1, d3) is not None
+    assert ffi.structural_equal(d1, d2)
+    assert ffi.structural_hash(d1) == ffi.structural_hash(d2)
+    assert not ffi.structural_equal(d1, d3)
+    assert ffi.structural_hash(d1) != ffi.structural_hash(d3)
+    assert ffi.get_first_structural_mismatch(d1, d2) is None
+    assert ffi.get_first_structural_mismatch(d1, d3) is not None
 
 
 def test_structural_dict_vs_map_different_type() -> None:
-    m = tvm_ffi.Map({"a": 1, "b": 2})
-    d = tvm_ffi.Dict({"a": 1, "b": 2})
+    m = ffi.Map({"a": 1, "b": 2})
+    d = ffi.Dict({"a": 1, "b": 2})
     # Different type_index => not structurally equal
-    assert not tvm_ffi.structural_equal(m, d)
-    assert tvm_ffi.structural_hash(m) != tvm_ffi.structural_hash(d)
+    assert not ffi.structural_equal(m, d)
+    assert ffi.structural_hash(m) != ffi.structural_hash(d)
 
 
 def test_structural_key_in_python_dict() -> None:
-    k1 = tvm_ffi.StructuralKey({"name": ["a", "b"], "ver": [1]})
-    k2 = tvm_ffi.StructuralKey({"ver": [1], "name": ["a", "b"]})
-    k3 = tvm_ffi.StructuralKey({"name": ["a", "c"], "ver": [1]})
+    k1 = ffi.StructuralKey({"name": ["a", "b"], "ver": [1]})
+    k2 = ffi.StructuralKey({"ver": [1], "name": ["a", "b"]})
+    k3 = ffi.StructuralKey({"name": ["a", "c"], "ver": [1]})
 
     data = {k1: "a", k3: "b"}
     assert data[k2] == "a"
@@ -99,17 +99,17 @@ def test_structural_key_tensor_content_policy() -> None:
     if not hasattr(t1_np, "__dlpack__"):
         return
 
-    t1 = tvm_ffi.from_dlpack(t1_np)
-    t2 = tvm_ffi.from_dlpack(t2_np)
+    t1 = ffi.from_dlpack(t1_np)
+    t2 = ffi.from_dlpack(t2_np)
 
     # Default policy compares tensor content.
-    assert not tvm_ffi.structural_equal(t1, t2)
+    assert not ffi.structural_equal(t1, t2)
     # Optional policy can ignore tensor content.
-    assert tvm_ffi.structural_equal(t1, t2, skip_tensor_content=True)
+    assert ffi.structural_equal(t1, t2, skip_tensor_content=True)
 
     # StructuralKey should follow default structural policy.
-    k1 = tvm_ffi.StructuralKey(t1)
-    k2 = tvm_ffi.StructuralKey(t2)
+    k1 = ffi.StructuralKey(t1)
+    k2 = ffi.StructuralKey(t2)
     assert k1 != k2
 
     data = {k1: "a", k2: "b"}
@@ -121,34 +121,34 @@ def test_structural_key_tensor_content_policy() -> None:
 
 def test_recursive_eq_self_referencing_cycle() -> None:
     """RecursiveEq should return True for structurally equivalent cycles."""
-    v_map = tvm_ffi.Map({})
-    obj = tvm_ffi.testing.create_object(
+    v_map = ffi.Map({})
+    obj = ffi.testing.create_object(
         "testing.TestObjectDerived",
         v_i64=1,
         v_f64=0.0,
         v_str="",
         v_map=v_map,
-        v_array=tvm_ffi.Array([]),
+        v_array=ffi.Array([]),
     )
-    obj.v_array = tvm_ffi.Array([obj])  # type: ignore[unresolved-attribute]
+    obj.v_array = ffi.Array([obj])  # type: ignore[unresolved-attribute]
     # Self-referencing object compared to itself — identity short-circuits.
     assert _recursive_eq(obj, obj)
 
 
 def test_recursive_eq_mutual_cycle() -> None:
     """RecursiveEq should return True for two distinct but structurally equivalent cyclic graphs."""
-    v_map = tvm_ffi.Map({})
+    v_map = ffi.Map({})
 
     def make_cyclic(v_i64: int) -> object:
-        o = tvm_ffi.testing.create_object(
+        o = ffi.testing.create_object(
             "testing.TestObjectDerived",
             v_i64=v_i64,
             v_f64=0.0,
             v_str="x",
             v_map=v_map,
-            v_array=tvm_ffi.Array([]),
+            v_array=ffi.Array([]),
         )
-        o.v_array = tvm_ffi.Array([o])  # type: ignore[unresolved-attribute]
+        o.v_array = ffi.Array([o])  # type: ignore[unresolved-attribute]
         return o
 
     a = make_cyclic(42)

--- a/tests/python/test_structural_py_class.py
+++ b/tests/python/test_structural_py_class.py
@@ -24,7 +24,7 @@ to Python using ``@py_class(structural_eq=...)`` and ``field(structural_eq=...)`
 from __future__ import annotations
 
 import pytest
-import tvm_ffi
+import tvm_ffi as ffi
 from tvm_ffi import get_first_structural_mismatch, structural_equal, structural_hash
 from tvm_ffi.dataclasses import field, py_class
 
@@ -34,7 +34,7 @@ from tvm_ffi.dataclasses import field, py_class
 
 
 @py_class("testing.py.Var", structural_eq="var")
-class TVar(tvm_ffi.Object):
+class TVar(ffi.Object):
     """Variable node — compared by binding position, not by name.
 
     Mirrors C++ TVarObj with:
@@ -46,14 +46,14 @@ class TVar(tvm_ffi.Object):
 
 
 @py_class("testing.py.Int", structural_eq="tree")
-class TInt(tvm_ffi.Object):
+class TInt(ffi.Object):
     """Simple integer literal node."""
 
     value: int
 
 
 @py_class("testing.py.Func", structural_eq="tree")
-class TFunc(tvm_ffi.Object):
+class TFunc(ffi.Object):
     """Function node with definition region and ignored comment.
 
     Mirrors C++ TFuncObj with:
@@ -67,14 +67,14 @@ class TFunc(tvm_ffi.Object):
 
 
 @py_class("testing.py.Expr", structural_eq="tree")
-class TExpr(tvm_ffi.Object):
+class TExpr(ffi.Object):
     """A simple expression node for tree-comparison tests."""
 
     value: int
 
 
 @py_class("testing.py.Metadata", structural_eq="const-tree")
-class TMetadata(tvm_ffi.Object):
+class TMetadata(ffi.Object):
     """Immutable metadata node — pointer shortcut is safe (no var children)."""
 
     tag: str
@@ -82,7 +82,7 @@ class TMetadata(tvm_ffi.Object):
 
 
 @py_class("testing.py.Binding", structural_eq="dag")
-class TBinding(tvm_ffi.Object):
+class TBinding(ffi.Object):
     """Binding node — sharing structure is semantically meaningful."""
 
     name: str
@@ -237,8 +237,8 @@ class TestTreeNode:
         """Under "tree", sharing doesn't affect equality."""
         s = TExpr(value=10)
         # Two arrays referencing the same object vs two copies
-        shared = tvm_ffi.Array([s, s])
-        copies = tvm_ffi.Array([TExpr(value=10), TExpr(value=10)])
+        shared = ffi.Array([s, s])
+        copies = ffi.Array([TExpr(value=10), TExpr(value=10)])
         assert structural_equal(shared, copies)
         assert structural_hash(shared) == structural_hash(copies)
 
@@ -282,8 +282,8 @@ class TestDAGNode:
         """Two DAGs with the same sharing shape are equal."""
         s1 = TBinding(name="s", value=1)
         s2 = TBinding(name="s", value=1)
-        dag1 = tvm_ffi.Array([s1, s1])  # shared
-        dag2 = tvm_ffi.Array([s2, s2])  # shared (same shape)
+        dag1 = ffi.Array([s1, s1])  # shared
+        dag2 = ffi.Array([s2, s2])  # shared (same shape)
         assert structural_equal(dag1, dag2)
 
     def test_dag_vs_tree_not_equal(self) -> None:
@@ -291,8 +291,8 @@ class TestDAGNode:
         shared = TBinding(name="s", value=1)
         copy1 = TBinding(name="s", value=1)
         copy2 = TBinding(name="s", value=1)
-        dag = tvm_ffi.Array([shared, shared])
-        tree = tvm_ffi.Array([copy1, copy2])
+        dag = ffi.Array([shared, shared])
+        tree = ffi.Array([copy1, copy2])
         assert not structural_equal(dag, tree)
 
     def test_dag_vs_tree_hash_differs(self) -> None:
@@ -300,16 +300,16 @@ class TestDAGNode:
         shared = TBinding(name="s", value=1)
         copy1 = TBinding(name="s", value=1)
         copy2 = TBinding(name="s", value=1)
-        dag = tvm_ffi.Array([shared, shared])
-        tree = tvm_ffi.Array([copy1, copy2])
+        dag = ffi.Array([shared, shared])
+        tree = ffi.Array([copy1, copy2])
         assert structural_hash(dag) != structural_hash(tree)
 
     def test_reverse_bijection(self) -> None:
         """(a, b) vs (a, a) where a ≅ b — reverse map detects inconsistency."""
         a = TBinding(name="a", value=1)
         b = TBinding(name="b", value=1)  # same content as a
-        lhs = tvm_ffi.Array([a, b])
-        rhs = tvm_ffi.Array([a, a])  # note: same object twice
+        lhs = ffi.Array([a, b])
+        rhs = ffi.Array([a, a])  # note: same object twice
         assert not structural_equal(lhs, rhs)
 
 
@@ -325,7 +325,7 @@ class TestUnsupported:
         """Structural hashing raises TypeError for types without structural_eq=."""
 
         @py_class("testing.py.Plain")
-        class Plain(tvm_ffi.Object):
+        class Plain(ffi.Object):
             x: int
 
         with pytest.raises(TypeError):
@@ -335,7 +335,7 @@ class TestUnsupported:
         """Structural equality raises TypeError for types without structural_eq=."""
 
         @py_class("testing.py.Plain2")
-        class Plain2(tvm_ffi.Object):
+        class Plain2(ffi.Object):
             x: int
 
         with pytest.raises(TypeError):

--- a/tests/python/test_tensor.py
+++ b/tests/python/test_tensor.py
@@ -29,45 +29,45 @@ except ImportError:
     torch = None  # ty: ignore[invalid-assignment]
 
 import numpy as np
-import tvm_ffi
+import tvm_ffi as ffi
 
 
 def test_tensor_attributes() -> None:
     data: npt.NDArray[Any] = np.zeros((10, 8, 4, 2), dtype="int16")
     if not hasattr(data, "__dlpack__"):
         return
-    x = tvm_ffi.from_dlpack(data)
-    assert isinstance(x, tvm_ffi.Tensor)
+    x = ffi.from_dlpack(data)
+    assert isinstance(x, ffi.Tensor)
     assert x.shape == (10, 8, 4, 2)
     assert x.strides == (64, 8, 2, 1)
-    assert x.dtype == tvm_ffi.dtype("int16")
-    assert x.device.dlpack_device_type() == tvm_ffi.DLDeviceType.kDLCPU
+    assert x.dtype == ffi.dtype("int16")
+    assert x.device.dlpack_device_type() == ffi.DLDeviceType.kDLCPU
     assert x.device.index == 0
     x2 = np.from_dlpack(x)
     np.testing.assert_equal(x2, data)
 
 
 def test_shape_object() -> None:
-    shape = tvm_ffi.Shape((10, 8, 4, 2))
-    assert isinstance(shape, tvm_ffi.Shape)
+    shape = ffi.Shape((10, 8, 4, 2))
+    assert isinstance(shape, ffi.Shape)
     assert shape == (10, 8, 4, 2)
 
-    fecho = tvm_ffi.convert(lambda x: x)
-    shape2: tvm_ffi.Shape = fecho(shape)
+    fecho = ffi.convert(lambda x: x)
+    shape2: ffi.Shape = fecho(shape)
     assert shape2._tvm_ffi_cached_object.same_as(shape._tvm_ffi_cached_object)
-    assert isinstance(shape2, tvm_ffi.Shape)
+    assert isinstance(shape2, ffi.Shape)
     assert isinstance(shape2, tuple)
 
-    shape3: tvm_ffi.Shape = tvm_ffi.convert(shape)
+    shape3: ffi.Shape = ffi.convert(shape)
     assert shape3._tvm_ffi_cached_object.same_as(shape._tvm_ffi_cached_object)
-    assert isinstance(shape3, tvm_ffi.Shape)
+    assert isinstance(shape3, ffi.Shape)
 
 
 @pytest.mark.skipif(torch is None, reason="Fast torch dlpack importer is not enabled")
 def test_tensor_auto_dlpack() -> None:
     assert torch is not None
     x = torch.arange(128)
-    fecho = tvm_ffi.get_global_func("testing.echo")
+    fecho = ffi.get_global_func("testing.echo")
     y = fecho(x)
     assert isinstance(y, torch.Tensor)
     assert y.data_ptr() == x.data_ptr()
@@ -85,46 +85,46 @@ def test_tensor_auto_dlpack_with_error() -> None:
     def raise_torch_error(x: Any) -> NoReturn:
         raise ValueError("error XYZ")
 
-    f = tvm_ffi.convert(raise_torch_error)
+    f = ffi.convert(raise_torch_error)
     with pytest.raises(ValueError):
         # pass in torch argment to trigger the error in set allocator path
         f(x)
 
 
 def test_tensor_class_override() -> None:
-    class MyTensor(tvm_ffi.Tensor):
+    class MyTensor(ffi.Tensor):
         pass
 
-    old_tensor = tvm_ffi.core._CLASS_TENSOR
-    tvm_ffi.core._set_class_tensor(MyTensor)
+    old_tensor = ffi.core._CLASS_TENSOR
+    ffi.core._set_class_tensor(MyTensor)
 
     data: npt.NDArray[Any] = np.zeros((10, 8, 4, 2), dtype="int16")
     if not hasattr(data, "__dlpack__"):
         return
-    x = tvm_ffi.from_dlpack(data)
+    x = ffi.from_dlpack(data)
 
-    fecho = tvm_ffi.get_global_func("testing.echo")
+    fecho = ffi.get_global_func("testing.echo")
     y = fecho(x)
     assert isinstance(y, MyTensor)
-    tvm_ffi.core._set_class_tensor(old_tensor)
+    ffi.core._set_class_tensor(old_tensor)
 
 
 def test_tvm_ffi_tensor_compatible() -> None:
     class MyTensor:
-        def __init__(self, tensor: tvm_ffi.Tensor) -> None:
+        def __init__(self, tensor: ffi.Tensor) -> None:
             """Initialize the MyTensor."""
             self._tensor = tensor
 
-        def __tvm_ffi_object__(self) -> tvm_ffi.Tensor:
+        def __tvm_ffi_object__(self) -> ffi.Tensor:
             """Implement __tvm_ffi_object__ protocol."""
             return self._tensor
 
     data: npt.NDArray[Any] = np.zeros((10, 8, 4, 2), dtype="int32")
     if not hasattr(data, "__dlpack__"):
         return
-    x = tvm_ffi.from_dlpack(data)
+    x = ffi.from_dlpack(data)
     y = MyTensor(x)
-    fecho = tvm_ffi.get_global_func("testing.echo")
+    fecho = ffi.get_global_func("testing.echo")
     z = fecho(y)
     assert z.__chandle__() == x.__chandle__()
 
@@ -158,20 +158,18 @@ def test_tvm_ffi_tensor_compatible() -> None:
 def test_tensor_from_pytorch_rocm() -> None:
     assert torch is not None
 
-    @tvm_ffi.register_global_func("testing.check_device", override=True)
-    def _check_device(x: tvm_ffi.Tensor) -> str:
+    @ffi.register_global_func("testing.check_device", override=True)
+    def _check_device(x: ffi.Tensor) -> str:
         return x.device.type
 
     # PyTorch uses device name "cuda" to represent ROCm device
     x = torch.randn(128, device="cuda")
-    device_type = tvm_ffi.get_global_func("testing.check_device")(x)
+    device_type = ffi.get_global_func("testing.check_device")(x)
     assert device_type == "rocm"
 
 
 def test_optional_tensor_view() -> None:
-    optional_tensor_view_has_value = tvm_ffi.get_global_func(
-        "testing.optional_tensor_view_has_value"
-    )
+    optional_tensor_view_has_value = ffi.get_global_func("testing.optional_tensor_view_has_value")
     assert not optional_tensor_view_has_value(None)
     x: npt.NDArray[Any] = np.zeros((128,), dtype="float32")
     if not hasattr(x, "__dlpack__"):

--- a/tests/python/test_type_converter.py
+++ b/tests/python/test_type_converter.py
@@ -27,7 +27,7 @@ from numbers import Integral
 from typing import Callable, Iterator, Optional, Union
 
 import pytest
-import tvm_ffi
+import tvm_ffi as ffi
 from tvm_ffi.core import (
     CAny,
     ObjectConvertible,
@@ -170,27 +170,27 @@ class TestRejections:
 class TestSpecialTypes:
     def test_device_pass(self) -> None:
         """Test device pass."""
-        dev = tvm_ffi.Device("cpu", 0)
-        A(tvm_ffi.Device).check_value(dev)
+        dev = ffi.Device("cpu", 0)
+        A(ffi.Device).check_value(dev)
 
     def test_device_fail(self) -> None:
         """Test device fail."""
         with pytest.raises(TypeError):
-            A(tvm_ffi.Device).check_value(42)
+            A(ffi.Device).check_value(42)
 
     def test_dtype_pass(self) -> None:
         """Test dtype pass."""
-        dt = tvm_ffi.core.DataType("float32")
-        A(tvm_ffi.core.DataType).check_value(dt)
+        dt = ffi.core.DataType("float32")
+        A(ffi.core.DataType).check_value(dt)
 
     def test_dtype_str_pass(self) -> None:
         """Str accepted as dtype (will be parsed)."""
-        A(tvm_ffi.core.DataType).check_value("float32")
+        A(ffi.core.DataType).check_value("float32")
 
     def test_dtype_fail(self) -> None:
         """Test dtype fail."""
         with pytest.raises(TypeError):
-            A(tvm_ffi.core.DataType).check_value(42)
+            A(ffi.core.DataType).check_value(42)
 
     def test_opaque_ptr_pass(self) -> None:
         """Test opaque ptr pass."""
@@ -249,22 +249,22 @@ class TestSpecialTypes:
 class TestObjectTypes:
     def test_object_pass(self) -> None:
         """Any CObject passes TypeSchema('Object')."""
-        f = tvm_ffi.get_global_func("testing.echo")
-        A(tvm_ffi.core.Object).check_value(f)
+        f = ffi.get_global_func("testing.echo")
+        A(ffi.core.Object).check_value(f)
 
     def test_object_fail(self) -> None:
         """Test object fail."""
         with pytest.raises(TypeError):
-            A(tvm_ffi.core.Object).check_value(42)
+            A(ffi.core.Object).check_value(42)
 
     def test_specific_object_pass(self) -> None:
         """A Function object should pass its own type schema."""
-        f = tvm_ffi.get_global_func("testing.echo")
+        f = ffi.get_global_func("testing.echo")
         A(Callable).check_value(f)
 
     def test_function_from_extern_c_exists(self) -> None:
         """ffi.FunctionFromExternC should be registered."""
-        fn = tvm_ffi.get_global_func("ffi.FunctionFromExternC", allow_missing=True)
+        fn = ffi.get_global_func("ffi.FunctionFromExternC", allow_missing=True)
         assert fn is not None, "ffi.FunctionFromExternC not registered"
 
 
@@ -375,24 +375,24 @@ class TestContainers:
     @requires_py39
     def test_map_pass(self) -> None:
         """Test map pass."""
-        A(tvm_ffi.Map[str, int]).check_value({"a": 1, "b": 2})
+        A(ffi.Map[str, int]).check_value({"a": 1, "b": 2})
 
     @requires_py39
     def test_map_wrong_key(self) -> None:
         """Test map wrong key."""
         with pytest.raises(TypeError, match="expected str"):
-            A(tvm_ffi.Map[str, int]).check_value({1: 2})
+            A(ffi.Map[str, int]).check_value({1: 2})
 
     @requires_py39
     def test_map_wrong_value(self) -> None:
         """Test map wrong value."""
         with pytest.raises(TypeError, match="expected int"):
-            A(tvm_ffi.Map[str, int]).check_value({"a": "b"})
+            A(ffi.Map[str, int]).check_value({"a": "b"})
 
     @requires_py39
     def test_map_empty_pass(self) -> None:
         """Test map empty pass."""
-        A(tvm_ffi.Map[str, int]).check_value({})
+        A(ffi.Map[str, int]).check_value({})
 
     @requires_py39
     def test_dict_pass(self) -> None:
@@ -403,13 +403,13 @@ class TestContainers:
     def test_map_wrong_container(self) -> None:
         """Test map wrong container."""
         with pytest.raises(TypeError, match="expected Map"):
-            A(tvm_ffi.Map[str, int]).check_value([1, 2])
+            A(ffi.Map[str, int]).check_value([1, 2])
 
     @requires_py39
     def test_map_rejects_non_mapping_pairs(self) -> None:
         """Lists of pairs are not accepted by Map schemas."""
         with pytest.raises(TypeError, match="expected Map"):
-            A(tvm_ffi.Map[str, int]).check_value([("a", 1)])
+            A(ffi.Map[str, int]).check_value([("a", 1)])
 
 
 # ---------------------------------------------------------------------------
@@ -424,13 +424,13 @@ class TestNestedTypes:
     @requires_py39
     def test_map_str_array_int(self) -> None:
         """Test map str array int."""
-        A(tvm_ffi.Map[str, tuple[int, ...]]).check_value({"a": [1, 2]})
+        A(ffi.Map[str, tuple[int, ...]]).check_value({"a": [1, 2]})
 
     @requires_py39
     def test_map_str_array_int_nested_fail(self) -> None:
         """Test map str array int nested fail."""
         with pytest.raises(TypeError, match="expected int"):
-            A(tvm_ffi.Map[str, tuple[int, ...]]).check_value({"a": [1, "x"]})
+            A(ffi.Map[str, tuple[int, ...]]).check_value({"a": [1, "x"]})
 
     @requires_py39
     def test_union_with_containers(self) -> None:
@@ -471,7 +471,7 @@ class TestAny:
         inner = TestIntPair(1, 2)
 
         class Convertible(ObjectConvertible):
-            def asobject(self) -> tvm_ffi.core.Object:
+            def asobject(self) -> ffi.core.Object:
                 return inner
 
         result = _to_py_class_value(A(typing.Any).convert(Convertible()))
@@ -481,7 +481,7 @@ class TestAny:
         """Any surfaces asobject() failures during eager normalization."""
 
         class BadConvertible(ObjectConvertible):
-            def asobject(self) -> tvm_ffi.core.Object:
+            def asobject(self) -> ffi.core.Object:
                 raise RuntimeError("broken")
 
         with pytest.raises(TypeError, match=r"asobject\(\) failed"):
@@ -528,7 +528,7 @@ class TestErrorMessages:
     def test_nested_map_error(self) -> None:
         """Test nested map error."""
         with pytest.raises(TypeError, match=r"value for key 'b'.*expected int, got str"):
-            A(tvm_ffi.Map[str, int]).check_value({"a": 1, "b": "x"})
+            A(ffi.Map[str, int]).check_value({"a": 1, "b": "x"})
 
     def test_union_error_lists_alternatives(self) -> None:
         """Test union error lists alternatives."""
@@ -725,25 +725,25 @@ class TestConvertPOD:
         assert type(result) is bool
 
     def test_str_passthrough(self) -> None:
-        """Test str passthrough — returns tvm_ffi.String (subclass of str)."""
+        """Test str passthrough — returns ffi.String (subclass of str)."""
         result = _to_py_class_value(A(str).convert("hello"))
         assert result == "hello"
         assert isinstance(result, str)
-        assert isinstance(result, tvm_ffi.core.String)
+        assert isinstance(result, ffi.core.String)
 
     def test_bytes_passthrough(self) -> None:
-        """Test bytes passthrough — returns tvm_ffi.Bytes (subclass of bytes)."""
+        """Test bytes passthrough — returns ffi.Bytes (subclass of bytes)."""
         result = _to_py_class_value(A(bytes).convert(b"data"))
         assert result == b"data"
         assert isinstance(result, bytes)
-        assert isinstance(result, tvm_ffi.core.Bytes)
+        assert isinstance(result, ffi.core.Bytes)
 
     def test_bytearray_to_bytes(self) -> None:
-        """Bytearray -> bytes converts to tvm_ffi.Bytes."""
+        """Bytearray -> bytes converts to ffi.Bytes."""
         result = _to_py_class_value(A(bytes).convert(bytearray(b"data")))
         assert result == b"data"
         assert isinstance(result, bytes)
-        assert isinstance(result, tvm_ffi.core.Bytes)
+        assert isinstance(result, ffi.core.Bytes)
 
 
 # ---------------------------------------------------------------------------
@@ -800,20 +800,20 @@ class TestNoneDisambiguation:
 class TestConvertSpecialTypes:
     def test_dtype_str_converts(self) -> None:
         """Str -> dtype actually creates a DataType object."""
-        result = _to_py_class_value(A(tvm_ffi.core.DataType).convert("float32"))
-        assert isinstance(result, tvm_ffi.core.DataType)
+        result = _to_py_class_value(A(ffi.core.DataType).convert("float32"))
+        assert isinstance(result, ffi.core.DataType)
         assert str(result) == "float32"
 
     def test_dtype_passthrough(self) -> None:
         """Test dtype passthrough."""
-        dt = tvm_ffi.core.DataType("int32")
-        result = _to_py_class_value(A(tvm_ffi.core.DataType).convert(dt))
+        dt = ffi.core.DataType("int32")
+        result = _to_py_class_value(A(ffi.core.DataType).convert(dt))
         assert str(result) == str(dt)
 
     def test_device_passthrough(self) -> None:
         """Test device passthrough."""
-        dev = tvm_ffi.Device("cpu", 0)
-        result = _to_py_class_value(A(tvm_ffi.Device).convert(dev))
+        dev = ffi.Device("cpu", 0)
+        result = _to_py_class_value(A(ffi.Device).convert(dev))
         assert str(result) == str(dev)
 
     def test_callable_passthrough(self) -> None:
@@ -851,13 +851,13 @@ class TestConvertContainers:
         """Array[Any] wraps into ffi.Array."""
         original = [1, "x", None]
         result = _to_py_class_value(A(tuple[typing.Any, ...]).convert(original))
-        assert isinstance(result, tvm_ffi.Array)
+        assert isinstance(result, ffi.Array)
 
     @requires_py39
     def test_map_converts_values(self) -> None:
         """Map[str, float] converts int values to float."""
-        result = _to_py_class_value(A(tvm_ffi.Map[str, float]).convert({"a": 1, "b": 2}))
-        assert isinstance(result, tvm_ffi.Map)
+        result = _to_py_class_value(A(ffi.Map[str, float]).convert({"a": 1, "b": 2}))
+        assert isinstance(result, ffi.Map)
         assert type(result["a"]) is float
         assert type(result["b"]) is float
         assert result["a"] == 1.0
@@ -866,21 +866,21 @@ class TestConvertContainers:
     @requires_py39
     def test_map_any_float_converts_values(self) -> None:
         """Map[Any, float] still converts values when keys are Any."""
-        result = _to_py_class_value(A(tvm_ffi.Map[typing.Any, float]).convert({"a": 1, "b": 2}))
-        assert isinstance(result, tvm_ffi.Map)
+        result = _to_py_class_value(A(ffi.Map[typing.Any, float]).convert({"a": 1, "b": 2}))
+        assert isinstance(result, ffi.Map)
         assert type(result["a"]) is float
 
     @requires_py39
     def test_map_any_any_passthrough(self) -> None:
         """Map[Any, Any] wraps into ffi.Map."""
         original = {"a": 1}
-        result = _to_py_class_value(A(tvm_ffi.Map[typing.Any, typing.Any]).convert(original))
-        assert isinstance(result, tvm_ffi.Map)
+        result = _to_py_class_value(A(ffi.Map[typing.Any, typing.Any]).convert(original))
+        assert isinstance(result, ffi.Map)
 
     @requires_py39
     def test_map_empty_dict_convert(self) -> None:
         """Empty dict converts to Map[str, int]."""
-        result = _to_py_class_value(A(tvm_ffi.Map[str, int]).convert({}))
+        result = _to_py_class_value(A(ffi.Map[str, int]).convert({}))
         assert len(result) == 0
 
     @requires_py39
@@ -900,10 +900,8 @@ class TestConvertContainers:
     @requires_py39
     def test_nested_array_in_map(self) -> None:
         """Map[str, Array[int]] recursively converts elements."""
-        result = _to_py_class_value(
-            A(tvm_ffi.Map[str, tuple[int, ...]]).convert({"a": [True, False]})
-        )
-        assert isinstance(result, tvm_ffi.Map)
+        result = _to_py_class_value(A(ffi.Map[str, tuple[int, ...]]).convert({"a": [True, False]}))
+        assert isinstance(result, ffi.Map)
         assert list(result["a"]) == [1, 0]
         assert all(type(x) is int for x in result["a"])
 
@@ -977,7 +975,7 @@ class TestConvertRejections:
     def test_map_rejects_wrong_value(self) -> None:
         """Test map rejects wrong value."""
         with pytest.raises(TypeError, match=r"value for key 'a'.*expected int, got str"):
-            A(tvm_ffi.Map[str, int]).convert({"a": "x"})
+            A(ffi.Map[str, int]).convert({"a": "x"})
 
     @requires_py39
     def test_tuple_rejects_wrong_length(self) -> None:
@@ -1081,9 +1079,7 @@ class TestNestedMapComposite:
     @requires_py39
     def test_map_str_optional_float_with_int(self) -> None:
         """Map[str, Optional[float]] converts int values to float."""
-        result = _to_py_class_value(
-            A(tvm_ffi.Map[str, Optional[float]]).convert({"a": 1, "b": None})
-        )
+        result = _to_py_class_value(A(ffi.Map[str, Optional[float]]).convert({"a": 1, "b": None}))
         assert type(result["a"]) is float
         assert result["a"] == 1.0
         assert result["b"] is None
@@ -1092,7 +1088,7 @@ class TestNestedMapComposite:
     def test_map_str_union_int_str(self) -> None:
         """Map[str, Union[int, str]] converts bool values via int."""
         result = _to_py_class_value(
-            A(tvm_ffi.Map[str, Union[int, str]]).convert({"x": True, "y": "hello"})
+            A(ffi.Map[str, Union[int, str]]).convert({"x": True, "y": "hello"})
         )
         assert result["x"] == 1
         assert result["y"] == "hello"
@@ -1113,7 +1109,7 @@ class TestNestedMapComposite:
     def test_map_str_optional_float_failure(self) -> None:
         """Map[str, Optional[float]] fails for non-float non-None value."""
         with pytest.raises(TypeError, match="expected float"):
-            A(tvm_ffi.Map[str, Optional[float]]).check_value({"a": "bad"})
+            A(ffi.Map[str, Optional[float]]).check_value({"a": "bad"})
 
 
 # ---------------------------------------------------------------------------
@@ -1138,7 +1134,7 @@ class TestNestedContainerInContainer:
     def test_map_str_array_float(self) -> None:
         """Map[str, Array[float]] with int->float conversion in arrays."""
         result = _to_py_class_value(
-            A(tvm_ffi.Map[str, tuple[float, ...]]).convert({"a": [1, 2], "b": [True, 3]})
+            A(ffi.Map[str, tuple[float, ...]]).convert({"a": [1, 2], "b": [True, 3]})
         )
         assert list(result["a"]) == [1.0, 2.0]
         assert list(result["b"]) == [1.0, 3.0]
@@ -1156,7 +1152,7 @@ class TestNestedContainerInContainer:
     def test_array_of_map_str_int(self) -> None:
         """Array[Map[str, int]] with bool->int value conversion."""
         result = _to_py_class_value(
-            A(tuple[tvm_ffi.Map[str, int], ...]).convert([{"x": True}, {"y": 2}])
+            A(tuple[ffi.Map[str, int], ...]).convert([{"x": True}, {"y": 2}])
         )
         assert result[0]["x"] == 1
         assert result[1]["y"] == 2
@@ -1166,7 +1162,7 @@ class TestNestedContainerInContainer:
     def test_map_str_map_str_float(self) -> None:
         """Map[str, Map[str, float]] double nested with int->float."""
         result = _to_py_class_value(
-            A(tvm_ffi.Map[str, tvm_ffi.Map[str, float]]).convert({"outer": {"inner": 42}})
+            A(ffi.Map[str, ffi.Map[str, float]]).convert({"outer": {"inner": 42}})
         )
         assert result["outer"]["inner"] == 42.0
         assert type(result["outer"]["inner"]) is float
@@ -1187,9 +1183,7 @@ class TestNestedContainerInContainer:
     @requires_py39
     def test_empty_inner_containers(self) -> None:
         """Map[str, Array[int]] with empty inner arrays."""
-        result = _to_py_class_value(
-            A(tvm_ffi.Map[str, tuple[int, ...]]).convert({"a": [], "b": []})
-        )
+        result = _to_py_class_value(A(ffi.Map[str, tuple[int, ...]]).convert({"a": [], "b": []}))
         assert list(result["a"]) == []
         assert list(result["b"]) == []
 
@@ -1206,7 +1200,7 @@ class TestNestedContainerInContainer:
     @requires_py39
     def test_map_of_map_of_array_float(self) -> None:
         """Nested map-to-array conversion still coerces inner values."""
-        schema = A(tvm_ffi.Map[str, tvm_ffi.Map[str, tuple[float, ...]]])
+        schema = A(ffi.Map[str, ffi.Map[str, tuple[float, ...]]])
         data = {"outer": {"inner": [1, 2, True]}}
         result = _to_py_class_value(schema.convert(data))
         assert list(result["outer"]["inner"]) == [1.0, 2.0, 1.0]
@@ -1234,20 +1228,20 @@ class TestOptionalUnionWrappingContainers:
     @requires_py39
     def test_optional_map_str_float(self) -> None:
         """Optional[Map[str, float]] converts inner int values."""
-        result = _to_py_class_value(A(Optional[tvm_ffi.Map[str, float]]).convert({"a": 1}))
+        result = _to_py_class_value(A(Optional[ffi.Map[str, float]]).convert({"a": 1}))
         assert result["a"] == 1.0
         assert type(result["a"]) is float
 
     @requires_py39
     def test_optional_map_str_float_none(self) -> None:
         """Optional[Map[str, float]] accepts None."""
-        result = _to_py_class_value(A(Optional[tvm_ffi.Map[str, float]]).convert(None))
+        result = _to_py_class_value(A(Optional[ffi.Map[str, float]]).convert(None))
         assert result is None
 
     @requires_py39
     def test_union_array_int_or_map_str_int(self) -> None:
         """Union[Array[int], Map[str, int]] matches first with conversion."""
-        schema = A(Union[tuple[int, ...], tvm_ffi.Map[str, int]])
+        schema = A(Union[tuple[int, ...], ffi.Map[str, int]])
         # list matches Array alternative
         result = _to_py_class_value(schema.convert([True, 2]))
         assert list(result) == [1, 2]
@@ -1256,7 +1250,7 @@ class TestOptionalUnionWrappingContainers:
     @requires_py39
     def test_union_array_int_or_map_str_int_dict(self) -> None:
         """Union[Array[int], Map[str, int]] matches Map for dict input."""
-        schema = A(Union[tuple[int, ...], tvm_ffi.Map[str, int]])
+        schema = A(Union[tuple[int, ...], ffi.Map[str, int]])
         result = _to_py_class_value(schema.convert({"a": True}))
         assert result["a"] == 1
         assert type(result["a"]) is int
@@ -1301,7 +1295,7 @@ class TestNestedTuple:
     def test_map_str_tuple_int_str(self) -> None:
         """Map[str, tuple[int, str]] with inner bool->int conversion."""
         result = _to_py_class_value(
-            A(tvm_ffi.Map[str, tuple[int, str]]).convert({"a": (True, "hello")})
+            A(ffi.Map[str, tuple[int, str]]).convert({"a": (True, "hello")})
         )
         assert result["a"][0] == 1
         assert str(result["a"][1]) == "hello"
@@ -1310,7 +1304,7 @@ class TestNestedTuple:
     @requires_py39
     def test_tuple_of_array_int_and_map(self) -> None:
         """tuple[Array[int], Map[str, float]] nested conversion."""
-        schema = A(tuple[tuple[int, ...], tvm_ffi.Map[str, float]])
+        schema = A(tuple[tuple[int, ...], ffi.Map[str, float]])
         result = _to_py_class_value(schema.convert(([True, 2], {"k": 3})))
         assert list(result[0]) == [1, 2]
         assert result[1]["k"] == 3.0
@@ -1341,7 +1335,7 @@ class TestDeepNesting:
     def test_map_str_array_optional_int(self) -> None:
         """Map[str, Array[Optional[int]]] with 3-level nesting and conversion."""
         result = _to_py_class_value(
-            A(tvm_ffi.Map[str, tuple[Optional[int], ...]]).convert({"a": [1, None, True]})
+            A(ffi.Map[str, tuple[Optional[int], ...]]).convert({"a": [1, None, True]})
         )
         assert list(result["a"]) == [1, None, 1]
         assert type(result["a"][0]) is int
@@ -1352,9 +1346,7 @@ class TestDeepNesting:
     def test_array_map_str_optional_float(self) -> None:
         """Array[Map[str, Optional[float]]] with 3-level nesting."""
         result = _to_py_class_value(
-            A(tuple[tvm_ffi.Map[str, Optional[float]], ...]).convert(
-                [{"x": 1, "y": None}, {"z": True}]
-            )
+            A(tuple[ffi.Map[str, Optional[float]], ...]).convert([{"x": 1, "y": None}, {"z": True}])
         )
         assert result[0]["x"] == 1.0
         assert result[0]["y"] is None
@@ -1365,7 +1357,7 @@ class TestDeepNesting:
     @requires_py39
     def test_optional_array_map_str_int(self) -> None:
         """Optional[Array[Map[str, int]]] 3 levels deep."""
-        schema = A(Optional[tuple[tvm_ffi.Map[str, int], ...]])
+        schema = A(Optional[tuple[ffi.Map[str, int], ...]])
         result = _to_py_class_value(schema.convert([{"a": True}, {"b": 2}]))
         assert result[0]["a"] == 1
         assert result[1]["b"] == 2
@@ -1377,7 +1369,7 @@ class TestDeepNesting:
     def test_map_str_array_array_int(self) -> None:
         """Map[str, Array[Array[int]]] 3-level container nesting."""
         result = _to_py_class_value(
-            A(tvm_ffi.Map[str, tuple[tuple[int, ...], ...]]).convert({"m": [[True, 1], [False, 2]]})
+            A(ffi.Map[str, tuple[tuple[int, ...], ...]]).convert({"m": [[True, 1], [False, 2]]})
         )
         assert [list(row) for row in result["m"]] == [[1, 1], [0, 2]]
         assert all(type(x) is int for row in result["m"] for x in row)
@@ -1398,68 +1390,68 @@ class TestDeepNesting:
     def test_deep_nesting_failure_propagation(self) -> None:
         """Error from deepest level propagates with full path info."""
         with pytest.raises(TypeError, match=r"value for key 'key'.*element .1..*expected int"):
-            A(tvm_ffi.Map[str, tuple[Optional[int], ...]]).check_value({"key": [1, "bad"]})
+            A(ffi.Map[str, tuple[Optional[int], ...]]).check_value({"key": [1, "bad"]})
 
 
 # ---------------------------------------------------------------------------
-# Category 27: FFI container inputs (tvm_ffi.Array/List/Map/Dict)
+# Category 27: FFI container inputs (ffi.Array/List/Map/Dict)
 # ---------------------------------------------------------------------------
 class TestFFIContainerInputs:
     @requires_py39
     def test_ffi_array_with_element_conversion(self) -> None:
-        """tvm_ffi.Array([True, 2]) passes Array[int] with bool->int conversion."""
-        arr = tvm_ffi.Array([True, 2, 3])
+        """ffi.Array([True, 2]) passes Array[int] with bool->int conversion."""
+        arr = ffi.Array([True, 2, 3])
         result = _to_py_class_value(A(tuple[int, ...]).convert(arr))
         assert list(result) == [1, 2, 3]
         assert type(result[0]) is int
 
     @requires_py39
     def test_ffi_array_any_passthrough(self) -> None:
-        """tvm_ffi.Array passes Array[Any] as-is."""
-        arr = tvm_ffi.Array([1, "x", None])
+        """ffi.Array passes Array[Any] as-is."""
+        arr = ffi.Array([1, "x", None])
         result = _to_py_class_value(A(tuple[typing.Any, ...]).convert(arr))
         assert result.same_as(arr)
 
     @requires_py39
     def test_ffi_list_with_list_schema(self) -> None:
-        """tvm_ffi.List passes List[int] with conversion."""
-        lst = tvm_ffi.List([True, 2])
+        """ffi.List passes List[int] with conversion."""
+        lst = ffi.List([True, 2])
         result = _to_py_class_value(A(list[int]).convert(lst))
         assert list(result) == [1, 2]
         assert type(result[0]) is int
 
     @requires_py39
     def test_ffi_list_accepted_by_array_schema(self) -> None:
-        """tvm_ffi.List passes Array schema (C++ allows cross-type via kOtherTypeIndex)."""
-        lst = tvm_ffi.List([1, 2])
+        """ffi.List passes Array schema (C++ allows cross-type via kOtherTypeIndex)."""
+        lst = ffi.List([1, 2])
         A(tuple[int, ...]).check_value(lst)
 
     @requires_py39
     def test_ffi_array_accepted_by_list_schema(self) -> None:
-        """tvm_ffi.Array passes List schema (C++ allows cross-type via kOtherTypeIndex)."""
-        arr = tvm_ffi.Array([1, 2])
+        """ffi.Array passes List schema (C++ allows cross-type via kOtherTypeIndex)."""
+        arr = ffi.Array([1, 2])
         A(list[int]).check_value(arr)
 
     @requires_py39
     def test_ffi_map_with_value_conversion(self) -> None:
-        """tvm_ffi.Map passes Map[str, int] with bool->int conversion."""
-        m = tvm_ffi.Map({"a": True, "b": 2})
-        result = _to_py_class_value(A(tvm_ffi.Map[str, int]).convert(m))
+        """ffi.Map passes Map[str, int] with bool->int conversion."""
+        m = ffi.Map({"a": True, "b": 2})
+        result = _to_py_class_value(A(ffi.Map[str, int]).convert(m))
         assert result["a"] == 1
         assert result["b"] == 2
         assert type(result["a"]) is int
 
     @requires_py39
     def test_ffi_map_any_any_passthrough(self) -> None:
-        """tvm_ffi.Map passes Map[Any, Any] as-is."""
-        m = tvm_ffi.Map({"a": 1})
-        result = _to_py_class_value(A(tvm_ffi.Map[typing.Any, typing.Any]).convert(m))
+        """ffi.Map passes Map[Any, Any] as-is."""
+        m = ffi.Map({"a": 1})
+        result = _to_py_class_value(A(ffi.Map[typing.Any, typing.Any]).convert(m))
         assert result.same_as(m)
 
     @requires_py39
     def test_ffi_dict_with_dict_schema(self) -> None:
-        """tvm_ffi.Dict passes Dict[str, float] with int->float conversion."""
-        d = tvm_ffi.Dict({"x": 1, "y": 2})
+        """ffi.Dict passes Dict[str, float] with int->float conversion."""
+        d = ffi.Dict({"x": 1, "y": 2})
         result = _to_py_class_value(A(dict[str, float]).convert(d))
         assert result["x"] == 1.0
         assert result["y"] == 2.0
@@ -1467,20 +1459,20 @@ class TestFFIContainerInputs:
 
     @requires_py39
     def test_ffi_dict_accepted_by_map_schema(self) -> None:
-        """tvm_ffi.Dict passes Map schema (C++ allows cross-type via kOtherTypeIndex)."""
-        d = tvm_ffi.Dict({"a": 1})
-        A(tvm_ffi.Map[str, int]).check_value(d)
+        """ffi.Dict passes Map schema (C++ allows cross-type via kOtherTypeIndex)."""
+        d = ffi.Dict({"a": 1})
+        A(ffi.Map[str, int]).check_value(d)
 
     @requires_py39
     def test_ffi_map_accepted_by_dict_schema(self) -> None:
-        """tvm_ffi.Map passes Dict schema (C++ allows cross-type via kOtherTypeIndex)."""
-        m = tvm_ffi.Map({"a": 1})
+        """ffi.Map passes Dict schema (C++ allows cross-type via kOtherTypeIndex)."""
+        m = ffi.Map({"a": 1})
         A(dict[str, int]).check_value(m)
 
     @requires_py39
     def test_ffi_array_nested_optional_float(self) -> None:
-        """tvm_ffi.Array with nested Optional[float] conversion."""
-        arr = tvm_ffi.Array([1, None, True])
+        """ffi.Array with nested Optional[float] conversion."""
+        arr = ffi.Array([1, None, True])
         result = _to_py_class_value(A(tuple[Optional[float], ...]).convert(arr))
         assert list(result) == [1.0, None, 1.0]
         assert type(result[0]) is float
@@ -1488,36 +1480,36 @@ class TestFFIContainerInputs:
 
     @requires_py39
     def test_ffi_map_nested_array_int(self) -> None:
-        """tvm_ffi.Map with value being a Python list, converted as Array[int]."""
+        """ffi.Map with value being a Python list, converted as Array[int]."""
         # Map values are already stored; create a map with array values
-        m = tvm_ffi.Map({"k": tvm_ffi.Array([True, 2])})
-        result = _to_py_class_value(A(tvm_ffi.Map[str, tuple[int, ...]]).convert(m))
+        m = ffi.Map({"k": ffi.Array([True, 2])})
+        result = _to_py_class_value(A(ffi.Map[str, tuple[int, ...]]).convert(m))
         assert list(result["k"]) == [1, 2]
         assert type(result["k"][0]) is int
 
     @requires_py39
     def test_ffi_array_wrong_element_type(self) -> None:
-        """tvm_ffi.Array with wrong element type gives clear error."""
-        arr = tvm_ffi.Array([1, "bad", 3])
+        """ffi.Array with wrong element type gives clear error."""
+        arr = ffi.Array([1, "bad", 3])
         with pytest.raises(TypeError, match=r"element \[1\].*expected int"):
             A(tuple[int, ...]).check_value(arr)
 
     @requires_py39
     def test_ffi_map_wrong_value_type(self) -> None:
-        """tvm_ffi.Map with wrong value type gives clear error."""
-        m = tvm_ffi.Map({"a": 1, "b": "bad"})
+        """ffi.Map with wrong value type gives clear error."""
+        m = ffi.Map({"a": 1, "b": "bad"})
         with pytest.raises(TypeError, match=r"value for key.*expected int"):
-            A(tvm_ffi.Map[str, int]).check_value(m)
+            A(ffi.Map[str, int]).check_value(m)
 
     def test_ffi_array_object_schema(self) -> None:
-        """tvm_ffi.Array passes Object schema (it is a CObject)."""
-        arr = tvm_ffi.Array([1, 2])
-        A(tvm_ffi.core.Object).check_value(arr)
+        """ffi.Array passes Object schema (it is a CObject)."""
+        arr = ffi.Array([1, 2])
+        A(ffi.core.Object).check_value(arr)
 
     def test_ffi_map_object_schema(self) -> None:
-        """tvm_ffi.Map passes Object schema (it is a CObject)."""
-        m = tvm_ffi.Map({"a": 1})
-        A(tvm_ffi.core.Object).check_value(m)
+        """ffi.Map passes Object schema (it is a CObject)."""
+        m = ffi.Map({"a": 1})
+        A(ffi.core.Object).check_value(m)
 
 
 # ---------------------------------------------------------------------------
@@ -1526,33 +1518,33 @@ class TestFFIContainerInputs:
 class TestMixedPythonFFIContainers:
     @requires_py39
     def test_python_list_of_ffi_arrays(self) -> None:
-        """Python list containing tvm_ffi.Array elements, Array[Array[int]]."""
-        inner1 = tvm_ffi.Array([True, 2])
-        inner2 = tvm_ffi.Array([3, False])
+        """Python list containing ffi.Array elements, Array[Array[int]]."""
+        inner1 = ffi.Array([True, 2])
+        inner2 = ffi.Array([3, False])
         result = _to_py_class_value(A(tuple[tuple[int, ...], ...]).convert([inner1, inner2]))
         assert [list(row) for row in result] == [[1, 2], [3, 0]]
 
     @requires_py39
     def test_python_dict_with_ffi_array_values(self) -> None:
-        """Python dict with tvm_ffi.Array values, Map[str, Array[float]]."""
-        val = tvm_ffi.Array([1, True])
-        result = _to_py_class_value(A(tvm_ffi.Map[str, tuple[float, ...]]).convert({"k": val}))
+        """Python dict with ffi.Array values, Map[str, Array[float]]."""
+        val = ffi.Array([1, True])
+        result = _to_py_class_value(A(ffi.Map[str, tuple[float, ...]]).convert({"k": val}))
         assert list(result["k"]) == [1.0, 1.0]
         assert all(type(x) is float for x in result["k"])
 
     @requires_py39
     def test_ffi_map_with_python_list_in_union(self) -> None:
-        """Union[Map[str, int], Array[int]] with tvm_ffi.Map input."""
-        schema = A(Union[tvm_ffi.Map[str, int], tuple[int, ...]])
-        m = tvm_ffi.Map({"a": True})
+        """Union[Map[str, int], Array[int]] with ffi.Map input."""
+        schema = A(Union[ffi.Map[str, int], tuple[int, ...]])
+        m = ffi.Map({"a": True})
         result = _to_py_class_value(schema.convert(m))
         assert result["a"] == 1
         assert type(result["a"]) is int
 
     @requires_py39
     def test_ffi_array_in_optional(self) -> None:
-        """Optional[Array[int]] with tvm_ffi.Array input."""
-        arr = tvm_ffi.Array([True, 2])
+        """Optional[Array[int]] with ffi.Array input."""
+        arr = ffi.Array([True, 2])
         result = _to_py_class_value(A(Optional[tuple[int, ...]]).convert(arr))
         assert list(result) == [1, 2]
         assert type(result[0]) is int
@@ -1575,7 +1567,7 @@ class TestNestedErrorPropagation:
             TypeError,
             match=r"value for key 'k'.*element \[2\].*expected int, got str",
         ):
-            A(tvm_ffi.Map[str, tuple[int, ...]]).convert({"k": [1, 2, "bad"]})
+            A(ffi.Map[str, tuple[int, ...]]).convert({"k": [1, 2, "bad"]})
 
     @requires_py39
     def test_array_map_int_inner_failure(self) -> None:
@@ -1584,7 +1576,7 @@ class TestNestedErrorPropagation:
             TypeError,
             match=r"element \[0\].*value for key 'x'.*expected int, got str",
         ):
-            A(tuple[tvm_ffi.Map[str, int], ...]).convert([{"x": "bad"}])
+            A(tuple[ffi.Map[str, int], ...]).convert([{"x": "bad"}])
 
     @requires_py39
     def test_optional_array_int_inner_failure(self) -> None:
@@ -1602,12 +1594,12 @@ class TestNestedErrorPropagation:
     def test_deep_3_level_error(self) -> None:
         """Error at 3 levels deep: Map -> Array -> Optional -> type mismatch."""
         with pytest.raises(TypeError, match=r"value for key 'key'.*element .1..*expected int"):
-            A(tvm_ffi.Map[str, tuple[Optional[int], ...]]).check_value({"key": [1, "bad"]})
+            A(ffi.Map[str, tuple[Optional[int], ...]]).check_value({"key": [1, "bad"]})
 
     @requires_py39
     def test_ffi_array_nested_error(self) -> None:
-        """Error from tvm_ffi.Array in nested context."""
-        arr = tvm_ffi.Array([1, "bad", 3])
+        """Error from ffi.Array in nested context."""
+        arr = ffi.Array([1, "bad", 3])
         with pytest.raises(TypeError, match=r"element \[1\].*expected int"):
             A(tuple[int, ...]).convert(arr)
 
@@ -1659,7 +1651,7 @@ class TestCustomObjectHierarchy:
     def test_derived_passes_object_schema(self) -> None:
         """TestObjectDerived passes TypeSchema('Object')."""
         obj = TestObjectDerived(v_map={"a": 1}, v_array=[1], v_i64=0, v_f64=0.0, v_str="")
-        A(tvm_ffi.core.Object).check_value(obj)
+        A(ffi.core.Object).check_value(obj)
 
     def test_cxx_derived_passes_base(self) -> None:
         """_TestCxxClassDerived passes TestCxxClassBase schema."""
@@ -1685,7 +1677,7 @@ class TestCustomObjectHierarchy:
             _TestCxxClassDerived(v_i64=1, v_i32=2, v_f64=3.0),
             _TestCxxClassDerivedDerived(v_i64=1, v_i32=2, v_f64=3.0, v_bool=True),
         ]
-        schema = A(tvm_ffi.core.Object)
+        schema = A(ffi.core.Object)
         for obj in objs:
             schema.check_value(obj)
 
@@ -1765,32 +1757,32 @@ class TestCustomObjectInContainers:
     def test_map_str_to_custom_object(self) -> None:
         """Map[str, testing.TestIntPair] pass."""
         objs = {"a": TestIntPair(1, 2), "b": TestIntPair(3, 4)}
-        A(tvm_ffi.Map[str, TestIntPair]).check_value(objs)
+        A(ffi.Map[str, TestIntPair]).check_value(objs)
 
     @requires_py39
     def test_map_str_to_custom_object_wrong_value(self) -> None:
         """Map[str, testing.TestIntPair] with int value fails."""
         data = {"a": TestIntPair(1, 2), "b": 42}
         with pytest.raises(TypeError, match="value for key 'b'"):
-            A(tvm_ffi.Map[str, TestIntPair]).check_value(data)
+            A(ffi.Map[str, TestIntPair]).check_value(data)
 
     @requires_py39
     def test_ffi_array_of_custom_objects(self) -> None:
-        """tvm_ffi.Array of custom objects passes Array[Object]."""
-        arr = tvm_ffi.Array([TestIntPair(1, 2), TestObjectBase(v_i64=1, v_f64=2.0, v_str="s")])
-        A(tuple[tvm_ffi.core.Object, ...]).check_value(arr)
+        """ffi.Array of custom objects passes Array[Object]."""
+        arr = ffi.Array([TestIntPair(1, 2), TestObjectBase(v_i64=1, v_f64=2.0, v_str="s")])
+        A(tuple[ffi.core.Object, ...]).check_value(arr)
 
     @requires_py39
     def test_ffi_array_of_custom_objects_specific_type(self) -> None:
-        """tvm_ffi.Array of TestIntPair passes Array[testing.TestIntPair]."""
-        arr = tvm_ffi.Array([TestIntPair(1, 2), TestIntPair(3, 4)])
+        """ffi.Array of TestIntPair passes Array[testing.TestIntPair]."""
+        arr = ffi.Array([TestIntPair(1, 2), TestIntPair(3, 4)])
         A(tuple[TestIntPair, ...]).check_value(arr)
 
     @requires_py39
     def test_ffi_map_with_custom_object_values(self) -> None:
-        """tvm_ffi.Map with custom object values passes."""
-        m = tvm_ffi.Map({"x": TestIntPair(1, 2), "y": TestIntPair(3, 4)})
-        A(tvm_ffi.Map[str, TestIntPair]).check_value(m)
+        """ffi.Map with custom object values passes."""
+        m = ffi.Map({"x": TestIntPair(1, 2), "y": TestIntPair(3, 4)})
+        A(ffi.Map[str, TestIntPair]).check_value(m)
 
 
 # ---------------------------------------------------------------------------
@@ -1848,7 +1840,7 @@ class TestCustomObjectFromTypeIndex:
     def test_from_type_index_custom_object(self) -> None:
         """from_type_index resolves a custom object type and validates."""
         obj = TestIntPair(1, 2)
-        tindex = tvm_ffi.core._object_type_key_to_index("testing.TestIntPair")
+        tindex = ffi.core._object_type_key_to_index("testing.TestIntPair")
         assert tindex is not None
         schema = TypeSchema.from_type_index(tindex)
         assert schema.origin == "testing.TestIntPair"
@@ -1856,7 +1848,7 @@ class TestCustomObjectFromTypeIndex:
 
     def test_from_type_index_rejects_wrong_object(self) -> None:
         """from_type_index schema rejects wrong object type."""
-        tindex = tvm_ffi.core._object_type_key_to_index("testing.TestIntPair")
+        tindex = ffi.core._object_type_key_to_index("testing.TestIntPair")
         assert tindex is not None
         schema = TypeSchema.from_type_index(tindex)
         with pytest.raises(TypeError):
@@ -1864,7 +1856,7 @@ class TestCustomObjectFromTypeIndex:
 
     def test_from_type_index_hierarchy(self) -> None:
         """from_type_index for base type accepts derived objects."""
-        tindex = tvm_ffi.core._object_type_key_to_index("testing.TestObjectBase")
+        tindex = ffi.core._object_type_key_to_index("testing.TestObjectBase")
         assert tindex is not None
         schema = TypeSchema.from_type_index(tindex)
         derived = TestObjectDerived(v_map={"a": 1}, v_array=[1], v_i64=0, v_f64=0.0, v_str="")
@@ -1888,7 +1880,7 @@ class TestCustomObjectNestedContainers:
             "group1": [TestIntPair(1, 2), TestIntPair(3, 4)],
             "group2": [TestIntPair(5, 6)],
         }
-        A(tvm_ffi.Map[str, tuple[TestIntPair, ...]]).check_value(data)
+        A(ffi.Map[str, tuple[TestIntPair, ...]]).check_value(data)
 
     @requires_py39
     def test_array_of_union_custom_objects(self) -> None:
@@ -1923,7 +1915,7 @@ class TestCustomObjectNestedContainers:
         with pytest.raises(
             TypeError, match=r"value for key 'bad'.*expected testing\.TestIntPair.*got int"
         ):
-            A(tvm_ffi.Map[str, TestIntPair]).check_value(data)
+            A(ffi.Map[str, TestIntPair]).check_value(data)
 
     @requires_py39
     def test_deep_nested_custom_objects(self) -> None:
@@ -1932,14 +1924,14 @@ class TestCustomObjectNestedContainers:
             "a": [TestIntPair(1, 2), None],
             "b": [None, TestIntPair(3, 4), TestIntPair(5, 6)],
         }
-        A(tvm_ffi.Map[str, tuple[Optional[TestIntPair], ...]]).check_value(data)
+        A(ffi.Map[str, tuple[Optional[TestIntPair], ...]]).check_value(data)
 
     @requires_py39
     def test_deep_nested_custom_objects_error(self) -> None:
         """Map[str, Array[testing.TestIntPair]] error at 3 levels."""
         data = {"k": [TestIntPair(1, 2), "bad"]}
         with pytest.raises(TypeError, match=r"value for key 'k'.*element .1."):
-            A(tvm_ffi.Map[str, tuple[TestIntPair, ...]]).check_value(data)
+            A(ffi.Map[str, tuple[TestIntPair, ...]]).check_value(data)
 
     @requires_py39
     def test_tuple_with_custom_object(self) -> None:
@@ -1972,7 +1964,7 @@ class TestLowercaseOrigins:
         """TypeSchema("list", (float,)).convert([1, True]) does int->float."""
         # S: lowercase "list" is an internal origin
         result = _to_py_class_value(S("list", S("float")).convert([1, True]))
-        assert isinstance(result, tvm_ffi.List)
+        assert isinstance(result, ffi.List)
         assert list(result) == [1.0, 1.0]
         assert all(type(x) is float for x in result)
 
@@ -1993,7 +1985,7 @@ class TestLowercaseOrigins:
         """TypeSchema("dict", (str, float)).convert({"a": 1}) does int->float."""
         # S: lowercase "dict" is an internal origin
         result = _to_py_class_value(S("dict", S("str"), S("float")).convert({"a": 1, "b": True}))
-        assert isinstance(result, tvm_ffi.Dict)
+        assert isinstance(result, ffi.Dict)
         assert result["a"] == 1.0
         assert result["b"] == 1.0
         assert all(type(v) is float for v in result.values())
@@ -2023,56 +2015,56 @@ class TestLowercaseOrigins:
 class TestCrossTypeContainers:
     @requires_py39
     def test_array_schema_accepts_ffi_list(self) -> None:
-        """Array[int] schema accepts tvm_ffi.List (C++ kOtherTypeIndex)."""
-        lst = tvm_ffi.List([1, 2, 3])
+        """Array[int] schema accepts ffi.List (C++ kOtherTypeIndex)."""
+        lst = ffi.List([1, 2, 3])
         A(tuple[int, ...]).check_value(lst)
 
     @requires_py39
     def test_list_schema_accepts_ffi_array(self) -> None:
-        """List[int] schema accepts tvm_ffi.Array (C++ kOtherTypeIndex)."""
-        arr = tvm_ffi.Array([1, 2, 3])
+        """List[int] schema accepts ffi.Array (C++ kOtherTypeIndex)."""
+        arr = ffi.Array([1, 2, 3])
         A(list[int]).check_value(arr)
 
     @requires_py39
     def test_map_schema_accepts_ffi_dict(self) -> None:
-        """Map[str, int] schema accepts tvm_ffi.Dict (C++ kOtherTypeIndex)."""
-        d = tvm_ffi.Dict({"a": 1, "b": 2})
-        A(tvm_ffi.Map[str, int]).check_value(d)
+        """Map[str, int] schema accepts ffi.Dict (C++ kOtherTypeIndex)."""
+        d = ffi.Dict({"a": 1, "b": 2})
+        A(ffi.Map[str, int]).check_value(d)
 
     @requires_py39
     def test_dict_schema_accepts_ffi_map(self) -> None:
-        """Dict[str, int] schema accepts tvm_ffi.Map (C++ kOtherTypeIndex)."""
-        m = tvm_ffi.Map({"a": 1, "b": 2})
+        """Dict[str, int] schema accepts ffi.Map (C++ kOtherTypeIndex)."""
+        m = ffi.Map({"a": 1, "b": 2})
         A(dict[str, int]).check_value(m)
 
     @requires_py39
     def test_array_schema_converts_list_elements(self) -> None:
-        """Array[float] converts elements from tvm_ffi.List[int]."""
-        lst = tvm_ffi.List([1, 2, True])
+        """Array[float] converts elements from ffi.List[int]."""
+        lst = ffi.List([1, 2, True])
         result = _to_py_class_value(A(tuple[float, ...]).convert(lst))
         assert list(result) == [1.0, 2.0, 1.0]
         assert all(type(x) is float for x in result)
 
     @requires_py39
     def test_list_schema_converts_array_elements(self) -> None:
-        """List[float] converts elements from tvm_ffi.Array[int]."""
-        arr = tvm_ffi.Array([1, 2, True])
+        """List[float] converts elements from ffi.Array[int]."""
+        arr = ffi.Array([1, 2, True])
         result = _to_py_class_value(A(list[float]).convert(arr))
         assert list(result) == [1.0, 2.0, 1.0]
         assert all(type(x) is float for x in result)
 
     @requires_py39
     def test_map_schema_converts_dict_values(self) -> None:
-        """Map[str, float] converts values from tvm_ffi.Dict."""
-        d = tvm_ffi.Dict({"a": 1, "b": True})
-        result = _to_py_class_value(A(tvm_ffi.Map[str, float]).convert(d))
+        """Map[str, float] converts values from ffi.Dict."""
+        d = ffi.Dict({"a": 1, "b": True})
+        result = _to_py_class_value(A(ffi.Map[str, float]).convert(d))
         assert result["a"] == 1.0
         assert result["b"] == 1.0
 
     @requires_py39
     def test_dict_schema_converts_map_values(self) -> None:
-        """Dict[str, float] converts values from tvm_ffi.Map."""
-        m = tvm_ffi.Map({"a": 1, "b": True})
+        """Dict[str, float] converts values from ffi.Map."""
+        m = ffi.Map({"a": 1, "b": True})
         result = _to_py_class_value(A(dict[str, float]).convert(m))
         assert result["a"] == 1.0
         assert result["b"] == 1.0
@@ -2080,16 +2072,16 @@ class TestCrossTypeContainers:
     @requires_py39
     def test_cross_type_still_rejects_wrong_container(self) -> None:
         """Array schema still rejects non-sequence CObjects (e.g. Map)."""
-        m = tvm_ffi.Map({"a": 1})
+        m = ffi.Map({"a": 1})
         with pytest.raises(TypeError, match="expected Array"):
             A(tuple[int, ...]).check_value(m)
 
     @requires_py39
     def test_cross_type_map_rejects_array(self) -> None:
         """Map schema still rejects sequence CObjects (e.g. Array)."""
-        arr = tvm_ffi.Array([1, 2])
+        arr = ffi.Array([1, 2])
         with pytest.raises(TypeError, match="expected Map"):
-            A(tvm_ffi.Map[str, int]).check_value(arr)
+            A(ffi.Map[str, int]).check_value(arr)
 
 
 # ---------------------------------------------------------------------------
@@ -2118,29 +2110,29 @@ class TestTupleAcceptsListAndArray:
 
     @requires_py39
     def test_tuple_accepts_ffi_array(self) -> None:
-        """tuple[int, int] accepts tvm_ffi.Array (C++ Tuple accepts kTVMFFIArray)."""
-        arr = tvm_ffi.Array([1, 2])
+        """tuple[int, int] accepts ffi.Array (C++ Tuple accepts kTVMFFIArray)."""
+        arr = ffi.Array([1, 2])
         A(tuple[int, int]).check_value(arr)
 
     @requires_py39
     def test_tuple_ffi_array_with_conversion(self) -> None:
-        """tuple[float, float] converts tvm_ffi.Array elements."""
-        arr = tvm_ffi.Array([1, True])
+        """tuple[float, float] converts ffi.Array elements."""
+        arr = ffi.Array([1, True])
         result = _to_py_class_value(A(tuple[float, float]).convert(arr))
         assert list(result) == [1.0, 1.0]
         assert all(type(x) is float for x in result)
 
     @requires_py39
     def test_tuple_ffi_array_wrong_length(self) -> None:
-        """tuple[int, int] rejects tvm_ffi.Array of wrong length."""
-        arr = tvm_ffi.Array([1, 2, 3])
+        """tuple[int, int] rejects ffi.Array of wrong length."""
+        arr = ffi.Array([1, 2, 3])
         with pytest.raises(TypeError, match="length"):
             A(tuple[int, int]).check_value(arr)
 
     @requires_py39
     def test_tuple_rejects_ffi_map(self) -> None:
         """Tuple schema rejects Map CObject."""
-        m = tvm_ffi.Map({"a": 1})
+        m = ffi.Map({"a": 1})
         with pytest.raises(TypeError, match="expected tuple"):
             A(tuple[int]).check_value(m)
 
@@ -2151,8 +2143,8 @@ class TestTupleAcceptsListAndArray:
         A(tuple).check_value([1, "a", None])
 
     def test_untyped_tuple_accepts_ffi_array(self) -> None:
-        """Tuple (no args) accepts tvm_ffi.Array as-is."""
-        arr = tvm_ffi.Array([1, 2, 3])
+        """Tuple (no args) accepts ffi.Array as-is."""
+        arr = ffi.Array([1, 2, 3])
         A(tuple).check_value(arr)
 
     def test_typed_empty_tuple_rejects_non_empty_list(self) -> None:
@@ -2162,10 +2154,10 @@ class TestTupleAcceptsListAndArray:
             schema.check_value([1])
 
     def test_untyped_tuple_converts_ffi_list_to_array(self) -> None:
-        """Tuple (no args) normalizes tvm_ffi.List input to tvm_ffi.Array."""
-        lst = tvm_ffi.List([1, 2, 3])
+        """Tuple (no args) normalizes ffi.List input to ffi.Array."""
+        lst = ffi.List([1, 2, 3])
         result = _to_py_class_value(A(tuple).convert(lst))
-        assert isinstance(result, tvm_ffi.Array)
+        assert isinstance(result, ffi.Array)
         assert list(result) == [1, 2, 3]
         assert not result.same_as(lst)
 
@@ -2177,26 +2169,26 @@ class TestDtypeParseErrors:
     def test_check_value_bad_dtype_raises_error(self) -> None:
         """check_value should raise TypeError for invalid dtype."""
         with pytest.raises(TypeError, match="dtype"):
-            A(tvm_ffi.core.DataType).check_value("not_a_valid_dtype_xyz")
+            A(ffi.core.DataType).check_value("not_a_valid_dtype_xyz")
 
     def test_convert_bad_dtype_raises_type_error_2(self) -> None:
         """Convert should raise TypeError for invalid dtype string."""
         with pytest.raises(TypeError, match="dtype"):
-            A(tvm_ffi.core.DataType).convert("not_a_valid_dtype_xyz")
+            A(ffi.core.DataType).convert("not_a_valid_dtype_xyz")
 
     def test_convert_bad_dtype_raises_type_error(self) -> None:
         """Convert should raise TypeError for invalid dtype string."""
         with pytest.raises(TypeError, match="dtype"):
-            A(tvm_ffi.core.DataType).convert("not_a_valid_dtype_xyz")
+            A(ffi.core.DataType).convert("not_a_valid_dtype_xyz")
 
     def test_valid_dtype_string_still_works(self) -> None:
         """Valid dtype strings should still convert successfully."""
-        result = _to_py_class_value(A(tvm_ffi.core.DataType).convert("float32"))
+        result = _to_py_class_value(A(ffi.core.DataType).convert("float32"))
         assert str(result) == "float32"
 
     def test_convert_valid_dtype(self) -> None:
         """Convert with valid dtype returns DataType."""
-        result = _to_py_class_value(A(tvm_ffi.core.DataType).convert("int8"))
+        result = _to_py_class_value(A(ffi.core.DataType).convert("int8"))
         assert str(result) == "int8"
 
 
@@ -2431,14 +2423,14 @@ class TestFromTypeIndexEdgeCases:
 
     def test_valid_object_index_works(self) -> None:
         """Valid registered object type_index constructs fine."""
-        tindex = tvm_ffi.core._object_type_key_to_index("testing.TestIntPair")
+        tindex = ffi.core._object_type_key_to_index("testing.TestIntPair")
         assert tindex is not None
         schema = TypeSchema.from_type_index(tindex)
         assert schema.origin == "testing.TestIntPair"
 
     def test_from_type_index_with_args(self) -> None:
         """from_type_index with type arguments creates parameterized schema."""
-        arr_schema = A(tvm_ffi.Array)
+        arr_schema = A(ffi.Array)
         schema = TypeSchema.from_type_index(arr_schema.origin_type_index, (A(int),))
         assert schema.origin == "Array"
         schema.check_value([1, 2, 3])
@@ -2570,7 +2562,7 @@ class TestDeviceProtocol:
             def __dlpack_device__(self) -> tuple[int, int]:
                 return (1, 0)
 
-        A(tvm_ffi.Device).check_value(DevProto())
+        A(ffi.Device).check_value(DevProto())
 
     def test_dlpack_device_protocol_convert(self) -> None:
         """Convert returns protocol value as-is."""
@@ -2580,7 +2572,7 @@ class TestDeviceProtocol:
                 return (2, 1)
 
         obj = DevProto()
-        result = _to_py_class_value(A(tvm_ffi.Device).convert(obj))
+        result = _to_py_class_value(A(ffi.Device).convert(obj))
         assert result is not None
 
     def test_without_protocol_still_rejected(self) -> None:
@@ -2590,7 +2582,7 @@ class TestDeviceProtocol:
             pass
 
         with pytest.raises(TypeError, match="expected Device"):
-            A(tvm_ffi.Device).check_value(NoProto())
+            A(ffi.Device).check_value(NoProto())
 
 
 # ---------------------------------------------------------------------------
@@ -2606,7 +2598,7 @@ class TestDtypeProtocols:
             def __dlpack_data_type__(self) -> tuple[int, int, int]:
                 return (2, 32, 1)  # float32
 
-        A(tvm_ffi.core.DataType).check_value(DTypeProto())
+        A(ffi.core.DataType).check_value(DTypeProto())
 
     def test_dlpack_data_type_protocol_convert(self) -> None:
         """Convert returns protocol value as-is."""
@@ -2616,31 +2608,31 @@ class TestDtypeProtocols:
                 return (0, 32, 1)
 
         obj = DTypeProto()
-        result = _to_py_class_value(A(tvm_ffi.core.DataType).convert(obj))
+        result = _to_py_class_value(A(ffi.core.DataType).convert(obj))
         assert result is not None
 
     def test_numpy_dtype_accepted(self) -> None:
         """numpy.dtype passes dtype schema (if numpy installed)."""
         numpy = pytest.importorskip("numpy")
-        A(tvm_ffi.core.DataType).check_value(numpy.dtype("float32"))
+        A(ffi.core.DataType).check_value(numpy.dtype("float32"))
 
     def test_numpy_dtype_convert(self) -> None:
         """Convert returns numpy.dtype as-is."""
         numpy = pytest.importorskip("numpy")
         dt = numpy.dtype("int32")
-        result = _to_py_class_value(A(tvm_ffi.core.DataType).convert(dt))
+        result = _to_py_class_value(A(ffi.core.DataType).convert(dt))
         assert result is not None
 
     def test_torch_dtype_accepted(self) -> None:
         """torch.dtype passes dtype schema (if torch installed)."""
         torch = pytest.importorskip("torch")
-        A(tvm_ffi.core.DataType).check_value(torch.float32)
+        A(ffi.core.DataType).check_value(torch.float32)
 
     def test_torch_dtype_convert(self) -> None:
         """Convert returns torch.dtype as-is."""
         torch = pytest.importorskip("torch")
         dt = torch.int64
-        result = _to_py_class_value(A(tvm_ffi.core.DataType).convert(dt))
+        result = _to_py_class_value(A(ffi.core.DataType).convert(dt))
         assert result is not None
 
 
@@ -2653,22 +2645,22 @@ class TestTensorProtocol:
     def test_dlpack_c_exchange_api_accepted(self) -> None:
         """Object with a valid __dlpack_c_exchange_api__ passes Tensor schema."""
         np = pytest.importorskip("numpy")
-        tensor = tvm_ffi.from_dlpack(np.arange(4, dtype="int32"))
-        wrapper = tvm_ffi.core.DLTensorTestWrapper(tensor)
-        A(tvm_ffi.Tensor).check_value(wrapper)
+        tensor = ffi.from_dlpack(np.arange(4, dtype="int32"))
+        wrapper = ffi.core.DLTensorTestWrapper(tensor)
+        A(ffi.Tensor).check_value(wrapper)
 
     def test_dlpack_c_exchange_api_convert(self) -> None:
         """Valid exchange-api wrappers can be converted to Tensor."""
         np = pytest.importorskip("numpy")
-        tensor = tvm_ffi.from_dlpack(np.arange(4, dtype="int32"))
-        wrapper = tvm_ffi.core.DLTensorTestWrapper(tensor)
-        result = _to_py_class_value(A(tvm_ffi.Tensor).convert(wrapper))
-        assert isinstance(result, tvm_ffi.Tensor)
+        tensor = ffi.from_dlpack(np.arange(4, dtype="int32"))
+        wrapper = ffi.core.DLTensorTestWrapper(tensor)
+        result = _to_py_class_value(A(ffi.Tensor).convert(wrapper))
+        assert isinstance(result, ffi.Tensor)
 
     def test_dlpack_still_accepted(self) -> None:
         """Object with __dlpack__ still accepted (existing behavior)."""
         np = pytest.importorskip("numpy")
-        A(tvm_ffi.Tensor).check_value(np.arange(4, dtype="int32"))
+        A(ffi.Tensor).check_value(np.arange(4, dtype="int32"))
 
 
 # ---------------------------------------------------------------------------
@@ -2685,7 +2677,7 @@ class TestObjectProtocol:
             def __tvm_ffi_object__(self) -> object:
                 return inner
 
-        A(tvm_ffi.core.Object).check_value(ObjProto())
+        A(ffi.core.Object).check_value(ObjProto())
 
     def test_object_protocol_specific_type(self) -> None:
         """__tvm_ffi_object__ returning TestIntPair passes TestIntPair schema."""
@@ -2729,7 +2721,7 @@ class TestObjectProtocol:
                 raise RuntimeError("broken")
 
         with pytest.raises(TypeError, match=r"__tvm_ffi_object__\(\) failed"):
-            A(tvm_ffi.core.Object).check_value(BadProto())
+            A(ffi.core.Object).check_value(BadProto())
 
     def test_object_protocol_hierarchy(self) -> None:
         """__tvm_ffi_object__ returning derived passes base schema."""
@@ -2753,17 +2745,17 @@ class TestObjectConvertibleProtocol:
         inner = TestIntPair(10, 20)
 
         class MyConvertible(ObjectConvertible):
-            def asobject(self) -> tvm_ffi.core.Object:
+            def asobject(self) -> ffi.core.Object:
                 return inner
 
-        A(tvm_ffi.core.Object).check_value(MyConvertible())
+        A(ffi.core.Object).check_value(MyConvertible())
 
     def test_object_convertible_specific_type(self) -> None:
         """ObjectConvertible passes specific type schema."""
         inner = TestIntPair(1, 2)
 
         class MyConvertible(ObjectConvertible):
-            def asobject(self) -> tvm_ffi.core.Object:
+            def asobject(self) -> ffi.core.Object:
                 return inner
 
         A(TestIntPair).check_value(MyConvertible())
@@ -2773,7 +2765,7 @@ class TestObjectConvertibleProtocol:
         inner = TestIntPair(7, 8)
 
         class MyConvertible(ObjectConvertible):
-            def asobject(self) -> tvm_ffi.core.Object:
+            def asobject(self) -> ffi.core.Object:
                 return inner
 
         result = _to_py_class_value(A(TestIntPair).convert(MyConvertible()))
@@ -2784,7 +2776,7 @@ class TestObjectConvertibleProtocol:
         inner = TestIntPair(9, 10)
 
         class MyConvertible(ObjectConvertible):
-            def asobject(self) -> tvm_ffi.core.Object:
+            def asobject(self) -> ffi.core.Object:
                 return inner
 
         result = _to_py_class_value(A(Union[TestIntPair, int]).convert(MyConvertible()))
@@ -2795,7 +2787,7 @@ class TestObjectConvertibleProtocol:
         inner = TestIntPair(1, 2)
 
         class MyConvertible(ObjectConvertible):
-            def asobject(self) -> tvm_ffi.core.Object:
+            def asobject(self) -> ffi.core.Object:
                 return inner
 
         with pytest.raises(
@@ -2808,11 +2800,11 @@ class TestObjectConvertibleProtocol:
         """asobject() that raises produces error, not exception."""
 
         class BadConvertible(ObjectConvertible):
-            def asobject(self) -> tvm_ffi.core.Object:
+            def asobject(self) -> ffi.core.Object:
                 raise RuntimeError("broken asobject")
 
         with pytest.raises(TypeError, match=r"asobject\(\) failed"):
-            A(tvm_ffi.core.Object).check_value(BadConvertible())
+            A(ffi.core.Object).check_value(BadConvertible())
 
 
 # ---------------------------------------------------------------------------
@@ -2973,10 +2965,10 @@ class TestProtocolsInContainers:
         inner = TestIntPair(3, 4)
 
         class Convertible(ObjectConvertible):
-            def asobject(self) -> tvm_ffi.core.Object:
+            def asobject(self) -> ffi.core.Object:
                 return inner
 
-        result = _to_py_class_value(A(tuple[tvm_ffi.core.Object, ...]).convert([Convertible()]))
+        result = _to_py_class_value(A(tuple[ffi.core.Object, ...]).convert([Convertible()]))
         assert result[0].same_as(inner)
 
     @requires_py39
@@ -2987,7 +2979,7 @@ class TestProtocolsInContainers:
             def __dlpack_device__(self) -> tuple[int, int]:
                 return (1, 0)
 
-        A(tvm_ffi.Map[str, tvm_ffi.Device]).check_value({"gpu": DevProto()})
+        A(ffi.Map[str, ffi.Device]).check_value({"gpu": DevProto()})
 
 
 # ---------------------------------------------------------------------------
@@ -3014,7 +3006,7 @@ class TestNestedValueProtocol:
             def __tvm_ffi_value__(self) -> object:
                 return 99
 
-        A(tvm_ffi.Map[str, int]).check_value({"a": VP()})
+        A(ffi.Map[str, int]).check_value({"a": VP()})
 
     @requires_py39
     def test_value_in_map_keys(self) -> None:
@@ -3024,7 +3016,7 @@ class TestNestedValueProtocol:
             def __tvm_ffi_value__(self) -> object:
                 return "key"
 
-        A(tvm_ffi.Map[str, int]).check_value({VP(): 1})
+        A(ffi.Map[str, int]).check_value({VP(): 1})
 
     @requires_py39
     def test_value_in_tuple_positions(self) -> None:
@@ -3219,43 +3211,43 @@ class TestObjectMarshalFallback:
 
     def test_exception_accepted_by_object_schema(self) -> None:
         """TypeSchema('Object') accepts Exception (-> ffi.Error)."""
-        A(tvm_ffi.core.Object).check_value(RuntimeError("test"))
+        A(ffi.core.Object).check_value(RuntimeError("test"))
 
     def test_exception_accepted_by_error_schema(self) -> None:
         """TypeSchema('ffi.Error') accepts Exception."""
-        A(tvm_ffi.core.Error).check_value(ValueError("oops"))
+        A(ffi.core.Error).check_value(ValueError("oops"))
 
     def test_shape_accepted_from_python_list_via_convert(self) -> None:
         """TypeSchema('ffi.Shape') converts Python lists via __ffi_convert__."""
         result = _to_py_class_value(S("ffi.Shape").convert([1, 2, 3]))
-        assert isinstance(result, tvm_ffi.Shape)
+        assert isinstance(result, ffi.Shape)
         assert tuple(result) == (1, 2, 3)
 
     def test_shape_accepted_from_ffi_list_via_convert(self) -> None:
         """TypeSchema('ffi.Shape') converts ffi.List via __ffi_convert__."""
-        result = _to_py_class_value(S("ffi.Shape").convert(tvm_ffi.List([1, 2, 3])))
-        assert isinstance(result, tvm_ffi.Shape)
+        result = _to_py_class_value(S("ffi.Shape").convert(ffi.List([1, 2, 3])))
+        assert isinstance(result, ffi.Shape)
         assert tuple(result) == (1, 2, 3)
 
     def test_shape_accepted_from_ffi_array_via_convert(self) -> None:
         """TypeSchema('ffi.Shape') converts ffi.Array via __ffi_convert__."""
-        result = _to_py_class_value(S("ffi.Shape").convert(tvm_ffi.Array([1, 2, 3])))
-        assert isinstance(result, tvm_ffi.Shape)
+        result = _to_py_class_value(S("ffi.Shape").convert(ffi.Array([1, 2, 3])))
+        assert isinstance(result, ffi.Shape)
         assert tuple(result) == (1, 2, 3)
 
     def test_shape_convert_repeated_conversions(self) -> None:
         """Repeated __ffi_convert__ conversions keep returning live owning objects."""
         result1 = _to_py_class_value(S("ffi.Shape").convert([1, 2, 3]))
-        result2 = _to_py_class_value(S("ffi.Shape").convert(tvm_ffi.List([1, 2, 3])))
-        assert isinstance(result1, tvm_ffi.Shape)
-        assert isinstance(result2, tvm_ffi.Shape)
+        result2 = _to_py_class_value(S("ffi.Shape").convert(ffi.List([1, 2, 3])))
+        assert isinstance(result1, ffi.Shape)
+        assert isinstance(result2, ffi.Shape)
         assert tuple(result1) == (1, 2, 3)
         assert tuple(result2) == (1, 2, 3)
 
     def test_exception_rejected_by_array_schema(self) -> None:
         """Exception is NOT accepted by Array schema (Error !IS-A Array)."""
         with pytest.raises(TypeError, match="expected Array"):
-            A(tvm_ffi.Array).check_value(RuntimeError("x"))
+            A(ffi.Array).check_value(RuntimeError("x"))
 
     def test_opaque_object_accepted_by_object_schema(self) -> None:
         """TypeSchema('Object') accepts arbitrary Python objects (-> OpaquePyObject)."""
@@ -3263,11 +3255,11 @@ class TestObjectMarshalFallback:
         class Custom:
             pass
 
-        A(tvm_ffi.core.Object).check_value(Custom())
+        A(ffi.core.Object).check_value(Custom())
 
     def test_plain_object_accepted_by_object_schema(self) -> None:
         """TypeSchema('Object') accepts object()."""
-        A(tvm_ffi.core.Object).check_value(object())
+        A(ffi.core.Object).check_value(object())
 
     def test_opaque_rejected_by_specific_schema(self) -> None:
         """Specific schema rejects arbitrary Python object."""
@@ -3281,39 +3273,39 @@ class TestObjectMarshalFallback:
     @pytest.mark.xfail(reason="SmallStr -> ObjectRef conversion is not supported yet")
     def test_str_accepted_by_object_schema(self) -> None:
         """TypeSchema('Object') accepts str (-> ffi.String IS-A Object)."""
-        A(tvm_ffi.core.Object).check_value("hello")
+        A(ffi.core.Object).check_value("hello")
 
     @pytest.mark.xfail(reason="SmallBytes -> ObjectRef conversion is not supported yet")
     def test_bytes_accepted_by_object_schema(self) -> None:
         """TypeSchema('Object') accepts bytes (-> ffi.Bytes IS-A Object)."""
-        A(tvm_ffi.core.Object).check_value(b"hello")
+        A(ffi.core.Object).check_value(b"hello")
 
     def test_list_accepted_by_object_schema(self) -> None:
         """TypeSchema('Object') accepts list (-> ffi.Array IS-A Object)."""
-        A(tvm_ffi.core.Object).check_value([1, 2, 3])
+        A(ffi.core.Object).check_value([1, 2, 3])
 
     def test_dict_accepted_by_object_schema(self) -> None:
         """TypeSchema('Object') accepts dict (-> ffi.Map IS-A Object)."""
-        A(tvm_ffi.core.Object).check_value({"a": 1})
+        A(ffi.core.Object).check_value({"a": 1})
 
     def test_callable_accepted_by_object_schema(self) -> None:
         """TypeSchema('Object') accepts callable (-> ffi.Function IS-A Object)."""
-        A(tvm_ffi.core.Object).check_value(lambda: None)
+        A(ffi.core.Object).check_value(lambda: None)
 
     def test_int_rejected_by_object_schema(self) -> None:
         """TypeSchema('Object') rejects int (int is a POD type, not Object)."""
         with pytest.raises(TypeError):
-            A(tvm_ffi.core.Object).check_value(42)
+            A(ffi.core.Object).check_value(42)
 
     def test_float_rejected_by_object_schema(self) -> None:
         """TypeSchema('Object') rejects float (float is a POD, not Object)."""
         with pytest.raises(TypeError):
-            A(tvm_ffi.core.Object).check_value(3.14)
+            A(ffi.core.Object).check_value(3.14)
 
     def test_none_rejected_by_object_schema(self) -> None:
         """TypeSchema('Object') rejects None (None is a POD, not Object)."""
         with pytest.raises(TypeError):
-            A(tvm_ffi.core.Object).check_value(None)
+            A(ffi.core.Object).check_value(None)
 
 
 # ---------------------------------------------------------------------------
@@ -3372,7 +3364,7 @@ class TestDeviceDlpackGuard:
                 return (1, 0)
 
         with pytest.raises(TypeError):
-            A(tvm_ffi.Device).check_value(TensorLike())
+            A(ffi.Device).check_value(TensorLike())
 
     def test_both_dlpack_and_device_accepted_by_tensor(self) -> None:
         """Object with both __dlpack__ and __dlpack_device__ accepted by Tensor."""
@@ -3388,7 +3380,7 @@ class TestDeviceDlpackGuard:
             def __dlpack_device__(self) -> tuple[int, int]:
                 return self.array.__dlpack_device__()
 
-        A(tvm_ffi.Tensor).check_value(TensorLike())
+        A(ffi.Tensor).check_value(TensorLike())
 
     def test_device_only_accepted_by_device(self) -> None:
         """Object with only __dlpack_device__ still accepted by Device."""
@@ -3397,7 +3389,7 @@ class TestDeviceDlpackGuard:
             def __dlpack_device__(self) -> tuple[int, int]:
                 return (1, 0)
 
-        A(tvm_ffi.Device).check_value(DevOnly())
+        A(ffi.Device).check_value(DevOnly())
 
     def test_dlpack_only_rejected_by_device(self) -> None:
         """Object with only __dlpack__ rejected by Device schema."""
@@ -3407,7 +3399,7 @@ class TestDeviceDlpackGuard:
                 return None
 
         with pytest.raises(TypeError):
-            A(tvm_ffi.Device).check_value(DLPackOnly())
+            A(ffi.Device).check_value(DLPackOnly())
 
 
 # ---------------------------------------------------------------------------
@@ -3420,9 +3412,9 @@ class TestSkipDlpackEnvGate:
         """__dlpack_c_exchange_api__ accepted when env not set."""
         os.environ.pop("TVM_FFI_SKIP_DLPACK_C_EXCHANGE_API", None)
         np = pytest.importorskip("numpy")
-        tensor = tvm_ffi.from_dlpack(np.arange(4, dtype="int32"))
-        wrapper = tvm_ffi.core.DLTensorTestWrapper(tensor)
-        A(tvm_ffi.Tensor).check_value(wrapper)
+        tensor = ffi.from_dlpack(np.arange(4, dtype="int32"))
+        wrapper = ffi.core.DLTensorTestWrapper(tensor)
+        A(ffi.Tensor).check_value(wrapper)
 
     def test_exchange_api_rejected_when_skipped(self) -> None:
         """__dlpack_c_exchange_api__ rejected when env=1."""
@@ -3434,7 +3426,7 @@ class TestSkipDlpackEnvGate:
                     return 0
 
             with pytest.raises(TypeError):
-                A(tvm_ffi.Tensor).check_value(ExchangeAPI())
+                A(ffi.Tensor).check_value(ExchangeAPI())
         finally:
             del os.environ["TVM_FFI_SKIP_DLPACK_C_EXCHANGE_API"]
 
@@ -3565,14 +3557,14 @@ class TestZeroCopyConversion:
     def test_map_str_int_exact_dict(self) -> None:
         """Map[str, int] on exact dict converts successfully."""
         original = {"a": 1, "b": 2}
-        result = _to_py_class_value(A(tvm_ffi.Map[str, int]).convert(original))
+        result = _to_py_class_value(A(ffi.Map[str, int]).convert(original))
         assert dict(result) == original
 
     @requires_py39
     def test_map_str_int_needs_conversion(self) -> None:
         """Map[str, int] on dict needing conversion returns converted dict."""
         original = {"a": True, "b": 2}
-        result = _to_py_class_value(A(tvm_ffi.Map[str, int]).convert(original))
+        result = _to_py_class_value(A(ffi.Map[str, int]).convert(original))
         assert result is not None
 
     @requires_py39
@@ -3684,7 +3676,7 @@ class TestValueProtocolPrecedence:
 
         with pytest.raises(TypeError):
             A(int).check_value(Dual())
-        A(tvm_ffi.core.Object).check_value(Dual())
+        A(ffi.core.Object).check_value(Dual())
 
     def test_value_protocol_runs_before_float_protocol(self) -> None:
         """__tvm_ffi_value__ is applied before __tvm_ffi_float__."""
@@ -3698,7 +3690,7 @@ class TestValueProtocolPrecedence:
 
         with pytest.raises(TypeError):
             A(float).check_value(Dual())
-        A(tvm_ffi.core.Object).check_value(Dual())
+        A(ffi.core.Object).check_value(Dual())
 
     def test_pure_value_protocol_still_works(self) -> None:
         """Class with ONLY __tvm_ffi_value__ still converts eagerly."""
@@ -3734,10 +3726,10 @@ class TestValueProtocolPrecedence:
             def __tvm_ffi_value__(self) -> object:
                 return 999
 
-            def asobject(self) -> tvm_ffi.core.Object:
+            def asobject(self) -> ffi.core.Object:
                 return TestIntPair(99, 99)
 
-        result = _to_py_class_value(A(tvm_ffi.core.Object).convert(Both()))
+        result = _to_py_class_value(A(ffi.core.Object).convert(Both()))
         assert result.same_as(inner)
 
 
@@ -3866,7 +3858,7 @@ class TestObjectConvertiblePrecedence:
         pair = TestIntPair(10, 20)
 
         class DualProtocol(ObjectConvertible):
-            def asobject(self) -> tvm_ffi.core.Object:
+            def asobject(self) -> ffi.core.Object:
                 return pair
 
             def __tvm_ffi_value__(self) -> object:
@@ -3877,17 +3869,17 @@ class TestObjectConvertiblePrecedence:
         # Object schema: __tvm_ffi_value__ returns 42 (POD int, not Object),
         # should REJECT (not accept via ObjectConvertible)
         with pytest.raises(TypeError):
-            A(tvm_ffi.core.Object).check_value(DualProtocol())
+            A(ffi.core.Object).check_value(DualProtocol())
 
     def test_pure_convertible_still_works(self) -> None:
         """ObjectConvertible without __tvm_ffi_value__ still accepted."""
         pair = TestIntPair(1, 2)
 
         class PureConvertible(ObjectConvertible):
-            def asobject(self) -> tvm_ffi.core.Object:
+            def asobject(self) -> ffi.core.Object:
                 return pair
 
-        A(tvm_ffi.core.Object).check_value(PureConvertible())
+        A(ffi.core.Object).check_value(PureConvertible())
         A(TestIntPair).check_value(PureConvertible())
 
 
@@ -3983,27 +3975,27 @@ class TestCAny:
     def test_to_py_array(self) -> None:
         """to_py() returns ffi.Array for Array convert."""
         result = _to_py_class_value(A(tuple[int, ...]).convert([1, 2, 3]))
-        assert isinstance(result, tvm_ffi.Array)
+        assert isinstance(result, ffi.Array)
         assert list(result) == [1, 2, 3]
 
     @requires_py39
     def test_to_py_list(self) -> None:
         """to_py() returns ffi.List for List convert."""
         result = _to_py_class_value(A(list[int]).convert([1, 2, 3]))
-        assert isinstance(result, tvm_ffi.List)
+        assert isinstance(result, ffi.List)
         assert list(result) == [1, 2, 3]
 
     @requires_py39
     def test_to_py_map(self) -> None:
         """to_py() returns ffi.Map for Map convert."""
-        result = _to_py_class_value(A(tvm_ffi.Map[str, int]).convert({"a": 1}))
-        assert isinstance(result, tvm_ffi.Map)
+        result = _to_py_class_value(A(ffi.Map[str, int]).convert({"a": 1}))
+        assert isinstance(result, ffi.Map)
 
     @requires_py39
     def test_to_py_dict(self) -> None:
         """to_py() returns ffi.Dict for Dict convert."""
         result = _to_py_class_value(A(dict[str, int]).convert({"a": 1}))
-        assert isinstance(result, tvm_ffi.Dict)
+        assert isinstance(result, ffi.Dict)
 
     def test_multiple_to_py_calls(self) -> None:
         """to_py() can be called multiple times safely."""
@@ -4094,52 +4086,52 @@ class TestFromAnnotationScalars:
         assert A(typing.Any) == S("Any")
 
     def test_tvm_ffi_string(self) -> None:
-        """tvm_ffi.String maps to str schema."""
-        assert A(tvm_ffi.core.String) == S("str")
+        """ffi.String maps to str schema."""
+        assert A(ffi.core.String) == S("str")
 
     def test_tvm_ffi_bytes(self) -> None:
-        """tvm_ffi.Bytes maps to bytes schema."""
-        assert A(tvm_ffi.core.Bytes) == S("bytes")
+        """ffi.Bytes maps to bytes schema."""
+        assert A(ffi.core.Bytes) == S("bytes")
 
 
 class TestFromAnnotationFFITypes:
     """FFI container and object types."""
 
     def test_array(self) -> None:
-        """tvm_ffi.Array → canonical origin 'Array'."""
-        assert A(tvm_ffi.Array) == S("Array")
+        """ffi.Array → canonical origin 'Array'."""
+        assert A(ffi.Array) == S("Array")
 
     def test_list(self) -> None:
-        """tvm_ffi.List → same as A(list)."""
-        assert A(tvm_ffi.List) == A(list)
+        """ffi.List → same as A(list)."""
+        assert A(ffi.List) == A(list)
 
     def test_map(self) -> None:
-        """tvm_ffi.Map → canonical origin 'Map'."""
-        assert A(tvm_ffi.Map) == S("Map")
+        """ffi.Map → canonical origin 'Map'."""
+        assert A(ffi.Map) == S("Map")
 
     def test_dict(self) -> None:
-        """tvm_ffi.Dict → same as A(dict)."""
-        assert A(tvm_ffi.Dict) == A(dict)
+        """ffi.Dict → same as A(dict)."""
+        assert A(ffi.Dict) == A(dict)
 
     def test_function(self) -> None:
-        """tvm_ffi.Function → same as A(Callable)."""
-        assert A(tvm_ffi.core.Function) == A(Callable)
+        """ffi.Function → same as A(Callable)."""
+        assert A(ffi.core.Function) == A(Callable)
 
     def test_object(self) -> None:
-        """tvm_ffi.Object → canonical origin 'Object'."""
-        assert A(tvm_ffi.core.Object) == S("Object")
+        """ffi.Object → canonical origin 'Object'."""
+        assert A(ffi.core.Object) == S("Object")
 
     def test_tensor(self) -> None:
-        """tvm_ffi.Tensor → canonical origin 'Tensor'."""
-        assert A(tvm_ffi.Tensor) == S("Tensor")
+        """ffi.Tensor → canonical origin 'Tensor'."""
+        assert A(ffi.Tensor) == S("Tensor")
 
     def test_dtype(self) -> None:
-        """tvm_ffi.core.DataType → canonical origin 'dtype'."""
-        assert A(tvm_ffi.core.DataType) == S("dtype")
+        """ffi.core.DataType → canonical origin 'dtype'."""
+        assert A(ffi.core.DataType) == S("dtype")
 
     def test_device(self) -> None:
-        """tvm_ffi.Device → canonical origin 'Device'."""
-        assert A(tvm_ffi.Device) == S("Device")
+        """ffi.Device → canonical origin 'Device'."""
+        assert A(ffi.Device) == S("Device")
 
     def test_ctypes_c_void_p(self) -> None:
         """ctypes.c_void_p → canonical origin 'ctypes.c_void_p'."""
@@ -4147,58 +4139,58 @@ class TestFromAnnotationFFITypes:
 
     @requires_py39
     def test_array_parameterized(self) -> None:
-        """tvm_ffi.Array[int] cross-equivalent to tuple[int, ...]."""
-        assert A(tvm_ffi.Array[int]) == A(tuple[int, ...])
+        """ffi.Array[int] cross-equivalent to tuple[int, ...]."""
+        assert A(ffi.Array[int]) == A(tuple[int, ...])
 
     @requires_py39
     def test_list_parameterized(self) -> None:
-        """tvm_ffi.List[str] cross-equivalent to list[str]."""
-        assert A(tvm_ffi.List[str]) == A(list[str])
+        """ffi.List[str] cross-equivalent to list[str]."""
+        assert A(ffi.List[str]) == A(list[str])
 
     @requires_py39
     def test_map_parameterized(self) -> None:
-        """tvm_ffi.Map[str, float]."""
-        assert A(tvm_ffi.Map[str, float]) == S("Map", S("str"), S("float"))
+        """ffi.Map[str, float]."""
+        assert A(ffi.Map[str, float]) == S("Map", S("str"), S("float"))
 
     @requires_py39
     def test_dict_parameterized(self) -> None:
-        """tvm_ffi.Dict[str, int] cross-equivalent to dict[str, int]."""
-        assert A(tvm_ffi.Dict[str, int]) == A(dict[str, int])
+        """ffi.Dict[str, int] cross-equivalent to dict[str, int]."""
+        assert A(ffi.Dict[str, int]) == A(dict[str, int])
 
     @requires_py39
     def test_array_too_many_args(self) -> None:
-        """tvm_ffi.Array[int, str] raises TypeError."""
+        """ffi.Array[int, str] raises TypeError."""
         with pytest.raises(TypeError, match="requires 1"):
-            A(tvm_ffi.Array[int, str])  # type: ignore[type-arg]
+            A(ffi.Array[int, str])  # type: ignore[type-arg]
 
     @requires_py39
     def test_list_too_many_args(self) -> None:
-        """tvm_ffi.List[int, str] raises TypeError."""
+        """ffi.List[int, str] raises TypeError."""
         with pytest.raises(TypeError, match="requires 1"):
-            A(tvm_ffi.List[int, str])  # type: ignore[type-arg]
+            A(ffi.List[int, str])  # type: ignore[type-arg]
 
     @requires_py39
     def test_dict_one_arg(self) -> None:
-        """tvm_ffi.Dict[str] raises TypeError."""
+        """ffi.Dict[str] raises TypeError."""
         with pytest.raises(TypeError, match="requires 2"):
-            A(tvm_ffi.Dict[str])  # type: ignore[type-arg]
+            A(ffi.Dict[str])  # type: ignore[type-arg]
 
     @requires_py39
     def test_dict_three_args(self) -> None:
-        """tvm_ffi.Dict[str, int, float] raises TypeError."""
+        """ffi.Dict[str, int, float] raises TypeError."""
         with pytest.raises(TypeError, match="requires 2"):
-            A(tvm_ffi.Dict[str, int, float])  # type: ignore[type-arg]
+            A(ffi.Dict[str, int, float])  # type: ignore[type-arg]
 
     @requires_py39
     def test_map_one_arg(self) -> None:
-        """tvm_ffi.Map[str] raises TypeError."""
+        """ffi.Map[str] raises TypeError."""
         with pytest.raises(TypeError, match="requires 2"):
-            A(tvm_ffi.Map[str])  # type: ignore[type-arg]
+            A(ffi.Map[str])  # type: ignore[type-arg]
 
     def test_unregistered_cobject_errors(self) -> None:
         """Unregistered CObject subclass raises TypeError."""
         with pytest.raises(TypeError, match="not registered"):
-            A(tvm_ffi.core.CObject)
+            A(ffi.core.CObject)
 
 
 class TestFromAnnotationCallable:
@@ -4358,7 +4350,6 @@ class TestFromAnnotationErrors:
 # ---------------------------------------------------------------------------
 # Convert returns FFI containers
 # ---------------------------------------------------------------------------
-import tvm_ffi as _tvm_ffi
 
 
 class TestConvertReturnFFIContainers:
@@ -4368,39 +4359,39 @@ class TestConvertReturnFFIContainers:
     def test_array_from_list(self) -> None:
         """Array convert from Python list."""
         result = _to_py_class_value(A(tuple[float, ...]).convert([1, 2, 3]))
-        assert isinstance(result, _tvm_ffi.Array)
+        assert isinstance(result, ffi.Array)
         assert list(result) == [1.0, 2.0, 3.0]
 
     @requires_py39
     def test_list_from_list(self) -> None:
         """List convert from Python list."""
         result = _to_py_class_value(A(list[int]).convert([1, 2, 3]))
-        assert isinstance(result, _tvm_ffi.List)
+        assert isinstance(result, ffi.List)
         assert list(result) == [1, 2, 3]
 
     @requires_py39
     def test_dict_from_dict(self) -> None:
         """Dict convert from Python dict."""
         result = _to_py_class_value(A(dict[str, int]).convert({"a": 1}))
-        assert isinstance(result, _tvm_ffi.Dict)
+        assert isinstance(result, ffi.Dict)
 
     @requires_py39
     def test_map_from_dict(self) -> None:
         """Map convert from Python dict."""
-        result = _to_py_class_value(A(tvm_ffi.Map[str, int]).convert({"a": 1}))
-        assert isinstance(result, _tvm_ffi.Map)
+        result = _to_py_class_value(A(ffi.Map[str, int]).convert({"a": 1}))
+        assert isinstance(result, ffi.Map)
 
     @requires_py39
     def test_array_passthrough(self) -> None:
         """ffi.Array input passes through unchanged."""
-        arr = _tvm_ffi.Array([1, 2, 3])
+        arr = ffi.Array([1, 2, 3])
         result = _to_py_class_value(A(tuple[int, ...]).convert(arr))
         assert result.same_as(arr)
 
     @requires_py39
     def test_list_passthrough(self) -> None:
         """ffi.List input passes through unchanged."""
-        lst = _tvm_ffi.List([1, 2, 3])
+        lst = ffi.List([1, 2, 3])
         result = _to_py_class_value(A(list[int]).convert(lst))
         assert result.same_as(lst)
 
@@ -4408,7 +4399,7 @@ class TestConvertReturnFFIContainers:
     def test_array_subclass_passthrough(self) -> None:
         """ffi.Array subclasses pass through unchanged."""
 
-        class MyArray(_tvm_ffi.Array):
+        class MyArray(ffi.Array):
             pass
 
         arr = MyArray([1, 2, 3])
@@ -4419,7 +4410,7 @@ class TestConvertReturnFFIContainers:
     def test_list_subclass_passthrough(self) -> None:
         """ffi.List subclasses pass through unchanged."""
 
-        class MyList(_tvm_ffi.List):
+        class MyList(ffi.List):
             pass
 
         lst = MyList([1, 2, 3])
@@ -4430,18 +4421,18 @@ class TestConvertReturnFFIContainers:
     def test_map_subclass_passthrough(self) -> None:
         """ffi.Map subclasses pass through unchanged for Map[Any, Any]."""
 
-        class MyMap(_tvm_ffi.Map):
+        class MyMap(ffi.Map):
             pass
 
         m = MyMap({"a": 1})
-        result = _to_py_class_value(A(tvm_ffi.Map[typing.Any, typing.Any]).convert(m))
+        result = _to_py_class_value(A(ffi.Map[typing.Any, typing.Any]).convert(m))
         assert result.same_as(m)
 
     @requires_py39
     def test_dict_subclass_passthrough(self) -> None:
         """ffi.Dict subclasses pass through unchanged for Dict[Any, Any]."""
 
-        class MyDict(_tvm_ffi.Dict):
+        class MyDict(ffi.Dict):
             pass
 
         d = MyDict({"a": 1})
@@ -4452,8 +4443,8 @@ class TestConvertReturnFFIContainers:
     def test_nested_array_convert(self) -> None:
         """Nested array conversion."""
         result = _to_py_class_value(A(tuple[tuple[int, ...], ...]).convert([[1, 2], [3, 4]]))
-        assert isinstance(result, _tvm_ffi.Array)
-        assert isinstance(result[0], _tvm_ffi.Array)
+        assert isinstance(result, ffi.Array)
+        assert isinstance(result[0], ffi.Array)
 
 
 # ---------------------------------------------------------------------------
@@ -4463,77 +4454,77 @@ class TestConvertToFFITypes:
     """convert() returns canonical FFI types for all value kinds."""
 
     def test_short_str_is_string(self) -> None:
-        """Short str (SmallStr) promotes to tvm_ffi.String."""
+        """Short str (SmallStr) promotes to ffi.String."""
         result = _to_py_class_value(A(str).convert("hi"))
-        assert isinstance(result, tvm_ffi.core.String)
+        assert isinstance(result, ffi.core.String)
         assert result == "hi"
 
     def test_long_str_is_string(self) -> None:
-        """Long str (kTVMFFIStr object) is tvm_ffi.String."""
+        """Long str (kTVMFFIStr object) is ffi.String."""
         long_s = "x" * 200
         result = _to_py_class_value(A(str).convert(long_s))
-        assert isinstance(result, tvm_ffi.core.String)
+        assert isinstance(result, ffi.core.String)
         assert result == long_s
 
     def test_empty_str_is_string(self) -> None:
-        """Empty str is tvm_ffi.String."""
+        """Empty str is ffi.String."""
         result = _to_py_class_value(A(str).convert(""))
-        assert isinstance(result, tvm_ffi.core.String)
+        assert isinstance(result, ffi.core.String)
         assert result == ""
 
     def test_short_bytes_is_bytes(self) -> None:
-        """Short bytes (SmallBytes) promotes to tvm_ffi.Bytes."""
+        """Short bytes (SmallBytes) promotes to ffi.Bytes."""
         result = _to_py_class_value(A(bytes).convert(b"hi"))
-        assert isinstance(result, tvm_ffi.core.Bytes)
+        assert isinstance(result, ffi.core.Bytes)
         assert result == b"hi"
 
     def test_long_bytes_is_bytes(self) -> None:
-        """Long bytes (kTVMFFIBytes object) is tvm_ffi.Bytes."""
+        """Long bytes (kTVMFFIBytes object) is ffi.Bytes."""
         long_b = b"x" * 200
         result = _to_py_class_value(A(bytes).convert(long_b))
-        assert isinstance(result, tvm_ffi.core.Bytes)
+        assert isinstance(result, ffi.core.Bytes)
         assert result == long_b
 
     def test_empty_bytes_is_bytes(self) -> None:
-        """Empty bytes is tvm_ffi.Bytes."""
+        """Empty bytes is ffi.Bytes."""
         result = _to_py_class_value(A(bytes).convert(b""))
-        assert isinstance(result, tvm_ffi.core.Bytes)
+        assert isinstance(result, ffi.core.Bytes)
         assert result == b""
 
     def test_bytearray_converts_to_ffi_bytes(self) -> None:
-        """Bytearray converts to tvm_ffi.Bytes."""
+        """Bytearray converts to ffi.Bytes."""
         result = _to_py_class_value(A(bytes).convert(bytearray(b"hello")))
-        assert isinstance(result, tvm_ffi.core.Bytes)
+        assert isinstance(result, ffi.core.Bytes)
         assert result == b"hello"
 
     def test_callable_is_function(self) -> None:
-        """Callable converts to tvm_ffi.Function."""
+        """Callable converts to ffi.Function."""
         result = _to_py_class_value(A(Callable).convert(lambda x: x))
-        assert isinstance(result, tvm_ffi.core.Function)
+        assert isinstance(result, ffi.core.Function)
 
     @requires_py39
     def test_array_is_ffi_array(self) -> None:
-        """Array[int] converts to tvm_ffi.Array."""
+        """Array[int] converts to ffi.Array."""
         result = _to_py_class_value(A(tuple[int, ...]).convert([1, 2]))
-        assert isinstance(result, _tvm_ffi.Array)
+        assert isinstance(result, ffi.Array)
 
     @requires_py39
     def test_list_is_ffi_list(self) -> None:
-        """List[int] converts to tvm_ffi.List."""
+        """List[int] converts to ffi.List."""
         result = _to_py_class_value(A(list[int]).convert([1, 2]))
-        assert isinstance(result, _tvm_ffi.List)
+        assert isinstance(result, ffi.List)
 
     @requires_py39
     def test_map_is_ffi_map(self) -> None:
-        """Map[str, int] converts to tvm_ffi.Map."""
-        result = _to_py_class_value(A(tvm_ffi.Map[str, int]).convert({"a": 1}))
-        assert isinstance(result, _tvm_ffi.Map)
+        """Map[str, int] converts to ffi.Map."""
+        result = _to_py_class_value(A(ffi.Map[str, int]).convert({"a": 1}))
+        assert isinstance(result, ffi.Map)
 
     @requires_py39
     def test_dict_is_ffi_dict(self) -> None:
-        """Dict[str, int] converts to tvm_ffi.Dict."""
+        """Dict[str, int] converts to ffi.Dict."""
         result = _to_py_class_value(A(dict[str, int]).convert({"a": 1}))
-        assert isinstance(result, _tvm_ffi.Dict)
+        assert isinstance(result, ffi.Dict)
 
     def test_int_is_int(self) -> None:
         """Int stays as int."""
@@ -4561,7 +4552,7 @@ class TestConvertToFFITypes:
         """Object converts to CObject subclass."""
         obj = TestIntPair(1, 2)
         result = _to_py_class_value(A(TestIntPair).convert(obj))
-        assert isinstance(result, tvm_ffi.core.CObject)
+        assert isinstance(result, ffi.core.CObject)
         assert result.same_as(obj)
 
 
@@ -4639,41 +4630,41 @@ class TestSmallStringOptimization:
         assert cany.type_index == _BYTES_TYPE_INDEX
 
     def test_small_str_roundtrips_as_string(self) -> None:
-        """SmallStr round-trips to tvm_ffi.String via _to_py_class_value."""
+        """SmallStr round-trips to ffi.String via _to_py_class_value."""
         cany = A(str).convert("hi")
         assert cany.type_index == _SMALL_STR_TYPE_INDEX
         result = _to_py_class_value(cany)
-        assert isinstance(result, tvm_ffi.core.String)
+        assert isinstance(result, ffi.core.String)
         assert result == "hi"
 
     def test_small_bytes_roundtrips_as_bytes(self) -> None:
-        """SmallBytes round-trips to tvm_ffi.Bytes via _to_py_class_value."""
+        """SmallBytes round-trips to ffi.Bytes via _to_py_class_value."""
         cany = A(bytes).convert(b"hi")
         assert cany.type_index == _SMALL_BYTES_TYPE_INDEX
         result = _to_py_class_value(cany)
-        assert isinstance(result, tvm_ffi.core.Bytes)
+        assert isinstance(result, ffi.core.Bytes)
         assert result == b"hi"
 
     def test_ffi_string_short_repacks_as_small(self) -> None:
-        """A short tvm_ffi.String is re-packed as SmallStr by CAny."""
-        s = tvm_ffi.core.String("hi")
+        """A short ffi.String is re-packed as SmallStr by CAny."""
+        s = ffi.core.String("hi")
         cany = A(str).convert(s)
         assert cany.type_index == _SMALL_STR_TYPE_INDEX
 
     def test_ffi_string_long_stays_heap(self) -> None:
-        """A long tvm_ffi.String stays as heap kTVMFFIStr."""
-        s = tvm_ffi.core.String("x" * 200)
+        """A long ffi.String stays as heap kTVMFFIStr."""
+        s = ffi.core.String("x" * 200)
         cany = A(str).convert(s)
         assert cany.type_index == _STR_TYPE_INDEX
 
     def test_ffi_bytes_short_repacks_as_small(self) -> None:
-        """A short tvm_ffi.Bytes is re-packed as SmallBytes by CAny."""
-        b = tvm_ffi.core.Bytes(b"hi")
+        """A short ffi.Bytes is re-packed as SmallBytes by CAny."""
+        b = ffi.core.Bytes(b"hi")
         cany = A(bytes).convert(b)
         assert cany.type_index == _SMALL_BYTES_TYPE_INDEX
 
     def test_ffi_bytes_long_stays_heap(self) -> None:
-        """A long tvm_ffi.Bytes stays as heap kTVMFFIBytes."""
-        b = tvm_ffi.core.Bytes(b"x" * 200)
+        """A long ffi.Bytes stays as heap kTVMFFIBytes."""
+        b = ffi.core.Bytes(b"x" * 200)
         cany = A(bytes).convert(b)
         assert cany.type_index == _BYTES_TYPE_INDEX


### PR DESCRIPTION
## Summary
- Replace `import tvm_ffi` / `tvm_ffi.X` with `import tvm_ffi as ffi` / `ffi.X` across all examples, docs, tests, and package docstrings
- Preserve Sphinx cross-references, C++ includes, CLI commands (`python -m tvm_ffi.*`), library filenames (`libtvm_ffi.so`), and registered type keys unchanged
- 58 files changed: 27 test files, 7 example files, 9 doc files, 15 package docstring files

## Test plan
- [x] `pre-commit run --all-files` — all 27 hooks passed
- [x] `uv run pytest -vvs tests/python` — 1927 passed, 25 skipped (7 pre-existing failures in test_structural_py_class.py also fail on upstream/main)
- [x] `sphinx-build -M html docs docs/_build` — build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)
