### PR TITLE
chore(ci): Use CPU-only PyTorch in Linter

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -73,8 +73,10 @@ jobs:
           fetch-tags: true
       - name: Set up uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098  # v7.3.1
+        with:
+          python-version: "3.14"
       - name: Set up Python environment
-        run: uv sync --group dev --no-install-project
+        run: uv sync --group dev --no-install-project --index https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
 
   clang-tidy:


### PR DESCRIPTION
To avoid 7min of downloading time...