### PR TITLE
perf(container): use iterator lookup instead of exception handling in Map/Dict

### DIFF
--- a/src/ffi/container.cc
+++ b/src/ffi/container.cc
@@ -195,11 +195,11 @@ TVM_FFI_STATIC_INIT_BLOCK() {
            })
       .def("ffi.MapGetItemOrMissing",
            [](const ffi::MapObj* n, const Any& k) -> Any {
-             try {
-               return n->at(k);
-             } catch (const tvm::ffi::Error& e) {
-               return GetMissingObject();
+             auto it = n->find(k);
+             if (it != n->end()) {
+               return it->second;
              }
+             return GetMissingObject();
            })
       .def_packed("ffi.Dict",
                   [](ffi::PackedArgs args, Any* ret) {
@@ -227,11 +227,11 @@ TVM_FFI_STATIC_INIT_BLOCK() {
            })
       .def("ffi.DictGetItemOrMissing",
            [](const ffi::DictObj* n, const Any& k) -> Any {
-             try {
-               return n->at(k);
-             } catch (const tvm::ffi::Error& e) {
-               return GetMissingObject();
+             auto it = n->find(k);
+             if (it != n->end()) {
+               return it->second;
              }
+             return GetMissingObject();
            })
       .def("ffi.ContainerFindFirstNonCPUDevice", [](const Any& container) -> DLDevice {
         DLDevice result{kDLCPU, 0};


### PR DESCRIPTION
## Summary

- Replace `try { n->at(k); } catch (...)` with `n->find(k)` + iterator check in `ffi.MapGetItemOrMissing` and `ffi.DictGetItemOrMissing`
- Avoids the overhead of throwing and catching exceptions on every missing-key lookup
- No behavioral change: both paths return `GetMissingObject()` for absent keys

Closes #547

## Test plan

- [x] `uv run pytest -vvs tests/python` -- 2088 passed, 38 skipped, 3 xfailed (no new failures)
- [x] Pre-commit hooks pass (clang-format, ASF header, file types, etc.)