### PR TITLE
chore(doc): Temp workaround missing pytorch docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -157,7 +157,7 @@ intersphinx_mapping = {
     "typing_extensions": ("https://typing-extensions.readthedocs.io/en/latest", None),
     "pillow": ("https://pillow.readthedocs.io/en/stable", None),
     "numpy": ("https://numpy.org/doc/stable", None),
-    "torch": ("https://pytorch.org/docs/stable", None),
+    "torch": ("https://pytorch.org/docs/2.11", None),
     "torch-cpp": ("https://docs.pytorch.org/cppdocs", None),
     "dlpack": ("https://dmlc.github.io/dlpack/latest", None),
     "data-api": ("https://data-apis.org/array-api/latest", None),


### PR DESCRIPTION
Will switch back once https://docs.pytorch.org/docs/stable/objects.inv becomes available again.