### PR TITLE
[EXTRA][FEAT] StructuralErrorContext for structural-context-aware error reporting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ set(_tvm_ffi_objs_sources
 set(_tvm_ffi_extra_objs_sources
     "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/extra/structural_equal.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/extra/structural_hash.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/extra/structural_error_context.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/extra/json_parser.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/extra/json_writer.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/extra/serialization.cc"

--- a/include/tvm/ffi/extra/structural_error_context.h
+++ b/include/tvm/ffi/extra/structural_error_context.h
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*!
+ * \file tvm/ffi/extra/structural_error_context.h
+ * \brief StructuralErrorContext: typed payload for Error::extra_context that records the
+ *        chain of ObjectRefs visited during a recursive structural visit when an error is thrown.
+ */
+#ifndef TVM_FFI_EXTRA_STRUCTURAL_ERROR_CONTEXT_H_
+#define TVM_FFI_EXTRA_STRUCTURAL_ERROR_CONTEXT_H_
+
+#include <tvm/ffi/container/array.h>
+#include <tvm/ffi/error.h>
+#include <tvm/ffi/extra/base.h>
+#include <tvm/ffi/memory.h>
+#include <tvm/ffi/object.h>
+#include <tvm/ffi/optional.h>
+#include <tvm/ffi/reflection/access_path.h>
+
+namespace tvm {
+namespace ffi {
+
+/*!
+ * \brief Object class for StructuralErrorContext.
+ *
+ * \sa StructuralErrorContext
+ */
+class StructuralErrorContextObj : public Object {
+ public:
+  /*!
+   * \brief Visit records that get populated, which include the object visit
+   *        path pattern in innermost-first order. Best-effort — not exhaustive.
+   */
+  Array<ObjectRef> reverse_visit_pattern;
+
+  /*!
+   * \brief Pre-existing Error::extra_context payload before we placed the
+   *        StructuralErrorContext.
+   */
+  Optional<ObjectRef> previous_error_context;
+
+  /// \cond Doxygen_Suppress
+  static constexpr bool _type_mutable = true;
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindUnsupported;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ffi.StructuralErrorContext", StructuralErrorContextObj,
+                                    Object);
+  /// \endcond
+};
+
+/*!
+ * \brief Typed payload attached to Error::extra_context to support
+ *        structural-context-aware error reporting.
+ *
+ * The StructuralErrorContext captures the reverse_visit_pattern —
+ * the chain of nodes visited before an error was thrown — so callers
+ * can translate it via FindAccessPaths into a structured access path
+ * for richer error messages.
+ *
+ * Typical usage:
+ *
+ *   1. A recursive structural visit is instrumented with
+ *      TVM_FFI_STRUCTURAL_VISIT_BEGIN / _END(node). On throw, the
+ *      macros record the visited nodes into a StructuralErrorContext
+ *      and attach it to the Error's extra_context.
+ *
+ *   2. The root catch handler retrieves the context via
+ *      TryGetFromError(err), then resolves the chain into one or more
+ *      reflection::AccessPath instances via FindAccessPaths(root, ctx).
+ *
+ *   3. The caller uses the AccessPath to enrich the error message
+ *      with structured position info (e.g., ".body[2].cond.lhs").
+ */
+class StructuralErrorContext : public ObjectRef {
+ public:
+  /*! \brief Get the StructuralErrorContext attached to err's extra_context.
+   *  \param err The error to inspect.
+   *  \return The attached StructuralErrorContext, or NullOpt if absent.
+   */
+  static Optional<StructuralErrorContext> TryGetFromError(const Error& err) {
+    std::optional<ObjectRef> ec = err.extra_context();
+    if (ec) {
+      return ec->as<StructuralErrorContext>();
+    }
+    return std::nullopt;
+  }
+
+  /*! \brief Find all access paths that match the pattern specified in the
+   *         StructuralErrorContext.
+   *  \param root The root ObjectRef to search from.
+   *  \param structural_context The StructuralErrorContext to match against.
+   *  \param allow_prefix_match If true, also report paths where only a
+   *                            prefix of the pattern was matched (i.e.,
+   *                            the algorithm descended through some
+   *                            matched records but could not find further
+   *                            matches before reaching a leaf). Default
+   *                            false — only full pattern matches are
+   *                            reported.
+   *  \return Array of matched access paths.
+   */
+  TVM_FFI_EXTRA_CXX_API static Array<reflection::AccessPath> FindAccessPaths(
+      const ObjectRef& root, const StructuralErrorContext& structural_context,
+      bool allow_prefix_match = false);
+
+  /// \cond Doxygen_Suppress
+  explicit StructuralErrorContext(ObjectPtr<StructuralErrorContextObj> n)
+      : ObjectRef(std::move(n)) {}
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(StructuralErrorContext, ObjectRef,
+                                                StructuralErrorContextObj);
+  /// \endcond
+};
+
+/*!
+ * \brief Begin a structural-visit try block.
+ *
+ * Must be paired with TVM_FFI_STRUCTURAL_VISIT_END(node) at the end of the
+ * visit body. Expands to an open `try {` — a mismatched _END macro is a
+ * compile error (unclosed try block).
+ *
+ * \code{.cpp}
+ * void MyVisitor::VisitNode(const ObjectRef& node) {
+ *   TVM_FFI_STRUCTURAL_VISIT_BEGIN();
+ *   DispatchVisit(node);
+ *   TVM_FFI_STRUCTURAL_VISIT_END(node);
+ * }
+ * \endcode
+ */
+#define TVM_FFI_STRUCTURAL_VISIT_BEGIN() try {
+/*!
+ * \brief End a structural-visit try block and catch+re-throw any Error,
+ *        appending node to the StructuralErrorContext on the way up.
+ *
+ * Must be paired with TVM_FFI_STRUCTURAL_VISIT_BEGIN() above the visit body.
+ *
+ * \param node The ObjectRef at the current visit level (appended to the
+ *             error context's reverse_visit_pattern on exception).
+ */
+#define TVM_FFI_STRUCTURAL_VISIT_END(node)                                          \
+  }                                                                                 \
+  catch (::tvm::ffi::Error & _tvm_ffi_visit_err_) {                                 \
+    ::tvm::ffi::details::UpdateStructuralErrorContext(_tvm_ffi_visit_err_, (node)); \
+    throw;                                                                          \
+  }
+
+namespace details {
+/*!
+ * \brief Implementation helper for TVM_FFI_STRUCTURAL_VISIT_END(node).
+ *        Calling convention may change; do not call directly from user code.
+ *
+ * \note Safe to call only while the Error is owned by the current thread during
+ *       exception unwind, before any external observer (Python wrapper, logging
+ *       hook) takes a reference. After the catch handler returns to wider scope,
+ *       treat the error as immutable. Writes directly to ErrorObj::extra_context
+ *       using ObjectUnsafe refcount-aware patterns (no separate fn-ptr needed).
+ */
+inline void UpdateStructuralErrorContext(Error err, ObjectRef node) {
+  std::optional<ObjectRef> ec = err.extra_context();
+  if (ec) {
+    Optional<StructuralErrorContext> sec = ec->as<StructuralErrorContext>();
+    if (sec) {
+      sec.value()->reverse_visit_pattern.push_back(node);
+      return;
+    }
+  }
+  // Build a fresh StructuralErrorContext, preserving any pre-existing payload.
+  ObjectPtr<StructuralErrorContextObj> obj = make_object<StructuralErrorContextObj>();
+  obj->reverse_visit_pattern = Array<ObjectRef>{node};
+  if (ec) obj->previous_error_context = *ec;
+
+  // Write directly to the ErrorObj cell using ObjectUnsafe patterns.
+  // This is safe here because we are the sole owner during exception unwind.
+  ErrorObj* error_obj =
+      static_cast<ErrorObj*>(details::ObjectUnsafe::RawObjectPtrFromObjectRef(err));
+  if (error_obj->extra_context != nullptr) {
+    details::ObjectUnsafe::DecRefObjectHandle(error_obj->extra_context);
+  }
+  error_obj->extra_context = details::ObjectUnsafe::MoveObjectPtrToTVMFFIObjectPtr(std::move(obj));
+}
+}  // namespace details
+
+}  // namespace ffi
+}  // namespace tvm
+#endif  // TVM_FFI_EXTRA_STRUCTURAL_ERROR_CONTEXT_H_

