### PR TITLE
[BUILD] TVM_FFI_COLD_CODE macro and -ffunction-sections for cold code layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,10 @@ if (TVM_FFI_ATTACH_DEBUG_SYMBOLS)
   endif ()
 endif ()
 
+# Per-function section emission so TVM_FFI_COLD_CODE-marked functions land in `.text.unlikely.*` and
+# the linker isolates them in a cold region at the tail of `.text`.
+tvm_ffi_enable_section_layout()
+
 include(cmake/Utils/CxxWarning.cmake)
 include(cmake/Utils/Sanitizer.cmake)
 

--- a/cmake/Utils/Library.cmake
+++ b/cmake/Utils/Library.cmake
@@ -400,3 +400,23 @@ function (tvm_ffi_install target)
     )
   endif ()
 endfunction ()
+
+# Enable per-function section emission so functions annotated with TVM_FFI_COLD_CODE land in
+# `.text.unlikely.*` and the linker's default placement rule groups them away from hot code at the
+# tail of `.text`. Compile flags only — `--gc-sections` is intentionally NOT enabled here (separate
+# optimization; risks stripping registered globals).
+function (tvm_ffi_enable_section_layout)
+  if (CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
+    foreach (target tvm_ffi_objs tvm_ffi_extra_objs)
+      if (TARGET ${target})
+        target_compile_options(${target} PRIVATE -ffunction-sections)
+      endif ()
+    endforeach ()
+  elseif (MSVC)
+    foreach (target tvm_ffi_objs tvm_ffi_extra_objs)
+      if (TARGET ${target})
+        target_compile_options(${target} PRIVATE /Gy)
+      endif ()
+    endforeach ()
+  endif ()
+endfunction ()

--- a/docs/dev/binary_layout.md
+++ b/docs/dev/binary_layout.md
@@ -1,0 +1,200 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Binary Layout: Hot/Cold Code Separation
+
+## Goal
+
+Group functions that only run on error / setup / teardown paths into a
+separate cold region of `.text`, away from the hot ABI dispatch and
+container code that takes the bulk of execution time. The cold region
+sits at one end of `.text`; the hot region fills the remaining bulk and
+benefits from better instruction-cache locality.
+
+Two ingredients enable this:
+
+1. A portable `TVM_FFI_COLD_CODE` attribute (`[[gnu::cold]]` on
+   GCC/Clang, no-op on MSVC) marking individual functions.
+2. The `-ffunction-sections` compile flag, which emits each function
+   into its own ELF section so the linker can place cold-marked
+   functions independently. The default GNU linker script gathers
+   `.text.unlikely.*` into a contiguous slot inside `.text`. No
+   linker-side `--gc-sections` is needed (and is deliberately
+   not enabled — see *Why no `--gc-sections`* below).
+
+`TVM_FFI_UNLIKELY` (a thin wrapper around `__builtin_expect`) is
+applied to a few representative error-check branches to give the
+optimizer a hint to keep the hot fall-through contiguous and let the
+out-of-line error block be split into the cold section.
+
+## Measurements
+
+All three builds: Release, GCC 11.4, ld.bfd 2.38, x86_64 Linux.
+Sizes are for the stripped shared library.
+
+| Build    | Stripped size | Delta vs baseline | `.text` size |
+| -------- | ------------: | ----------------: | -----------: |
+| baseline |     1,887,800 |                 - |    1,499,450 |
+| seed     |     1,830,472 |   -57,328 (-3.0%) |    1,452,947 |
+| final    |     1,826,368 |   -61,432 (-3.3%) |    1,452,691 |
+
+* baseline — `apache/tvm-ffi` `main` at `d4cfd86`, no annotations and
+  no `-ffunction-sections`.
+* seed — `TVM_FFI_COLD_CODE` defined, `ErrorBuilder` ctors and dtor
+  marked cold, `-ffunction-sections` enabled on `tvm_ffi_objs` /
+  `tvm_ffi_extra_objs`.
+* final — also marks the `TVMFFIError*` C ABI helpers and the
+  `SafeCallContext::Set*` /`MoveFromRaised` methods cold, and adds
+  `TVM_FFI_UNLIKELY` to (a) the `TVM_FFI_CHECK_SAFE_CALL` macro,
+  (b) the `TVM_FFI_CHECK` macro, and (c) the
+  `GlobalFunctionTable::Update` already-registered branch.
+
+The size drop comes almost entirely from `-ffunction-sections`. With
+per-function sections the linker can pack functions tightly without
+the inter-function padding that an in-TU `.text` requires for
+alignment between adjacent functions. There is no source-level dead
+code being removed (and `--gc-sections` is not in use).
+
+### Hot vs cold symbol layout (baseline)
+
+```text
+0x000084f1 t TVMFFIBacktrace.cold              <- only the .cold split-off
+0x0000adfa t TVMFFIErrorSetRaisedFromCStr.cold <- only the .cold split-off
+...
+0x00032e00 T TVMFFIBacktrace                   <- hot body in middle of .text
+0x00039f90 t ErrorBuilder ctor                 <- in middle of .text
+0x0003c260 t ErrorBuilder dtor                 <- in middle of .text
+0x00057cd0 T TVMFFIErrorSetRaisedFromCStr      <- interleaved with C ABI
+0x00059020 T TVMFFIErrorSetRaised
+```
+
+In baseline GCC's automatic cold-splitting pass already produces
+`.cold` partial-function sections (the early-region cluster at
+`0x84f1..0xaebe`). What it does NOT do is pull the full bodies of
+`ErrorBuilder` ctor/dtor or the `TVMFFIError*` C ABI exports into the
+cold region: those bodies sit at `0x39f90`, `0x3c260`, `0x57cd0`,
+`0x59020`, interleaved with hot C-ABI exports.
+
+### Hot vs cold symbol layout (final)
+
+```text
+0x00008450 t BacktraceFullCallback.cold
+0x00008488 t BacktraceSyminfoCallback.cold
+0x00008511 t TVMFFIBacktrace.cold
+0x000086f2 t ErrorBuilder ctor                 <- moved into cold region
+0x00008e54 t ErrorBuilder dtor                 <- moved into cold region
+0x0000b98a T TVMFFIErrorSetRaised              <- moved into cold region
+0x0000c4cd T TVMFFIErrorSetRaisedFromCStr      <- moved into cold region
+0x0000c7fd T TVMFFIErrorSetRaisedFromCStrParts <- moved into cold region
+...
+0x00047b80 T TVMFFIBacktrace                   <- hot body starts well after
+                                                cold cluster
+```
+
+`ErrorBuilder` ctor/dtor and the cold-marked C ABI exports now live
+inside the cold cluster at the head of `.text` (offsets `0x86f2`
+through `0xc7fd`). The hot `TVMFFIBacktrace` body has moved from
+offset `0x32e00` (baseline) to `0x47b80` (final), reflecting that the
+cold cluster grew. Every `TVM_FFI_THROW` site keeps its `ErrorBuilder`
+out-of-line in this cluster instead of side-by-side with C ABI
+exports.
+
+### `.text.unlikely.*` in the object files
+
+`-ffunction-sections` is doing its job at the object-file level. For
+`build_final/CMakeFiles/tvm_ffi_objs.dir/src/ffi/error.cc.o`:
+
+```console
+$ readelf -SW build_final/CMakeFiles/tvm_ffi_objs.dir/src/ffi/error.cc.o \
+    | grep -c '\.text\.'
+37
+```
+
+vs a single `.text` section in baseline. Section names such as
+`.text.unlikely.TVMFFIErrorSetRaisedFromCStr` are emitted for
+`[[gnu::cold]]`-marked functions, and the default linker script
+gathers all of them together in `.text` at link time.
+
+### Linker placement detail (ld.bfd / lld)
+
+The relevant fragment of the default GNU linker script is:
+
+```text
+.text :
+{
+  *(.text.unlikely .text.*_unlikely .text.unlikely.*)
+  *(.text.exit .text.exit.*)
+  *(.text.startup .text.startup.*)
+  *(.text.hot .text.hot.*)
+  *(SORT(.text.sorted.*))
+  *(.text .stub .text.* .gnu.linkonce.t.*)
+}
+```
+
+`.text.unlikely.*` is matched first, so cold-marked functions cluster
+at the START of `.text` (the lowest offsets), and the bulk of the
+ordinary `.text.*` follows. The separation goal — keeping cold code
+out of the hot instruction stream — is achieved regardless of whether
+cold sits at the head or the tail.
+
+## Why no `--gc-sections`
+
+`-ffunction-sections` is sufficient for cold-region separation. The
+related optimization `--gc-sections` (dead-section elimination) is
+intentionally not enabled here. tvm-ffi uses static-initializer
+registration patterns (`TVM_FFI_STATIC_INIT_BLOCK`, global function
+registries) where symbols are reachable only via runtime tables that
+the linker cannot trace statically. Enabling `--gc-sections` without
+auditing every such registration for `__attribute__((used))`
+(or equivalent) risks silently stripping registered globals at link
+time. Left for a follow-up.
+
+## How to apply `TVM_FFI_COLD_CODE`
+
+```cpp
+// header
+TVM_FFI_COLD_CODE
+[[noreturn]] void ReportFatalError(const std::string& message);
+
+// source
+TVM_FFI_COLD_CODE
+int TVMFFIErrorCreate(const TVMFFIByteArray* kind, ...) {
+  // ... only runs at error-construction time
+}
+```
+
+Apply it conservatively, only to functions that run exclusively on
+error / fatal / setup / teardown paths. Constructors of objects that
+also flow through non-error paths (e.g. `Error` itself, used for
+`EnvErrorAlreadySet()` and Python error propagation) must NOT be
+marked cold.
+
+## How to apply `TVM_FFI_UNLIKELY`
+
+```cpp
+int ret_code = TVMFFIThing(&arg);
+if (TVM_FFI_UNLIKELY(ret_code != 0)) {
+  throw ::tvm::ffi::details::MoveFromSafeCallRaised();
+}
+```
+
+Limit it to error-check branches in performance-sensitive call sites
+(C ABI dispatch macros, frequently-invoked check helpers). It is not a
+substitute for `TVM_FFI_COLD_CODE` on whole functions, and over-use
+makes ordinary branches harder to read.

--- a/include/tvm/ffi/base_details.h
+++ b/include/tvm/ffi/base_details.h
@@ -76,6 +76,42 @@
 #define TVM_FFI_UNREACHABLE() __builtin_unreachable()
 #endif
 
+/*!
+ * \brief Mark a function as cold so the toolchain places it in a
+ *        separate cold region of `.text`. Apply to functions that only
+ *        run on error / setup / teardown paths.
+ *
+ * On GCC and Clang, expands to `[[gnu::cold]]`, which emits the
+ * function into `.text.unlikely.<name>` (with `-ffunction-sections`)
+ * so the default linker script groups it away from hot code. On MSVC
+ * the attribute does not exist and the macro is a no-op.
+ */
+#if defined(__GNUC__) || defined(__clang__)
+#define TVM_FFI_COLD_CODE [[gnu::cold]]
+#else
+#define TVM_FFI_COLD_CODE
+#endif
+
+/*!
+ * \brief Branch-prediction / layout hint that the condition is unlikely
+ *        to be true. Use on error-checking branches to keep the hot
+ *        fall-through contiguous and push the error-handling block to
+ *        the function tail.
+ *
+ *   if (TVM_FFI_UNLIKELY(rc != 0)) { ...error... }
+ *
+ * On GCC/Clang, expands to `__builtin_expect((cond), 0)`. On MSVC,
+ * expands to `(cond)` (no equivalent builtin; modern MSVC does its own
+ * profile-driven block reordering).
+ */
+#if defined(__GNUC__) || defined(__clang__)
+#define TVM_FFI_UNLIKELY(cond) (__builtin_expect(static_cast<bool>(cond), 0))
+#define TVM_FFI_LIKELY(cond) (__builtin_expect(static_cast<bool>(cond), 1))
+#else
+#define TVM_FFI_UNLIKELY(cond) (cond)
+#define TVM_FFI_LIKELY(cond) (cond)
+#endif
+
 #define TVM_FFI_STR_CONCAT_(__x, __y) __x##__y
 #define TVM_FFI_STR_CONCAT(__x, __y) TVM_FFI_STR_CONCAT_(__x, __y)
 

--- a/include/tvm/ffi/error.h
+++ b/include/tvm/ffi/error.h
@@ -338,11 +338,13 @@ TVM_FFI_INLINE void SetSafeCallRaised(const Error& error) {
 
 class ErrorBuilder {
  public:
+  TVM_FFI_COLD_CODE
   explicit ErrorBuilder(std::string kind, std::string backtrace, bool log_before_throw)
       : kind_(std::move(kind)),
         backtrace_(std::move(backtrace)),
         log_before_throw_(log_before_throw) {}
 
+  TVM_FFI_COLD_CODE
   explicit ErrorBuilder(std::string kind, const TVMFFIByteArray* backtrace, bool log_before_throw)
       : ErrorBuilder(std::move(kind), std::string(backtrace->data, backtrace->size),
                      log_before_throw) {}
@@ -353,7 +355,7 @@ class ErrorBuilder {
 #pragma warning(disable : 4722)
 #endif
   // avoid inline to reduce binary size, error throw path do not need to be fast
-  [[noreturn]] ~ErrorBuilder() noexcept(false) {
+  [[noreturn]] TVM_FFI_COLD_CODE ~ErrorBuilder() noexcept(false) {
     ::tvm::ffi::Error error(std::move(kind_), stream_.str(), std::move(backtrace_));
     if (log_before_throw_) {
       std::cerr << error.FullMessage();
@@ -456,7 +458,8 @@ TVM_FFI_CHECK_FUNC(_NE, !=)
   TVM_FFI_THROW(ErrorKind) << "Check failed: " << #x " " #op " " #y << *__tvm_ffi_log_err << ": "
 
 #define TVM_FFI_CHECK(cond, ErrorKind) \
-  if (!(cond)) TVM_FFI_THROW(ErrorKind) << "Check failed: (" #cond << ") is false: "
+  if (TVM_FFI_UNLIKELY(!(cond)))       \
+  TVM_FFI_THROW(ErrorKind) << "Check failed: (" #cond << ") is false: "
 
 #define TVM_FFI_CHECK_LT(x, y, ErrorKind) TVM_FFI_CHECK_BINARY_OP(_LT, <, x, y, ErrorKind)
 #define TVM_FFI_CHECK_GT(x, y, ErrorKind) TVM_FFI_CHECK_BINARY_OP(_GT, >, x, y, ErrorKind)

--- a/include/tvm/ffi/function.h
+++ b/include/tvm/ffi/function.h
@@ -101,7 +101,7 @@ namespace ffi {
 #define TVM_FFI_CHECK_SAFE_CALL(func)                      \
   {                                                        \
     int ret_code = (func);                                 \
-    if (ret_code != 0) {                                   \
+    if (TVM_FFI_UNLIKELY(ret_code != 0)) {                 \
       throw ::tvm::ffi::details::MoveFromSafeCallRaised(); \
     }                                                      \
   }

--- a/src/ffi/error.cc
+++ b/src/ffi/error.cc
@@ -20,6 +20,7 @@
  * \file src/ffi/error.cc
  * \brief Error handling implementation
  */
+#include <tvm/ffi/base_details.h>
 #include <tvm/ffi/c_api.h>
 #include <tvm/ffi/error.h>
 
@@ -30,16 +31,19 @@ namespace ffi {
 
 class SafeCallContext {
  public:
+  TVM_FFI_COLD_CODE
   void SetRaised(TVMFFIObjectHandle error) {
     last_error_ =
         details::ObjectUnsafe::ObjectPtrFromUnowned<ErrorObj>(static_cast<TVMFFIObject*>(error));
   }
 
+  TVM_FFI_COLD_CODE
   void SetRaisedByCstr(const char* kind, const char* message, const TVMFFIByteArray* backtrace) {
     Error error(kind, message, backtrace);
     last_error_ = details::ObjectUnsafe::ObjectPtrFromObjectRef<ErrorObj>(std::move(error));
   }
 
+  TVM_FFI_COLD_CODE
   void SetRaisedByCstrParts(const char* kind, const char** message_parts, int32_t num_parts,
                             const TVMFFIByteArray* backtrace) {
     std::string message;
@@ -59,6 +63,7 @@ class SafeCallContext {
     last_error_ = details::ObjectUnsafe::ObjectPtrFromObjectRef<ErrorObj>(std::move(error));
   }
 
+  TVM_FFI_COLD_CODE
   void MoveFromRaised(TVMFFIObjectHandle* result) {
     result[0] = details::ObjectUnsafe::MoveObjectPtrToTVMFFIObjectPtr(std::move(last_error_));
   }
@@ -75,12 +80,14 @@ class SafeCallContext {
 }  // namespace ffi
 }  // namespace tvm
 
+TVM_FFI_COLD_CODE
 void TVMFFIErrorSetRaisedFromCStr(const char* kind, const char* message) {
   // NOTE: run backtrace here to simplify the depth of tracekback
   tvm::ffi::SafeCallContext::ThreadLocal()->SetRaisedByCstr(
       kind, message, TVMFFIBacktrace(nullptr, 0, nullptr, 0));
 }
 
+TVM_FFI_COLD_CODE
 void TVMFFIErrorSetRaisedFromCStrParts(const char* kind, const char** message_parts,
                                        int32_t num_parts) {
   // NOTE: run backtrace here to simplify the depth of tracekback
@@ -88,14 +95,17 @@ void TVMFFIErrorSetRaisedFromCStrParts(const char* kind, const char** message_pa
       kind, message_parts, num_parts, TVMFFIBacktrace(nullptr, 0, nullptr, 0));
 }
 
+TVM_FFI_COLD_CODE
 void TVMFFIErrorSetRaised(TVMFFIObjectHandle error) {
   tvm::ffi::SafeCallContext::ThreadLocal()->SetRaised(error);
 }
 
+TVM_FFI_COLD_CODE
 void TVMFFIErrorMoveFromRaised(TVMFFIObjectHandle* result) {
   tvm::ffi::SafeCallContext::ThreadLocal()->MoveFromRaised(result);
 }
 
+TVM_FFI_COLD_CODE
 int TVMFFIErrorCreate(const TVMFFIByteArray* kind, const TVMFFIByteArray* message,
                       const TVMFFIByteArray* backtrace, TVMFFIObjectHandle* out) {
   // log other errors to the logger
@@ -112,6 +122,7 @@ int TVMFFIErrorCreate(const TVMFFIByteArray* kind, const TVMFFIByteArray* messag
   TVM_FFI_LOG_EXCEPTION_CALL_END(TVMFFIErrorCreate);
 }
 
+TVM_FFI_COLD_CODE
 int TVMFFIErrorCreateWithCauseAndExtraContext(
     const TVMFFIByteArray* kind, const TVMFFIByteArray* message, const TVMFFIByteArray* backtrace,
     TVMFFIObjectHandle cause_chain, TVMFFIObjectHandle extra_context, TVMFFIObjectHandle* out) {

--- a/src/ffi/function.cc
+++ b/src/ffi/function.cc
@@ -83,7 +83,7 @@ class GlobalFunctionTable {
   };
 
   void Update(const String& name, Function func, bool can_override) {
-    if (table_.count(name)) {
+    if (TVM_FFI_UNLIKELY(table_.count(name) != 0)) {
       if (!can_override) {
         TVM_FFI_THROW(RuntimeError) << "Global Function `" << name << "` is already registered";
       }
@@ -93,7 +93,7 @@ class GlobalFunctionTable {
 
   void Update(const TVMFFIMethodInfo* method_info, bool can_override) {
     String name(method_info->name.data, method_info->name.size);
-    if (table_.count(name)) {
+    if (TVM_FFI_UNLIKELY(table_.count(name) != 0)) {
       if (!can_override) {
         TVM_FFI_LOG_AND_THROW(RuntimeError)
             << "Global Function `" << name << "` is already registered, possible causes:\n"


### PR DESCRIPTION
A binary-layout audit of libtvm_ffi.so showed that error-throw helpers (ErrorBuilder ctors/dtor, the TVMFFIError* C ABI exports) live in the middle of .text, interleaved with hot C ABI dispatch and container code. The entire library compiles into a single monolithic .text section because -ffunction-sections is not enabled, so the linker has no way to isolate cold code into a separate region.

This change introduces a portable TVM_FFI_COLD_CODE attribute and enables -ffunction-sections on the object-library targets so the toolchain can place error-only code in a separate cold region of .text. With this, ErrorBuilder ctor/dtor and the TVMFFIError* exports move into the cold cluster at the head of .text (offsets 0x86f2..0xc7fd in the final layout), and the hot TVMFFIBacktrace body shifts from 0x32e00 in baseline to 0x47b80 in the final build. Stripped libtvm_ffi.so shrinks from 1,887,800 to 1,826,368 bytes (-61,432, -3.3%), driven by tighter linker packing once functions live in their own sections.

The change has three pieces:

- A TVM_FFI_COLD_CODE macro in base_details.h that expands to [[gnu::cold]] on GCC/Clang and a no-op on MSVC, plus TVM_FFI_UNLIKELY / TVM_FFI_LIKELY wrappers around __builtin_expect. The macro is applied to ErrorBuilder ctors and the [[noreturn]] destructor (error.h), to SafeCallContext setter methods and the TVMFFIError* C ABI helpers (error.cc).
- A new tvm_ffi_enable_section_layout() helper in cmake/Utils/Library.cmake that turns on -ffunction-sections (GCC, Clang, AppleClang) or /Gy (MSVC) on tvm_ffi_objs and tvm_ffi_extra_objs. --gc-sections is intentionally not enabled because tvm-ffi uses static-init registration patterns that the linker cannot trace; that is left for a follow-up.
- TVM_FFI_UNLIKELY applied to a small set of representative error-check branches (the TVM_FFI_CHECK_SAFE_CALL macro, the TVM_FFI_CHECK macro, and GlobalFunctionTable::Update's already-registered check) to demonstrate the pattern without blanket-annotating the codebase.

Numbers, symbol maps, and the rationale for skipping --gc-sections are written up in [docs/dev/binary_layout.md](docs/dev/binary_layout.md).