### PR TITLE
[POC][FIX] Zero cause_chain and extra_context in SafeCallContext to prevent SIGBUS on macOS arm64

### DIFF
--- a/src/ffi/error.cc
+++ b/src/ffi/error.cc
@@ -31,12 +31,25 @@ namespace ffi {
 class SafeCallContext {
  public:
   void SetRaised(TVMFFIObjectHandle error) {
+    // Explicitly zero cause_chain and extra_context before storing in TLS.
+    // On macOS arm64 the allocator may reuse memory that contains stale
+    // non-null bytes, which would cause ~ErrorObj() to call DecRefObjectHandle
+    // on a garbage pointer → SIGBUS (alignment fault).
+    auto* cell = TVMFFIErrorGetCellPtr(error);
+    cell->cause_chain = nullptr;
+    cell->extra_context = nullptr;
     last_error_ =
         details::ObjectUnsafe::ObjectPtrFromUnowned<ErrorObj>(static_cast<TVMFFIObject*>(error));
   }
 
   void SetRaisedByCstr(const char* kind, const char* message, const TVMFFIByteArray* backtrace) {
     Error error(kind, message, backtrace);
+    // Zero the newly created Error's cause_chain / extra_context as defensive
+    // measure (see comment in SetRaised above).
+    auto* cell = TVMFFIErrorGetCellPtr(
+        details::ObjectUnsafe::TVMFFIObjectPtrFromObjectRef(error));
+    cell->cause_chain = nullptr;
+    cell->extra_context = nullptr;
     last_error_ = details::ObjectUnsafe::ObjectPtrFromObjectRef<ErrorObj>(std::move(error));
   }
 


### PR DESCRIPTION
## Problem

On macOS arm64 with tvm-ffi >= 0.1.8, when a C++ exception (e.g. InternalError from LOG(FATAL)) is thrown inside a PackedFunc and forwarded through SafeCallContext::SetRaised / SetRaisedByCstr, the process crashes with SIGBUS during cleanup.

## Root Cause

SafeCallContext::SetRaised stores an ErrorObj via ObjectPtrFromUnowned. The cause_chain and extra_context fields (added in PR #396 / v0.1.8) may contain stale non-null bytes from reused allocator memory on macOS arm64. When ~ErrorObj() runs, it calls DecRefObjectHandle on these garbage pointer values, causing SIGBUS (EXC_ARM_DA_ALIGN).

Crash address 0x6c616e7265746e49 = ASCII "Internal" (first 8 bytes of "InternalError") being dereferenced as a pointer.

Crash trace:
  SimpleObjAllocator::Handler<ErrorObjFromStd>::Deleter_
  TVMFFIObjectDecRef
  dict_dealloc → BaseException_dealloc → subtype_dealloc

## Fix

Explicitly zero cause_chain and extra_context before storing the ErrorObj in TLS, ensuring ~ErrorObj() correctly sees nullptr and short-circuits the DecRefObjectHandle calls.

## Tested

macOS arm64, tilelang 0.1.9 release
- Before: RC=-10 (SIGBUS)
- After: RC=0