### PR TITLE
fix(c_class): pre-allocate C++ object for custom __init__ to prevent NULL handle segfault

### DIFF
--- a/python/tvm_ffi/dataclasses/c_class.py
+++ b/python/tvm_ffi/dataclasses/c_class.py
@@ -109,7 +109,7 @@ def c_class(
     def decorator(cls: _T) -> _T:
         cls = register_object(type_key)(cls)
         _install_dataclass_dunders(
-            cls, init=init, repr=repr, eq=eq, order=order, unsafe_hash=unsafe_hash
+            cls, init=init, repr=repr, eq=eq, order=order, unsafe_hash=unsafe_hash, pre_alloc=True
         )
         return cls
 

--- a/python/tvm_ffi/registry.py
+++ b/python/tvm_ffi/registry.py
@@ -29,6 +29,24 @@ from .core import TypeInfo
 # whether we simplify skip unknown objects regtistration
 _SKIP_UNKNOWN_OBJECTS = False
 
+# Lazily cached reference to ffi.ObjectCreateEmpty (resolved on first use).
+_OBJECT_CREATE_EMPTY: Callable[..., Any] | None = None
+
+
+def _ffi_alloc_empty(type_index: int) -> Any:
+    """Allocate an empty (default-initialized) C++ object by *type_index*.
+
+    Calls ``ffi.ObjectCreateEmpty`` which invokes the type's registered
+    creator (the C++ default constructor).  Unlike
+    ``MakeObjectFromPackedArgs`` this does NOT validate required fields,
+    so it is safe to call before the user's ``__init__`` has had a chance
+    to set field values.
+    """
+    global _OBJECT_CREATE_EMPTY  # noqa: PLW0603
+    if _OBJECT_CREATE_EMPTY is None:
+        _OBJECT_CREATE_EMPTY = get_global_func("ffi.ObjectCreateEmpty")
+    return _OBJECT_CREATE_EMPTY(type_index)
+
 
 _T = TypeVar("_T", bound=type)
 
@@ -454,7 +472,7 @@ def _setup_copy_methods(
             setattr(type_cls, "__replace__", _replace_unsupported)
 
 
-def _install_init(cls: type, *, enabled: bool) -> None:
+def _install_init(cls: type, *, enabled: bool, pre_alloc: bool = False) -> None:
     """Install ``__init__`` from C++ reflection metadata, or a guard.
 
     When *enabled* is True, looks for a ``__ffi_init__`` method in the
@@ -467,8 +485,37 @@ def _install_init(cls: type, *, enabled: bool) -> None:
     When *enabled* is False, installs a guard that raises ``TypeError``
     on construction.  Skipped entirely if the class body already defines
     ``__init__``.
+
+    When *pre_alloc* is True and the class defines its own ``__init__``,
+    wrap it to pre-allocate a C++ object via
+    ``ffi.ObjectCreateEmpty`` before the user's code runs.  This
+    ensures field setters always find a valid handle.
     """
     if "__init__" in cls.__dict__:
+        if not enabled or pre_alloc:
+            # Wrap user's __init__ to ensure a C++ object is allocated.
+            # Pre-allocate the C++ object *before* the user's code runs so
+            # that field setters (which dereference chandle + offset) never
+            # hit a NULL handle.
+            #
+            # If the user's __init__ also calls __ffi_init__ (or
+            # __init_handle_by_constructor__), the pre-allocated handle is
+            # replaced.  We keep the pre-alloc object alive in a local so
+            # its __dealloc__ properly frees the handle when it goes out
+            # of scope -- unless the user init moved it to self, in which
+            # case self owns it and the local's chandle is already NULL.
+            user_init = cls.__dict__["__init__"]
+
+            import functools  # noqa: PLC0415
+
+            @functools.wraps(user_init)
+            def __init__(self: Any, *args: Any, **kwargs: Any) -> None:
+                actual_type_info = type(self).__tvm_ffi_type_info__
+                _pre_alloc_guard = _ffi_alloc_empty(actual_type_info.type_index)
+                self.__move_handle_from__(_pre_alloc_guard)
+                user_init(self, *args, **kwargs)
+
+            setattr(cls, "__init__", __init__)
         return
     type_info: TypeInfo | None = getattr(cls, "__tvm_ffi_type_info__", None)
     if type_info is None:
@@ -550,6 +597,7 @@ def _install_dataclass_dunders(
     eq: bool,
     order: bool,
     unsafe_hash: bool,
+    pre_alloc: bool = False,
 ) -> None:
     """Install structural dunder methods on *cls*.
 
@@ -578,9 +626,13 @@ def _install_dataclass_dunders(
         ``NotImplemented`` for unrelated types.
     unsafe_hash
         If True, install ``__hash__`` using ``RecursiveHash``.
+    pre_alloc
+        If True, wrap user-defined ``__init__`` to pre-allocate a C++
+        object before the user's code runs.  Used by ``@c_class`` to
+        ensure field setters never hit a NULL handle.
 
     """
-    _install_init(cls, enabled=init)
+    _install_init(cls, enabled=init, pre_alloc=pre_alloc)
 
     if repr and "__repr__" not in cls.__dict__:
         from .core import object_repr  # noqa: PLC0415

--- a/src/ffi/extra/reflection_extra.cc
+++ b/src/ffi/extra/reflection_extra.cc
@@ -164,6 +164,26 @@ inline void StructuralKeyRegisterReflection() {
       .attr("__any_equal__", reinterpret_cast<void*>(&StructuralKeyEqual));
 }
 
+/*! \brief Create an empty (default-initialized) object by type index.
+ *
+ * Unlike MakeObjectFromPackedArgs this does NOT validate required fields.
+ * It simply calls the registered creator, which runs the C++ default
+ * constructor (scalars are 0, ObjectRef fields are null, etc.).
+ * Used by the Python pre-allocation wrapper to ensure a valid chandle
+ * before user-defined __init__ runs.
+ */
+ObjectRef ObjectCreateEmpty(int32_t type_index) {
+  const TVMFFITypeInfo* type_info = TVMFFIGetTypeInfo(type_index);
+  if (type_info->metadata == nullptr || type_info->metadata->creator == nullptr) {
+    TVM_FFI_THROW(RuntimeError) << "Type `" << TypeIndexToTypeKey(type_index)
+                                << "` does not support default construction";
+  }
+  TVMFFIObjectHandle handle;
+  TVM_FFI_CHECK_SAFE_CALL(type_info->metadata->creator(&handle));
+  return ObjectRef(
+      details::ObjectUnsafe::ObjectPtrFromOwned<Object>(static_cast<TVMFFIObject*>(handle)));
+}
+
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   AccessStepRegisterReflection();
@@ -172,6 +192,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 
   refl::GlobalDef()
       .def_packed("ffi.MakeObjectFromPackedArgs", MakeObjectFromPackedArgs)
+      .def("ffi.ObjectCreateEmpty", ObjectCreateEmpty)
       .def("ffi.StructuralKey", [](Any key) { return StructuralKey(std::move(key)); })
       .def("ffi.StructuralKeyEqual", StructuralKeyEqual);
 }

--- a/src/ffi/testing/testing.cc
+++ b/src/ffi/testing/testing.cc
@@ -236,6 +236,39 @@ class TestDeepCopyEdgesObj : public Object {
   TVM_FFI_DECLARE_OBJECT_INFO("testing.TestDeepCopyEdges", TestDeepCopyEdgesObj, Object);
 };
 
+// Bug 6 regression: types used to verify that pre-allocation wrapping works
+// when a @c_class defines a custom __init__ without calling __ffi_init__.
+class TestBug6NodeObj : public Object {
+ public:
+  static constexpr bool _type_mutable = true;
+  static constexpr uint32_t _type_child_slots = 1;
+  TVM_FFI_DECLARE_OBJECT_INFO("testing.TestBug6Node", TestBug6NodeObj, Object);
+};
+
+class TestBug6ContainerObj : public Object {
+ public:
+  Any val;
+
+  static constexpr bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("testing.TestBug6Container", TestBug6ContainerObj, Object);
+};
+
+class TestBug6HybridObj : public Object {
+ public:
+  int64_t x = 0;
+
+  static constexpr bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("testing.TestBug6Hybrid", TestBug6HybridObj, Object);
+};
+
+class TestBug6PreallocObj : public Object {
+ public:
+  String name;
+
+  static constexpr bool _type_mutable = true;
+  TVM_FFI_DECLARE_OBJECT_INFO("testing.TestBug6Prealloc", TestBug6PreallocObj, Object);
+};
+
 class TestNonCopyable : public Object {
  public:
   int64_t value;
@@ -464,6 +497,12 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   refl::ObjectDef<TestDeepCopyEdgesObj>()
       .def_rw("v_any", &TestDeepCopyEdgesObj::v_any)
       .def_rw("v_obj", &TestDeepCopyEdgesObj::v_obj);
+
+  // Bug 6 regression test types
+  refl::ObjectDef<TestBug6NodeObj>();
+  refl::ObjectDef<TestBug6ContainerObj>().def_rw("val", &TestBug6ContainerObj::val);
+  refl::ObjectDef<TestBug6HybridObj>().def_rw("x", &TestBug6HybridObj::x);
+  refl::ObjectDef<TestBug6PreallocObj>().def_rw("name", &TestBug6PreallocObj::name);
 
   refl::ObjectDef<TestNonCopyable>()
       .def(refl::init<int64_t>())

--- a/tests/python/test_bug6_prealloc.py
+++ b/tests/python/test_bug6_prealloc.py
@@ -1,0 +1,111 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Regression tests for Bug #6: c_class with __slots__ = ('__dict__',)
+and custom __init__ must not segfault when stored in another c_class field.
+"""
+
+from __future__ import annotations
+
+from tvm_ffi.core import Object
+from tvm_ffi.dataclasses import c_class
+from tvm_ffi.testing import _TestCxxClassBase
+
+# -- Test helper classes (registered against C++ testing.TestBug6* types) ------
+
+
+@c_class("testing.TestBug6Node")
+class _Bug6Node(Object):
+    """Base node class (no fields)."""
+
+    __slots__ = ("__dict__",)
+
+
+@c_class("testing.TestBug6Container")
+class _Bug6Container(Object):
+    """Container with an Any-typed field to hold arbitrary objects."""
+
+    val: object  # maps to C++ Any
+
+
+@c_class("testing.TestBug6Hybrid")
+class _Bug6Hybrid(Object):
+    """Has both a reflected int field and a __dict__ slot."""
+
+    __slots__ = ("__dict__",)
+    x: int
+
+    def __init__(self, x: int, extra_name: str) -> None:
+        self.x = x
+        self._extra = extra_name  # goes to __dict__
+
+
+@c_class("testing.TestBug6Prealloc")
+class _Bug6Prealloc(Object):
+    """Has a reflected string field and a custom init (init=True default)."""
+
+    name: str
+
+    def __init__(self, name: str) -> None:
+        self.name = name  # must not segfault
+
+
+# -- Tests --------------------------------------------------------------------
+
+
+class TestBug6SlotsDictSegfault:
+    """Regression test for Bug #6: c_class with __slots__ = ('__dict__',)
+    and custom __init__ must not segfault when stored in another c_class field.
+    """
+
+    def test_dict_slots_stored_in_field(self) -> None:
+        """Object with __dict__ slot and custom init can be stored in a field.
+
+        The key assertion is that storing and retrieving the object does
+        not segfault (the pre-allocated chandle is valid).  The Python
+        ``__dict__`` is per-wrapper and is NOT preserved across FFI
+        round-trips; only the underlying C++ handle identity is checked.
+        """
+
+        @c_class("testing.TestBug6Node")
+        class DataType(_Bug6Node):
+            def __init__(self, tag: str) -> None:
+                self._tag = tag
+
+        dt = DataType("float32")
+        assert dt._tag == "float32"
+        c = _Bug6Container(val=dt)
+        # Must not segfault; the retrieved object should share the handle.
+        retrieved = c.val
+        assert isinstance(retrieved, Object)
+        assert retrieved.same_as(dt)
+
+    def test_custom_init_with_fields_and_dict(self) -> None:
+        """c_class with both annotated fields and __dict__ via custom init."""
+        h = _Bug6Hybrid(42, "hello")
+        assert h.x == 42
+        assert h._extra == "hello"
+
+    def test_init_true_custom_init_preallocates(self) -> None:
+        """With init=True (default), user __init__ should still get pre-allocation."""
+        obj = _Bug6Prealloc("test")
+        assert obj.name == "test"
+
+    def test_custom_init_still_supports_ffi_init(self) -> None:
+        """Existing classes that call __ffi_init__ in custom __init__ still work."""
+        obj = _TestCxxClassBase(v_i64=10, v_i32=20)
+        assert obj.v_i64 == 11  # +1 from custom __init__
+        assert obj.v_i32 == 22  # +2 from custom __init__


### PR DESCRIPTION
## Summary
- Fixes Bug #6: `@c_class` with `__slots__ = ('__dict__',)` and custom `__init__` segfaults when stored in another c_class field
- Root cause: when `init=True` (default) and a user-defined `__init__` exists, the C++ object was never allocated, leaving `chandle` NULL
- Adds `_ffi_alloc_empty` helper via new `ffi.ObjectCreateEmpty` C++ function to pre-allocate zero-initialized objects
- Wraps user `__init__` to call pre-allocation before user code runs (only for `@c_class` path)

## Test plan
- [x] 4 new regression tests in `tests/python/test_bug6_prealloc.py`
- [x] Full test suite: 964 passed, 23 skipped, 1 xfailed
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>