--- a/python/tvm_ffi/cython/error.pxi
+++ b/python/tvm_ffi/cython/error.pxi
@@ -104,6 +104,23 @@ cdef class Error(CObject):
     def backtrace(self):
         return bytearray_to_str(&(TVMFFIErrorGetCellPtr(self.chandle).backtrace))
 
+    @property
+    def extra_context(self):
+        """Optional structured payload attached to this error.
+
+        Returns ``None`` if nothing is attached.  May be inspected via the
+        appropriate type-specific helpers.
+        """
+        cdef TVMFFIObjectHandle ctx_handle = TVMFFIErrorGetCellPtr(self.chandle).extra_context
+        if ctx_handle == NULL:
+            return None
+        # Build an owned Any from the unowned handle by incrementing the refcount.
+        cdef TVMFFIAny any_val
+        any_val.type_index = TVMFFIObjectGetTypeIndex(ctx_handle)
+        any_val.v_obj = <TVMFFIObject*>ctx_handle
+        TVMFFIObjectIncRef(ctx_handle)
+        return make_ret_object(any_val)
+
 
 cdef inline Error move_from_last_error():
     # raise last error

--- a/src/ffi/extra/structural_error_context.cc
+++ b/src/ffi/extra/structural_error_context.cc
@@ -1,0 +1,289 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * \file src/ffi/extra/structural_error_context.cc
+ * \brief StructuralErrorContext implementation — breadcrumb-trail collection and access-path
+ *        extraction for recursive Object visits.
+ */
+#include <tvm/ffi/container/array.h>
+#include <tvm/ffi/container/dict.h>
+#include <tvm/ffi/container/list.h>
+#include <tvm/ffi/container/map.h>
+#include <tvm/ffi/extra/structural_error_context.h>
+#include <tvm/ffi/memory.h>
+#include <tvm/ffi/reflection/accessor.h>
+#include <tvm/ffi/string.h>
+
+#include <utility>
+#include <vector>
+
+namespace tvm {
+namespace ffi {
+
+/**
+ * \brief Internal handler for finding all access paths in a root ObjectRef
+ *        that match the breadcrumb pattern stored in a StructuralErrorContext.
+ */
+class StructuralErrorAccessPathFinder {
+ public:
+  explicit StructuralErrorAccessPathFinder(StructuralErrorContext context, bool allow_prefix_match)
+      : context_(std::move(context)),
+        allow_prefix_match_(allow_prefix_match),
+        num_pattern_step_matched_(0) {}
+
+  Array<reflection::AccessPath> Find(const ObjectRef& root) {
+    this->VisitObject(root);
+    return Array<reflection::AccessPath>(results_.begin(), results_.end());
+  }
+
+ private:
+  /**
+   * \brief Stack-allocated mirror of AccessStepObj used during the descent hot path.
+   *        For kAttr: stores const TVMFFIFieldInfo* encoded as void* in key (via
+   *        kTVMFFIOpaquePtr). String allocation is deferred to ToAccessStep().
+   *        Not an Object — pure struct, no Object header / refcount.
+   */
+  struct TempAccessStep {
+    reflection::AccessKind kind;
+    Any key{};  // For kAttr: FieldInfo pointer encoded as void* (kTVMFFIOpaquePtr).
+                // For kArrayItem: int64 index.
+                // For kMapItem: the user's key.
+
+    static TempAccessStep Attr(const TVMFFIFieldInfo* fi) {
+      TempAccessStep s;
+      s.kind = reflection::AccessKind::kAttr;
+      // Any has TypeTraits<void*> (kTVMFFIOpaquePtr) but not const void*.
+      // Cast away const for storage; restore on retrieval.
+      s.key = Any(const_cast<void*>(static_cast<const void*>(fi)));
+      return s;
+    }
+
+    static TempAccessStep ArrayItem(int64_t index) {
+      TempAccessStep s;
+      s.kind = reflection::AccessKind::kArrayItem;
+      s.key = Any(index);
+      return s;
+    }
+
+    static TempAccessStep MapItem(Any k) {
+      TempAccessStep s;
+      s.kind = reflection::AccessKind::kMapItem;
+      s.key = std::move(k);
+      return s;
+    }
+
+    /*! \brief Materialize the heap-allocated AccessStep. Called only at match time.
+     *         The String allocation for fi->name happens HERE, once. */
+    reflection::AccessStep ToAccessStep() const {
+      if (kind == reflection::AccessKind::kAttr) {
+        const TVMFFIFieldInfo* fi = static_cast<const TVMFFIFieldInfo*>(key.cast<void*>());
+        return reflection::AccessStep::Attr(String(fi->name.data, fi->name.size));
+      } else if (kind == reflection::AccessKind::kArrayItem) {
+        return reflection::AccessStep::ArrayItem(key.cast<int64_t>());
+      } else {
+        // kMapItem
+        return reflection::AccessStep::MapItem(key);
+      }
+    }
+  };
+
+  void VisitAny(Any value) {
+    // Skip null Any silently — error-path defensive.
+    if (value == nullptr) return;
+    const int32_t type_index = value.type_index();
+    if (type_index < TypeIndex::kTVMFFIStaticObjectBegin) {
+      // Primitive — cannot hold an ObjectRef chain entry.
+      return;
+    }
+    switch (type_index) {
+      case TypeIndex::kTVMFFIArray:
+        this->VisitSequence(
+            details::AnyUnsafe::MoveFromAnyAfterCheck<Array<Any>>(std::move(value)));
+        break;
+      case TypeIndex::kTVMFFIList:
+        this->VisitSequence(details::AnyUnsafe::MoveFromAnyAfterCheck<List<Any>>(std::move(value)));
+        break;
+      case TypeIndex::kTVMFFIMap:
+        this->VisitMap(details::AnyUnsafe::MoveFromAnyAfterCheck<Map<Any, Any>>(std::move(value)));
+        break;
+      case TypeIndex::kTVMFFIDict:
+        this->VisitMap(details::AnyUnsafe::MoveFromAnyAfterCheck<Dict<Any, Any>>(std::move(value)));
+        break;
+      default:
+        if (type_index >= TypeIndex::kTVMFFIStaticObjectBegin) {
+          ObjectRef obj = details::AnyUnsafe::MoveFromAnyAfterCheck<ObjectRef>(std::move(value));
+          this->VisitObject(std::move(obj));
+        }
+        break;
+    }
+  }
+
+  void VisitObject(ObjectRef node) {
+    // Defensive: error path; never throw.
+    if (!node.defined()) return;
+    const TVMFFITypeInfo* type_info = TVMFFIGetTypeInfo(node->type_index());
+    if (type_info == nullptr || type_info->metadata == nullptr) return;
+
+    const Array<ObjectRef>& records = context_->reverse_visit_pattern;
+    bool matched_step = num_pattern_step_matched_ < records.size() &&
+                        node.same_as(records[records.size() - 1 - num_pattern_step_matched_]);
+    if (matched_step) {
+      ++num_pattern_step_matched_;
+      if (num_pattern_step_matched_ == records.size()) {
+        // Full match — materialize the AccessPath and record.
+        results_.push_back(this->MaterializeAccessPath());
+        --num_pattern_step_matched_;
+        return;
+      }
+    }
+
+    this->VisitChildrenFields(node, type_info);
+
+    if (matched_step) --num_pattern_step_matched_;
+  }
+
+  void VisitChildrenFields(ObjectRef node, const TVMFFITypeInfo* type_info) {
+    // Snapshot results_.size() before descent to detect any inner full or
+    // prefix match recorded by a deeper call. If results_ grew, some inner
+    // node was recorded — we do not record again here.
+    size_t results_before = results_.size();
+    reflection::ForEachFieldInfo(type_info, [&](const TVMFFIFieldInfo* field_info) {
+      reflection::FieldGetter getter(field_info);
+      Any child_val = getter(node);
+      this->PushStep(TempAccessStep::Attr(field_info));
+      this->VisitAny(std::move(child_val));
+      this->PopStep();
+    });
+
+    // Leaf-with-prefix-match: this node contributed a match step, but no
+    // inner result was recorded from its subtree. Record the current node's
+    // path as the best-effort prefix. path_steps_ reflects the path TO this
+    // node (the step leading here was pushed by our caller), so
+    // MaterializeAccessPath() yields the correct prefix path.
+    // Skip when path_steps_ is empty — AccessPath::Root() gives no useful info.
+    if (allow_prefix_match_ && num_pattern_step_matched_ > 0 &&
+        num_pattern_step_matched_ < context_->reverse_visit_pattern.size() &&
+        !path_steps_.empty() && results_.size() == results_before) {
+      results_.push_back(this->MaterializeAccessPath());
+    }
+  }
+
+  template <typename SeqType>
+  void VisitSequence(SeqType seq) {
+    for (size_t i = 0; i < seq.size(); ++i) {
+      Any item = seq[i];
+      if (item == nullptr) continue;
+      this->PushStep(TempAccessStep::ArrayItem(static_cast<int64_t>(i)));
+      this->VisitAny(std::move(item));
+      this->PopStep();
+    }
+  }
+
+  template <typename MapType>
+  void VisitMap(const MapType& m) {
+    for (const std::pair<Any, Any>& kv : m) {
+      if (kv.first == nullptr || kv.second == nullptr) continue;
+      this->PushStep(TempAccessStep::MapItem(kv.first));
+      this->VisitAny(kv.second);
+      this->PopStep();
+    }
+  }
+
+  /*! \brief Append a TempAccessStep to the descent stack; cache unchanged. */
+  void PushStep(TempAccessStep step) { path_steps_.push_back(std::move(step)); }
+
+  /*! \brief Pop the top TempAccessStep; truncate materialized_paths_ to match. */
+  void PopStep() {
+    path_steps_.pop_back();
+    if (materialized_paths_.size() > path_steps_.size()) {
+      materialized_paths_.erase(materialized_paths_.begin() + path_steps_.size(),
+                                materialized_paths_.end());
+    }
+  }
+
+  // Cache invariant maintained jointly with PushStep / PopStep:
+  //   materialized_paths_[k] (when present) is the AccessPath built
+  //   from path_steps_[0..k+1] as they currently exist, and
+  //   materialized_paths_.size() <= path_steps_.size().
+  //
+  // - PushStep:              appends to path_steps_; cache unchanged.
+  // - PopStep:               pops path_steps_; truncates cache to match.
+  // - MaterializeAccessPath: extends cache up to path_steps_.size(),
+  //                          chaining new AccessPath nodes via Extend.
+  //
+  // Lazy materialization avoids per-descent AccessPath allocation;
+  // cache amortizes across consecutive matches with shared prefix
+  // (LCA sharing).
+  /*! \brief Materialize the AccessPath at the current descent depth. */
+  reflection::AccessPath MaterializeAccessPath() {
+    for (size_t idx = materialized_paths_.size(); idx < path_steps_.size(); ++idx) {
+      reflection::AccessPath parent =
+          (idx == 0) ? reflection::AccessPath::Root() : materialized_paths_[idx - 1];
+      materialized_paths_.push_back(parent->Extend(path_steps_[idx].ToAccessStep()));
+    }
+    return materialized_paths_.back();
+  }
+
+  // The structural error context whose pattern we're matching against.
+  StructuralErrorContext context_;
+  // When true, record prefix matches at leaves (partial pattern match).
+  bool allow_prefix_match_;
+  // Count of pattern entries matched so far (root-closest first). Incremented on
+  // match, decremented on unwind; full match when equal to pattern size.
+  size_t num_pattern_step_matched_;
+  // Current descent path — entries pushed on field/index/key descent, popped on unwind.
+  std::vector<TempAccessStep> path_steps_;
+  // Lazy cache of materialized AccessPath nodes, parallel to path_steps_.
+  // materialized_paths_[k] corresponds to path_steps_[0..k+1] as they currently
+  // stand. Extended on match; truncated by PopStep. size <= path_steps_.size().
+  std::vector<reflection::AccessPath> materialized_paths_;
+  // Recorded full-match paths.
+  std::vector<reflection::AccessPath> results_;
+};
+
+// ---------------------------------------------------------------------------
+// StructuralErrorContext::FindAccessPaths
+// ---------------------------------------------------------------------------
+
+Array<reflection::AccessPath> StructuralErrorContext::FindAccessPaths(
+    const ObjectRef& root, const StructuralErrorContext& structural_context,
+    bool allow_prefix_match) {
+  StructuralErrorAccessPathFinder finder(structural_context, allow_prefix_match);
+  return finder.Find(root);
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  refl::ObjectDef<StructuralErrorContextObj>()
+      .def_ro("reverse_visit_pattern", &StructuralErrorContextObj::reverse_visit_pattern)
+      .def_ro("previous_error_context", &StructuralErrorContextObj::previous_error_context);
+  // Register FindAccessPaths with the 3-arg signature (UpdateError takes Error& which is
+  // not supported by the packed function protocol).
+  refl::GlobalDef().def("ffi.StructuralErrorContext.FindAccessPaths",
+                        static_cast<Array<reflection::AccessPath> (*)(
+                            const ObjectRef&, const StructuralErrorContext&, bool)>(
+                            &StructuralErrorContext::FindAccessPaths));
+}
+
+}  // namespace ffi
+}  // namespace tvm

--- a/tests/cpp/extra/test_structural_error_context.cc
+++ b/tests/cpp/extra/test_structural_error_context.cc
@@ -1,0 +1,517 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <gtest/gtest.h>
+#include <tvm/ffi/container/array.h>
+#include <tvm/ffi/container/map.h>
+#include <tvm/ffi/error.h>
+#include <tvm/ffi/extra/structural_equal.h>
+#include <tvm/ffi/extra/structural_error_context.h>
+#include <tvm/ffi/object.h>
+#include <tvm/ffi/reflection/access_path.h>
+#include <tvm/ffi/reflection/registry.h>
+#include <tvm/ffi/string.h>
+
+namespace {
+
+using namespace tvm::ffi;
+namespace refl = tvm::ffi::reflection;
+
+// ---------------------------------------------------------------------------
+// Test fixture: TPair — a minimal two-field Object with lhs and rhs slots.
+//
+// Covers kAttr AccessKind via its named fields.
+// Array<ObjectRef> and Map<Any, Any> are used alongside TPair in individual
+// tests to cover kArrayItem and kMapItem.
+// ---------------------------------------------------------------------------
+
+class TPair : public Object {
+ public:
+  ObjectRef lhs;
+  ObjectRef rhs;
+
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("test.TPair", TPair, Object);
+};
+
+class TPairRef : public ObjectRef {
+ public:
+  TPairRef(ObjectRef lhs, ObjectRef rhs) {
+    ObjectPtr<TPair> n = make_object<TPair>();
+    n->lhs = std::move(lhs);
+    n->rhs = std::move(rhs);
+    data_ = std::move(n);
+  }
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(TPairRef, ObjectRef, TPair);
+};
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace r = tvm::ffi::reflection;
+  r::ObjectDef<TPair>().def_ro("lhs", &TPair::lhs).def_ro("rhs", &TPair::rhs);
+}
+
+// ---------------------------------------------------------------------------
+// Helper: Visit — recursively walks a tree and throws when it reaches
+// throw_target, wrapping each recursion level with the structural visit
+// macros so the error chain accumulates on unwind.
+// ---------------------------------------------------------------------------
+
+void Visit(ObjectRef node, ObjectRef throw_target);
+
+void Visit(ObjectRef node, ObjectRef throw_target) {
+  TVM_FFI_STRUCTURAL_VISIT_BEGIN();
+
+  if (node.same_as(throw_target)) {
+    TVM_FFI_THROW(ValueError) << "boom";
+  } else if (Optional<TPairRef> pair = node.as<TPairRef>()) {
+    Visit((*pair)->lhs, throw_target);
+    Visit((*pair)->rhs, throw_target);
+  } else if (Optional<Array<ObjectRef>> arr = node.as<Array<ObjectRef>>()) {
+    for (const ObjectRef& child : *arr) {
+      Visit(child, throw_target);
+    }
+  } else if (Optional<Map<Any, Any>> m = node.as<Map<Any, Any>>()) {
+    for (const std::pair<Any, Any>& kv : *m) {
+      Visit(kv.second.cast<ObjectRef>(), throw_target);
+    }
+  }
+
+  TVM_FFI_STRUCTURAL_VISIT_END(node);
+}
+
+// ===========================================================================
+// Layer A — Macro → Chain
+//
+// Verify that TVM_FFI_STRUCTURAL_VISIT_BEGIN/_END correctly builds the
+// reverse_visit_pattern as an exception unwinds through visit levels.
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// MacroBuildsChain: throw deep in a two-level visit; confirm the chain
+// records nodes in innermost-first order (throw site first, root last).
+// ---------------------------------------------------------------------------
+
+TEST(StructuralErrorContext, MacroBuildsChain) {
+  // Tree: root = (lhs=leaf, rhs=empty)
+  // Visiting root -> descends into leaf -> throws.
+  Array<ObjectRef> empty;
+  TPairRef leaf(empty, empty);
+  TPairRef root(leaf, empty);
+
+  Error caught("RuntimeError", "", "");
+  bool did_catch = false;
+  try {
+    Visit(root, leaf);
+  } catch (Error& err) {
+    caught = err;
+    did_catch = true;
+  }
+
+  EXPECT_TRUE(did_catch);
+
+  Optional<StructuralErrorContext> sec = StructuralErrorContext::TryGetFromError(caught);
+  ASSERT_TRUE(sec.has_value());
+
+  // reverse_visit_pattern is innermost-first: leaf pushed first (inner catch
+  // fires first during unwind), root pushed last.
+  const Array<ObjectRef>& chain = (*sec)->reverse_visit_pattern;
+  EXPECT_GE(chain.size(), 2u);
+  // Innermost entry is leaf (the throw site).
+  EXPECT_TRUE(chain[0].same_as(leaf));
+  // Outermost entry is root.
+  EXPECT_TRUE(chain[chain.size() - 1].same_as(root));
+
+  // Verify order structurally: [leaf, ..., root].
+  Array<ObjectRef> expected_chain = {leaf, root};
+  EXPECT_TRUE(StructuralEqual::Equal(expected_chain, chain));
+}
+
+// ---------------------------------------------------------------------------
+// MacroPreExistingPayloadWrap: when UpdateStructuralErrorContext is called on
+// an error that already has a non-context extra_context payload, the existing
+// payload is stashed in previous_error_context and the visit chain starts
+// fresh.  Subsequent pushes append to the same context object; previous_error_context
+// is not modified.
+// ---------------------------------------------------------------------------
+
+TEST(StructuralErrorContext, MacroPreExistingPayloadWrap) {
+  // Stand-in for a pre-existing extra_context payload.
+  Array<ObjectRef> empty;
+  TPairRef existing_payload(empty, empty);
+  TPairRef leaf(empty, empty);
+  TPairRef root(leaf, empty);
+
+  // Construct an error that already carries a non-context extra_context payload.
+  Error err("RuntimeError", "test", "", std::nullopt, std::optional<ObjectRef>(existing_payload));
+  ASSERT_TRUE(err.extra_context().has_value());
+
+  // First push: existing payload is not a StructuralErrorContext → wrapped.
+  tvm::ffi::details::UpdateStructuralErrorContext(err, leaf);
+
+  Optional<StructuralErrorContext> sec = StructuralErrorContext::TryGetFromError(err);
+  ASSERT_TRUE(sec.has_value());
+  ASSERT_EQ((*sec)->reverse_visit_pattern.size(), 1u);
+  EXPECT_TRUE((*sec)->reverse_visit_pattern[0].same_as(leaf));
+  ASSERT_TRUE((*sec)->previous_error_context.has_value());
+  EXPECT_TRUE((*(*sec)->previous_error_context).same_as(existing_payload));
+
+  // Second push: context already exists → node appended; previous_error_context unchanged.
+  tvm::ffi::details::UpdateStructuralErrorContext(err, root);
+
+  Optional<StructuralErrorContext> sec2 = StructuralErrorContext::TryGetFromError(err);
+  ASSERT_TRUE(sec2.has_value());
+
+  Array<ObjectRef> expected_chain = {leaf, root};
+  EXPECT_TRUE(StructuralEqual::Equal(expected_chain, (*sec2)->reverse_visit_pattern));
+
+  ASSERT_TRUE((*sec2)->previous_error_context.has_value());
+  EXPECT_TRUE((*(*sec2)->previous_error_context).same_as(existing_payload));
+}
+
+// ===========================================================================
+// Layer B — Chain → AccessPaths
+//
+// Verify that FindAccessPaths(root, ctx) resolves a manually-constructed
+// StructuralErrorContext against a tree, producing AccessPaths that describe
+// where matched nodes live in the tree.
+//
+// Each test:
+//   1. Builds a root tree.
+//   2. Constructs a StructuralErrorContext with a specific reverse_visit_pattern.
+//   3. Calls FindAccessPaths(root, ctx).
+//   4. Asserts on the result using StructuralEqual::Equal on AccessPath
+//      (mirrors the pattern used in test_structural_equal_hash.cc).
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// BasicMatch: unambiguous single-node path via two Attr steps; and CSE
+// multi-match when the same pointer appears in two sibling slots.
+//
+// Sub-scenario A — SingleMatch:
+//   Tree: root.lhs = mid, mid.lhs = leaf
+//   Pattern: [leaf, mid, root]  (innermost-first)
+//   Expected path: Root->Attr("lhs")->Attr("lhs")
+//
+// Sub-scenario B — CSEMultiMatch:
+//   Tree: root.lhs = shared, root.rhs = shared  (identical pointer)
+//   Pattern: [shared, root]
+//   Expected: two paths, one for each slot (Attr("lhs") and Attr("rhs")).
+// ---------------------------------------------------------------------------
+
+TEST(FindAccessPaths, BasicMatch) {
+  Array<ObjectRef> empty;
+
+  // Sub-scenario A: single unambiguous path.
+  {
+    TPairRef leaf(empty, empty);
+    TPairRef mid(leaf, empty);
+    TPairRef root(mid, empty);
+
+    ObjectPtr<StructuralErrorContextObj> ctx_obj = make_object<StructuralErrorContextObj>();
+    ctx_obj->reverse_visit_pattern = Array<ObjectRef>{leaf, mid, root};
+    StructuralErrorContext ctx(std::move(ctx_obj));
+
+    Array<refl::AccessPath> paths = StructuralErrorContext::FindAccessPaths(root, ctx);
+    ASSERT_EQ(paths.size(), 1u);
+
+    refl::AccessPath expected = refl::AccessPath::Root()->Attr("lhs")->Attr("lhs");
+    EXPECT_TRUE(StructuralEqual::Equal(expected, paths[0]));
+  }
+
+  // Sub-scenario B: same pointer in two slots → two paths.
+  {
+    TPairRef shared(empty, empty);
+    TPairRef root(shared, shared);
+
+    ObjectPtr<StructuralErrorContextObj> ctx_obj = make_object<StructuralErrorContextObj>();
+    ctx_obj->reverse_visit_pattern = Array<ObjectRef>{shared, root};
+    StructuralErrorContext ctx(std::move(ctx_obj));
+
+    Array<refl::AccessPath> paths = StructuralErrorContext::FindAccessPaths(root, ctx);
+    ASSERT_EQ(paths.size(), 2u);
+
+    refl::AccessPath expected_lhs = refl::AccessPath::Root()->Attr("lhs");
+    refl::AccessPath expected_rhs = refl::AccessPath::Root()->Attr("rhs");
+    bool found_lhs = false;
+    bool found_rhs = false;
+    for (const refl::AccessPath& p : paths) {
+      if (StructuralEqual::Equal(p, expected_lhs)) found_lhs = true;
+      if (StructuralEqual::Equal(p, expected_rhs)) found_rhs = true;
+    }
+    EXPECT_TRUE(found_lhs);
+    EXPECT_TRUE(found_rhs);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AccessKindCoverage: exercises Attr (TPair fields), ArrayItem
+// (Array<ObjectRef>), and MapItem (Map<Any, Any>) access kinds.
+//
+// Sub-scenario A — Attr (kAttr):
+//   Tree: root.lhs = mid, mid.lhs = leaf
+//   Pattern: [leaf, root]
+//   Expected path: Root->Attr("lhs")->Attr("lhs")
+//
+// Sub-scenario B — ArrayItem (kArrayItem):
+//   Tree: root.lhs = [leaf1, leaf2]  (Array in ObjectRef slot)
+//   Pattern: [leaf1, root]
+//   Expected path: Root->Attr("lhs")->ArrayItem(0)
+//
+// Sub-scenario C — MapItem (kMapItem):
+//   Tree: root.lhs = {"key" -> target}  (Map in ObjectRef slot)
+//   Pattern: [target, root]
+//   Expected path: Root->Attr("lhs")->MapItem("key")
+// ---------------------------------------------------------------------------
+
+TEST(FindAccessPaths, AccessKindCoverage) {
+  Array<ObjectRef> empty;
+
+  // Sub-scenario A: Attr steps.
+  {
+    TPairRef leaf(empty, empty);
+    TPairRef mid(leaf, empty);
+    TPairRef root(mid, empty);
+
+    ObjectPtr<StructuralErrorContextObj> ctx_obj = make_object<StructuralErrorContextObj>();
+    ctx_obj->reverse_visit_pattern = Array<ObjectRef>{leaf, root};
+    StructuralErrorContext ctx(std::move(ctx_obj));
+
+    Array<refl::AccessPath> paths = StructuralErrorContext::FindAccessPaths(root, ctx);
+    ASSERT_EQ(paths.size(), 1u);
+
+    refl::AccessPath expected = refl::AccessPath::Root()->Attr("lhs")->Attr("lhs");
+    EXPECT_TRUE(StructuralEqual::Equal(expected, paths[0]));
+  }
+
+  // Sub-scenario B: ArrayItem step.
+  {
+    TPairRef leaf1(empty, empty);
+    TPairRef leaf2(empty, empty);
+    Array<ObjectRef> arr = {leaf1, leaf2};
+    TPairRef root(arr, empty);
+
+    ObjectPtr<StructuralErrorContextObj> ctx_obj = make_object<StructuralErrorContextObj>();
+    ctx_obj->reverse_visit_pattern = Array<ObjectRef>{leaf1, root};
+    StructuralErrorContext ctx(std::move(ctx_obj));
+
+    Array<refl::AccessPath> paths = StructuralErrorContext::FindAccessPaths(root, ctx);
+    ASSERT_EQ(paths.size(), 1u);
+
+    refl::AccessPath expected = refl::AccessPath::Root()->Attr("lhs")->ArrayItem(0);
+    EXPECT_TRUE(StructuralEqual::Equal(expected, paths[0]));
+  }
+
+  // Sub-scenario C: MapItem step.
+  {
+    TPairRef target(empty, empty);
+    Map<Any, Any> m;
+    m.Set(String("key"), target);
+    TPairRef root(m, empty);
+
+    ObjectPtr<StructuralErrorContextObj> ctx_obj = make_object<StructuralErrorContextObj>();
+    ctx_obj->reverse_visit_pattern = Array<ObjectRef>{target, root};
+    StructuralErrorContext ctx(std::move(ctx_obj));
+
+    Array<refl::AccessPath> paths = StructuralErrorContext::FindAccessPaths(root, ctx);
+    ASSERT_EQ(paths.size(), 1u);
+
+    refl::AccessPath expected = refl::AccessPath::Root()->Attr("lhs")->MapItem(String("key"));
+    EXPECT_TRUE(StructuralEqual::Equal(expected, paths[0]));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SparsePatternAnchors: demonstrates that intermediate breadcrumb anchors in
+// the pattern disambiguate when an innermost target appears in multiple branches.
+//
+// Tree layout:
+//   root
+//   ├─ branch_a: tpa → m_inner_a   (m_inner shared, no m_outer ancestor)
+//   └─ branch_b: tpb → m_outer → tpc → m_inner_b  (same m_inner pointer)
+//
+// m_inner is a POINTER-IDENTICAL ObjectRef (ref-count shared) used as both
+// m_inner_a (under branch_a) and m_inner_b (under branch_b via m_outer).
+// m_outer appears only under branch_b.
+//
+// Scenario 1: pattern with only innermost — 2 candidate paths.
+//   Pattern: [m_inner, root]
+//   Expected: paths.size() == 2
+//
+// Scenario 2: anchor narrows to branch_b only.
+//   Pattern: [m_inner, m_outer, root]
+//   Expected: paths.size() == 1, path through branch_b
+// ---------------------------------------------------------------------------
+
+TEST(FindAccessPaths, SparsePatternAnchors) {
+  Array<ObjectRef> empty;
+
+  // Shared inner node — identical pointer in both branches.
+  TPairRef m_inner(empty, empty);
+
+  // branch_a: tpa.lhs = m_inner (no m_outer ancestor)
+  TPairRef tpa(m_inner, empty);
+
+  // branch_b: tpb.lhs = m_outer, m_outer.lhs = tpc, tpc.lhs = m_inner
+  TPairRef tpc(m_inner, empty);
+  TPairRef m_outer(tpc, empty);
+  TPairRef tpb(m_outer, empty);
+
+  // root: lhs = tpa (branch_a), rhs = tpb (branch_b)
+  TPairRef root(tpa, tpb);
+
+  // Scenario 1: pattern = [m_inner, root] → 2 paths (one per branch).
+  {
+    ObjectPtr<StructuralErrorContextObj> ctx_obj = make_object<StructuralErrorContextObj>();
+    ctx_obj->reverse_visit_pattern = Array<ObjectRef>{m_inner, root};
+    StructuralErrorContext ctx(std::move(ctx_obj));
+
+    Array<refl::AccessPath> paths = StructuralErrorContext::FindAccessPaths(root, ctx);
+    EXPECT_EQ(paths.size(), 2u);
+  }
+
+  // Scenario 2: pattern = [m_inner, m_outer, root] → 1 path through branch_b.
+  {
+    ObjectPtr<StructuralErrorContextObj> ctx_obj = make_object<StructuralErrorContextObj>();
+    ctx_obj->reverse_visit_pattern = Array<ObjectRef>{m_inner, m_outer, root};
+    StructuralErrorContext ctx(std::move(ctx_obj));
+
+    Array<refl::AccessPath> paths = StructuralErrorContext::FindAccessPaths(root, ctx);
+    ASSERT_EQ(paths.size(), 1u);
+
+    // Path must go through branch_b (rhs), then m_outer (lhs), then tpc (lhs), then m_inner (lhs).
+    refl::AccessPath expected =
+        refl::AccessPath::Root()->Attr("rhs")->Attr("lhs")->Attr("lhs")->Attr("lhs");
+    EXPECT_TRUE(StructuralEqual::Equal(expected, paths[0]));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PartialChain: strict mode returns nothing when the innermost pattern entry
+// is unreachable; prefix-match mode returns the deepest matched prefix path.
+//
+// Sub-scenario A — strict (allow_prefix_match=false):
+//   Pattern: [unreachable, child, root]
+//   Expected: 0 results (unreachable breaks full match)
+//
+// Sub-scenario B — prefix match (allow_prefix_match=true):
+//   Same pattern, same tree.
+//   Expected: at least one result at the path to child (Root->Attr("lhs")).
+// ---------------------------------------------------------------------------
+
+TEST(FindAccessPaths, PartialChain) {
+  Array<ObjectRef> empty;
+  // unreachable is not present anywhere in the tree below root.
+  TPairRef unreachable(empty, empty);
+  TPairRef child(empty, empty);
+  TPairRef root(child, empty);
+
+  ObjectPtr<StructuralErrorContextObj> ctx_obj = make_object<StructuralErrorContextObj>();
+  ctx_obj->reverse_visit_pattern = Array<ObjectRef>{unreachable, child, root};
+  StructuralErrorContext ctx(std::move(ctx_obj));
+
+  // Sub-scenario A: strict mode — no full match.
+  {
+    Array<refl::AccessPath> paths = StructuralErrorContext::FindAccessPaths(root, ctx);
+    EXPECT_EQ(paths.size(), 0u);
+  }
+
+  // Sub-scenario B: prefix-match mode — path to child reported.
+  {
+    Array<refl::AccessPath> paths =
+        StructuralErrorContext::FindAccessPaths(root, ctx, /*allow_prefix_match=*/true);
+    ASSERT_GE(paths.size(), 1u);
+
+    refl::AccessPath expected = refl::AccessPath::Root()->Attr("lhs");
+    bool found_expected = false;
+    for (const refl::AccessPath& p : paths) {
+      if (StructuralEqual::Equal(p, expected)) {
+        found_expected = true;
+        break;
+      }
+    }
+    EXPECT_TRUE(found_expected);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// EdgeCases: empty pattern produces no results; null entries in the pattern
+// never match any live node and do not crash.
+// ---------------------------------------------------------------------------
+
+TEST(FindAccessPaths, EdgeCases) {
+  Array<ObjectRef> empty;
+
+  // Sub-scenario A: empty pattern.
+  {
+    TPairRef root(empty, empty);
+
+    ObjectPtr<StructuralErrorContextObj> ctx_obj = make_object<StructuralErrorContextObj>();
+    // reverse_visit_pattern left empty.
+    StructuralErrorContext ctx(std::move(ctx_obj));
+
+    Array<refl::AccessPath> paths = StructuralErrorContext::FindAccessPaths(root, ctx);
+    EXPECT_EQ(paths.size(), 0u);
+  }
+
+  // Sub-scenario B: null entries in pattern.
+  {
+    TPairRef root(empty, empty);
+
+    ObjectPtr<StructuralErrorContextObj> ctx_obj = make_object<StructuralErrorContextObj>();
+    ObjectRef null_ref;
+    ctx_obj->reverse_visit_pattern = Array<ObjectRef>{null_ref, null_ref};
+    StructuralErrorContext ctx(std::move(ctx_obj));
+
+    Array<refl::AccessPath> paths;
+    ASSERT_NO_THROW({ paths = StructuralErrorContext::FindAccessPaths(root, ctx); });
+    EXPECT_EQ(paths.size(), 0u);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// TryGetFromError: returns NullOpt when absent, the context when present.
+// Composes correctly with FindAccessPaths.
+// ---------------------------------------------------------------------------
+
+TEST(StructuralErrorContext, TryGetFromError) {
+  Array<ObjectRef> empty;
+  TPairRef leaf(empty, empty);
+  TPairRef root(leaf, empty);
+
+  Error err("RuntimeError", "test", "");
+
+  // No context attached → TryGetFromError returns NullOpt.
+  Optional<StructuralErrorContext> no_sec = StructuralErrorContext::TryGetFromError(err);
+  EXPECT_FALSE(no_sec.has_value());
+
+  // Attach context via UpdateStructuralErrorContext.
+  tvm::ffi::details::UpdateStructuralErrorContext(err, leaf);
+  tvm::ffi::details::UpdateStructuralErrorContext(err, root);
+
+  Optional<StructuralErrorContext> sec = StructuralErrorContext::TryGetFromError(err);
+  ASSERT_TRUE(sec.has_value());
+
+  // Compose TryGetFromError + FindAccessPaths → should resolve to root.lhs.
+  Array<refl::AccessPath> paths = StructuralErrorContext::FindAccessPaths(root, *sec);
+  ASSERT_EQ(paths.size(), 1u);
+
+  refl::AccessPath expected = refl::AccessPath::Root()->Attr("lhs");
+  EXPECT_TRUE(StructuralEqual::Equal(expected, paths[0]));
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

When code throws while recursively visiting an Object tree, the resulting error message lacks position context — the user sees what went wrong but not WHERE in the tree. This change adds a typed payload to attach the visit chain to `Error` and resolve it to a structured access path.

## API

- **`StructuralErrorContext`** — typed payload in `tvm/ffi/extra/`, holding a `reverse_visit_pattern` (innermost-first breadcrumb trail) and an optional `previous_error_context` (preserved when wrapping a pre-existing payload in `extra_context`).

- **`TVM_FFI_STRUCTURAL_VISIT_BEGIN()` / `TVM_FFI_STRUCTURAL_VISIT_END(node)`** macros instrument visit dispatch. On throw, they populate the `StructuralErrorContext` attached to the in-flight Error.

- **`StructuralErrorContext::FindAccessPaths(root, ctx, allow_prefix_match=false)`** walks `root` via reflection and returns `Array<reflection::AccessPath>` for matched positions. Strict full-match default; opt-in `allow_prefix_match=true` for best-effort partial reporting.

- **`StructuralErrorContext::TryGetFromError(err)`** inline helper fetches the payload from an Error.

## ABI

**No ABI changes.** No modifications to `c_api.h` or `error.h` (existing `Error::extra_context` slot is reused; direct refcount-aware assignment via existing `ObjectUnsafe` patterns).

## Test plan

- [x] Layer A — macro-builds-chain: \`MacroBuildsChain\`, \`MacroPreExistingPayloadWrap\`
- [x] Layer B — \`FindAccessPaths\` correctness: \`BasicMatch\`, \`AccessKindCoverage\`, \`SparsePatternAnchors\`, \`PartialChain\`, \`EdgeCases\`
- [x] \`StructuralErrorContext.TryGetFromError\` helper
- [x] All 363 existing C++ tests pass + 8 new tests = 371 total (2 pre-existing disabled, unrelated)
- [x] All 2301 Python tests pass
- [x] Pre-commit clean (27 hooks)