### PR TITLE
[FEAT][Python] Tie Python wrapper lifetime to underlying C++ FFI object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ set(_tvm_ffi_objs_sources
     "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/dtype.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/container.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/init_once.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/ffi/custom_allocator.cc"
 )
 
 set(_tvm_ffi_extra_objs_sources
@@ -254,20 +255,15 @@ if (TVM_FFI_BUILD_PYTHON_MODULE)
     message(STATUS "Free-threaded Python detected.")
   endif ()
 
+  # The PyObject-tying module builds against the per-version ABI (WITH_SOABI below), so it never
+  # needs the limited-API (abi3) SABIModule component -- a plain Development.Module find suffices
+  # for every version, free-threaded or not.
   set(_tvm_ffi_python_version ${Python_VERSION})
-  if (Python_VERSION VERSION_GREATER_EQUAL "3.12" AND NOT PYTHON_IS_FREE_THREADED)
-    find_package(
-      Python ${_tvm_ffi_python_version} EXACT
-      COMPONENTS Interpreter Development.Module Development.SABIModule
-      REQUIRED
-    )
-  else ()
-    find_package(
-      Python ${_tvm_ffi_python_version} EXACT
-      COMPONENTS Interpreter Development.Module
-      REQUIRED
-    )
-  endif ()
+  find_package(
+    Python ${_tvm_ffi_python_version} EXACT
+    COMPONENTS Interpreter Development.Module
+    REQUIRED
+  )
   set(_core_cpp ${CMAKE_CURRENT_BINARY_DIR}/core.cpp)
   set(_core_pyx ${CMAKE_CURRENT_SOURCE_DIR}/python/tvm_ffi/cython/core.pyx)
   set(_cython_sources
@@ -294,20 +290,11 @@ if (TVM_FFI_BUILD_PYTHON_MODULE)
     VERBATIM
   )
 
-  if (Python_VERSION VERSION_GREATER_EQUAL "3.12" AND NOT PYTHON_IS_FREE_THREADED)
-    # >= Python3.12, use Use_SABI version
-    python_add_library(tvm_ffi_cython MODULE "${_core_cpp}" USE_SABI 3.12)
-    target_link_libraries(tvm_ffi_cython PRIVATE Python::SABIModule)
-    set_target_properties(tvm_ffi_cython PROPERTIES OUTPUT_NAME "core")
-    if (NOT WIN32)
-      target_link_libraries(tvm_ffi_cython PRIVATE Python::Module)
-      set_target_properties(tvm_ffi_cython PROPERTIES SUFFIX ".abi3.so")
-    endif ()
-  else ()
-    # before Python3.12, use WITH_SOABI version
-    python_add_library(tvm_ffi_cython MODULE "${_core_cpp}" WITH_SOABI)
-    set_target_properties(tvm_ffi_cython PROPERTIES OUTPUT_NAME "core")
-  endif ()
+  # The PyObject-tying impl in tvm_ffi_python_object.h uses full Python C API (Py_IncRef,
+  # PyObject_GC_Del, atomic header reads), so we build against the per-version ABI rather than the
+  # limited (abi3) ABI.
+  python_add_library(tvm_ffi_cython MODULE "${_core_cpp}" WITH_SOABI)
+  set_target_properties(tvm_ffi_cython PROPERTIES OUTPUT_NAME "core")
   target_include_directories(
     tvm_ffi_cython PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/python/tvm_ffi/cython
   )
@@ -345,6 +332,9 @@ if (TVM_FFI_BUILD_PYTHON_MODULE)
           DESTINATION share/cmake/tvm_ffi
   )
   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/python/tvm_ffi/cython/tvm_ffi_python_helpers.h
+          DESTINATION include/
+  )
+  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/python/tvm_ffi/cython/tvm_ffi_python_object.h
           DESTINATION include/
   )
 endif ()

--- a/include/tvm/ffi/c_api.h
+++ b/include/tvm/ffi/c_api.h
@@ -582,6 +582,112 @@ TVM_FFI_DLL int TVMFFIObjectDecRef(TVMFFIObjectHandle obj);
 TVM_FFI_DLL int TVMFFIObjectCreateOpaque(void* handle, int32_t type_index,
                                          void (*deleter)(void* handle), TVMFFIObjectHandle* out);
 
+//-----------------------------------------------------------------------
+// Section: ObjectAllocHeader and CustomAllocator
+//-----------------------------------------------------------------------
+/*!
+ * \brief Mandatory header placed immediately before each TVMFFIObject body.
+ *
+ * A ``TVMFFIObject::deleter`` may invoke this header's ``delete_space``
+ * callback when the object's storage lifetime ends. Frontend custom allocators
+ * can use this mechanism to coordinate cleanup of language-specific state,
+ * such as a cached PyObject wrapper, with reclamation of the TVM FFI allocation.
+ *
+ * The callback may be NULL if the object deleter releases the storage directly.
+ */
+typedef struct {
+  /*!
+   * \brief Reclaim storage allocated for a TVMFFIObject.
+   * \param ptr Pointer to the object body returned by the allocator.
+   *
+   * When used, ``TVMFFIObject::deleter`` invokes this callback after the
+   * object's weak lifetime ends. The callback is responsible for eventually
+   * reclaiming the complete allocator-owned allocation, including any private
+   * prefix, and cleaning up associated frontend state.
+   *
+   * \note ``ptr`` points to the object body, not to the preceding
+   *       ``TVMFFIObjectAllocHeader``. The object's C++ lifetime may already
+   *       have ended, so the callback must not access its fields.
+   * \note This callback may be NULL if the object deleter reclaims the
+   *       allocation directly.
+   */
+  void (*delete_space)(void* ptr);
+} TVMFFIObjectAllocHeader;
+
+/*!
+ * \brief Allocator interface for TVM FFI object storage.
+ *
+ * A frontend may register this allocator with ``TVMFFISetCustomAllocator``
+ * to control allocations of subsequently created ``TVMFFIObject`` instances.
+ * This allows the frontend to prepend private metadata and coordinate object
+ * storage reclamation with language-specific state.
+ *
+ * Every returned object body must be immediately preceded by an initialized
+ * ``TVMFFIObjectAllocHeader``. An allocator may place additional private
+ * metadata before that header.
+ *
+ * \note The registered allocator and its context must remain valid for the
+ *       lifetime of the process.
+ * \note The allocation callback may be invoked concurrently.
+ */
+typedef struct {
+  /*!
+   * \brief Allocate uninitialized storage for a TVM FFI object body.
+   * \param size Size of the object body in bytes, excluding the preceding
+   *             ``TVMFFIObjectAllocHeader`` and any allocator-private metadata.
+   * \param alignment Required alignment of the returned object body.
+   * \param type_index Runtime type index of the object being allocated.
+   * \param context The allocator-defined context stored in this entry.
+   * \return An aligned pointer to the object body, or NULL on failure.
+   *
+   * The returned pointer must be immediately preceded by an initialized
+   * ``TVMFFIObjectAllocHeader`` whose ``delete_space`` callback is responsible
+   * for eventually reclaiming the complete allocator-owned allocation.
+   *
+   * On failure, the callback must report the error through
+   * ``TVMFFIErrorSetRaised`` before returning NULL.
+   *
+   * \note The returned storage is uninitialized: the caller is responsible for
+   *       zero-initializing or constructing the object body. Only the preceding
+   *       ``TVMFFIObjectAllocHeader`` is guaranteed to be initialized on return.
+   */
+  void* (*allocate)(size_t size, size_t alignment, int32_t type_index, void* context);
+
+  /*!
+   * \brief Opaque allocator-defined context passed unchanged to ``allocate``.
+   *
+   * The TVM FFI runtime neither interprets nor owns this pointer. It may be
+   * NULL; otherwise, the referenced state must remain valid for the lifetime
+   * of the registered allocator.
+   */
+  void* context;
+} TVMFFICustomAllocator;
+
+/*!
+ * \brief Get the process-wide custom allocator.
+ * \return The currently registered allocator (never NULL).
+ * \note ``TVMFFIGetCustomAllocator`` always returns a valid allocator and
+ *       can be overridden by ``TVMFFISetCustomAllocator``.
+ * \note Not synchronized against a concurrent ``TVMFFISetCustomAllocator``.
+ *       The allocator is expected to be installed once during frontend
+ *       initialization, before objects are created concurrently; reading it
+ *       afterwards from multiple threads is safe.
+ */
+TVM_FFI_DLL TVMFFICustomAllocator* TVMFFIGetCustomAllocator(void);
+
+/*!
+ * \brief Register the process-wide custom allocator.
+ * \param allocator Pointer to a TVMFFICustomAllocator, or NULL to restore
+ *                  the builtin default.
+ * \return 0 on success, nonzero on failure.
+ * \note ``allocator`` must be alive throughout the lifetime of the process.
+ * \note Not synchronized against concurrent ``TVMFFIGetCustomAllocator`` or
+ *       object creation. Install the allocator once during single-threaded
+ *       frontend initialization, before any object of a custom-allocated type
+ *       crosses into the frontend.
+ */
+TVM_FFI_DLL int TVMFFISetCustomAllocator(TVMFFICustomAllocator* allocator);
+
 /*!
  * \brief Convert type key to type index.
  * \param type_key The key of the type.

--- a/include/tvm/ffi/memory.h
+++ b/include/tvm/ffi/memory.h
@@ -27,6 +27,7 @@
 
 #include <cstddef>
 #include <cstdlib>
+#include <new>
 #include <type_traits>
 #include <utility>
 
@@ -49,12 +50,10 @@ namespace details {
 /*!
  * \brief Allocate aligned memory.
  * \param size The size.
- * \tparam align The alignment, must be a power of 2.
+ * \param align The alignment, must be a power of 2.
  * \return The pointer to the allocated memory.
  */
-template <size_t align>
-TVM_FFI_INLINE void* AlignedAlloc(size_t size) {
-  static_assert(align != 0 && (align & (align - 1)) == 0, "align must be a power of 2");
+TVM_FFI_INLINE void* AlignedAlloc(size_t size, size_t align) {
 #ifdef _MSC_VER
   // MSVC have to use _aligned_malloc
   if (void* ptr = _aligned_malloc(size, align)) {
@@ -62,20 +61,19 @@ TVM_FFI_INLINE void* AlignedAlloc(size_t size) {
   }
   throw std::bad_alloc();
 #else
-  if constexpr (align <= alignof(std::max_align_t)) {
+  if (align <= alignof(std::max_align_t)) {
     // malloc guarantees alignment of std::max_align_t
     if (void* ptr = std::malloc(size)) {
       return ptr;
     }
     throw std::bad_alloc();
-  } else {
-    void* ptr;
-    // for other alignments, use posix_memalign
-    if (posix_memalign(&ptr, align, size) != 0) {
-      throw std::bad_alloc();
-    }
-    return ptr;
   }
+  void* ptr;
+  // for other alignments, use posix_memalign
+  if (posix_memalign(&ptr, align, size) != 0) {
+    throw std::bad_alloc();
+  }
+  return ptr;
 #endif
 }
 
@@ -150,7 +148,12 @@ class ObjAllocatorBase {
 // Simple allocator that uses new/delete.
 class SimpleObjAllocator : public ObjAllocatorBase<SimpleObjAllocator> {
  private:
-  /*! \brief Guard a simple-allocator allocation until ownership is transferred to an object. */
+  /*! \brief Guard a custom-allocator allocation until ownership is transferred to an object.
+   *         If placement construction throws, free the raw block through its allocator's
+   *         ``delete_space`` (the same path the live deleter uses). ``data`` is a body pointer
+   *         offset past the ``TVMFFIObjectAllocHeader``, so a plain ``AlignedFree`` would be wrong;
+   *         the header (with ``delete_space`` wired) is set up by ``allocate`` before construction,
+   *         so this is valid even though the body was never constructed. */
   class AllocGuard {
    public:
     explicit AllocGuard(void* data) noexcept : data_(data) {}
@@ -159,7 +162,7 @@ class SimpleObjAllocator : public ObjAllocatorBase<SimpleObjAllocator> {
 
     ~AllocGuard() noexcept {
       if (data_ != nullptr) {
-        AlignedFree(data_);
+        ObjectUnsafe::GetObjectAllocHeaderFromPtr(data_)->delete_space(data_);
       }
     }
 
@@ -189,7 +192,11 @@ class SimpleObjAllocator : public ObjAllocatorBase<SimpleObjAllocator> {
       // class with non-virtual destructor.
       // We are fine here as we captured the right deleter during construction.
       // This is also the right way to get storage type for an object pool.
-      void* data = AlignedAlloc<alignof(T)>(sizeof(T));
+      static_assert(alignof(T) <= alignof(::std::max_align_t),
+                    "Object types with alignment > max_align_t are not supported "
+                    "by the custom allocator hook");
+      TVMFFICustomAllocator* alloc = TVMFFIGetCustomAllocator();
+      void* data = alloc->allocate(sizeof(T), alignof(T), T::RuntimeTypeIndex(), alloc->context);
       AllocGuard alloc_guard(data);
       new (data) T(std::forward<Args>(args)...);
       alloc_guard.Release();
@@ -210,7 +217,8 @@ class SimpleObjAllocator : public ObjAllocatorBase<SimpleObjAllocator> {
         tptr->T::~T();
       }
       if (flags & kTVMFFIObjectDeleterFlagBitMaskWeak) {
-        AlignedFree(static_cast<void*>(tptr));
+        ObjectUnsafe::GetObjectAllocHeaderFromPtr(static_cast<void*>(tptr))
+            ->delete_space(static_cast<void*>(tptr));
       }
     }
   };
@@ -238,12 +246,17 @@ class SimpleObjAllocator : public ObjAllocatorBase<SimpleObjAllocator> {
       static_assert(
           alignof(ArrayType) % alignof(ElemType) == 0 && sizeof(ArrayType) % alignof(ElemType) == 0,
           "element alignment constraint");
+      static_assert(alignof(ArrayType) <= alignof(::std::max_align_t),
+                    "Object types with alignment > max_align_t are not supported "
+                    "by the custom allocator hook");
       size_t size = sizeof(ArrayType) + sizeof(ElemType) * num_elems;
       // round up to the nearest multiple of align
       constexpr size_t align = alignof(ArrayType);
       // C++ standard always guarantees that alignof operator returns a power of 2
       size_t aligned_size = (size + (align - 1)) & ~(align - 1);
-      void* data = AlignedAlloc<align>(aligned_size);
+      TVMFFICustomAllocator* alloc = TVMFFIGetCustomAllocator();
+      void* data =
+          alloc->allocate(aligned_size, align, ArrayType::RuntimeTypeIndex(), alloc->context);
       AllocGuard alloc_guard(data);
       new (data) ArrayType(std::forward<Args>(args)...);
       alloc_guard.Release();
@@ -264,7 +277,8 @@ class SimpleObjAllocator : public ObjAllocatorBase<SimpleObjAllocator> {
         tptr->ArrayType::~ArrayType();
       }
       if (flags & kTVMFFIObjectDeleterFlagBitMaskWeak) {
-        AlignedFree(static_cast<void*>(tptr));
+        ObjectUnsafe::GetObjectAllocHeaderFromPtr(static_cast<void*>(tptr))
+            ->delete_space(static_cast<void*>(tptr));
       }
     }
   };

--- a/include/tvm/ffi/object.h
+++ b/include/tvm/ffi/object.h
@@ -1180,6 +1180,20 @@ struct ObjectUnsafe {
     return const_cast<TVMFFIObject*>(&(src->header_));
   }
 
+  /*!
+   * \brief Recover the TVMFFIObjectAllocHeader for an object body pointer.
+   * \param ptr The object body pointer the allocator returned (the object base).
+   * \return The header the allocator placed immediately before that body.
+   *
+   * \note ``ptr`` must be the pointer ``allocate`` returned. A vptr (if a
+   *       subclass ever had one) lives at or after ``ptr``, never before it, so
+   *       this backward arithmetic (``ptr - sizeof(header)``) is unaffected.
+   */
+  TVM_FFI_INLINE static TVMFFIObjectAllocHeader* GetObjectAllocHeaderFromPtr(void* ptr) {
+    return reinterpret_cast<TVMFFIObjectAllocHeader*>(static_cast<char*>(ptr) -
+                                                      sizeof(TVMFFIObjectAllocHeader));
+  }
+
 // Suppress -Winvalid-offsetof: we intentionally use offsetof on non-standard-layout types
 // to avoid undefined behavior from null pointer arithmetic that sanitizers flag.
 #if defined(__clang__) || defined(__GNUC__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,8 @@ dev = [
   "cmakelang==0.6.13",
   "ipdb",
   "ipython",
-  "cython>=3.0",
+  # cython>=3.2.8: see the [build-system] requires note (free-threaded __dealloc__ fix).
+  "cython>=3.2.8",
   "cython-lint==0.18.1",
   "cmake",
   "scikit-build-core",
@@ -105,7 +106,11 @@ tvm-ffi-config = "tvm_ffi.config:__main__"
 tvm-ffi-stubgen = "tvm_ffi.stub.cli:__main__"
 
 [build-system]
-requires = ["scikit-build-core>=0.10.0", "cython>=3.0", "setuptools-scm"]
+# cython>=3.2.8: the PyObject-tying dealloc handshake runs inside the wrapper's
+# __dealloc__, and Cython 3.2.8 (2026-06-30) fixed the free-threaded object
+# keep-alive scheme for code executed there (cython#7769). Earlier Cython can
+# collect the wrapper mid-__dealloc__ on the 3.14t build.
+requires = ["scikit-build-core>=0.10.0", "cython>=3.2.8", "setuptools-scm"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
@@ -242,14 +247,11 @@ docstring-code-line-length = 80
 [tool.cibuildwheel]
 build-verbosity = 1
 
-# only build up to cp312, cp312
-# will be abi3 and can be used in future versions
-# ship 314t threaded nogil version
-build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp314t-*"]
+# Per-Python-version wheels (no abi3 / limited API).
+build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314t-*"]
 skip = ["*musllinux*"]
 # we only need to test on cp312
 test-skip = ["cp39-*", "cp310-*", "cp311-*"]
-# focus on testing abi3 wheel
 build-frontend = "build[uv]"
 test-command = "pytest {package}/tests/python -vvs"
 test-groups = ["test"]

--- a/python/tvm_ffi/cython/base.pxi
+++ b/python/tvm_ffi/cython/base.pxi
@@ -360,6 +360,18 @@ def _env_get_current_stream(int device_type, int device_id):
     return <uint64_t>current_stream
 
 
+# PyObject-tying state machine (binds one Python wrapper to one C++ chandle). The C++ impl lives in
+# tvm_ffi_python_object.h; see its top-of-file banner for the design.
+cdef extern from "tvm_ffi_python_object.h":
+    int TVMFFIPyRegisterDefaultAllocator() noexcept
+    void TVMFFIPyMarkPythonFinalizing() noexcept
+
+    void TVMFFIPyCompareAndRebindPyObject(void* chandle, PyObject* expect, PyObject* new_object) noexcept
+    void TVMFFIPyTpDealloc(void** ptr_to_chandle, PyObject* wrapper) noexcept
+    void TVMFFIPyInstallTypeSlots(PyObject* type_obj) noexcept
+    object TVMFFIPyMakeRetObject(void* chandle, PyObject* cls_type)
+
+
 cdef extern from "tvm_ffi_python_helpers.h":
     # no need to expose fields of the call context setter data structure
     ctypedef struct TVMFFIPyCallContext:

--- a/python/tvm_ffi/cython/core.pyx
+++ b/python/tvm_ffi/cython/core.pyx
@@ -22,6 +22,16 @@
 # where the base class has to be registered before the derived class.
 # Otherwise, `TypeInfo.parent_type_info` may not be properly propagated to the derived class.
 include "./base.pxi"
+
+# Install the PyObject-tying default allocator before any FFI type is registered
+# below, so every object created through the registry carries the prepended
+# PyCustomAllocHeader. The atexit hook flips the shutdown guard so cached
+# allocations on still-live chandles are leaked (not touched via a teardown
+# interpreter) once Python starts finalizing.
+CHECK_CALL(TVMFFIPyRegisterDefaultAllocator())
+import atexit as _tvm_ffi_atexit
+_tvm_ffi_atexit.register(TVMFFIPyMarkPythonFinalizing)
+
 include "./type_info.pxi"
 include "./object.pxi"
 _register_object_by_index(kTVMFFIObject, Object)

--- a/python/tvm_ffi/cython/function.pxi
+++ b/python/tvm_ffi/cython/function.pxi
@@ -555,9 +555,13 @@ cdef int TVMFFIPyArgSetterObjectRValueRef_(
     PyObject* py_arg, TVMFFIAny* out
 ) except -1:
     """Setter for ObjectRValueRef"""
-    cdef object arg = <object>py_arg
+    cdef CObject src = (<object>py_arg).obj
+    # Eager-detach the canonical binding before passing the chandle by rvalue ref: the callee
+    # either moves it (src.chandle -> NULL) or leaves it, and either way ``src`` must no longer be
+    # the canonical wrapper. Recycling in both cases is handled in TVMFFIPyTpDealloc on src death.
+    TVMFFIPyCompareAndRebindPyObject(src.chandle, <PyObject*>src, NULL)
     out.type_index = kTVMFFIObjectRValueRef
-    out.v_ptr = &((<CObject>(arg.obj)).chandle)
+    out.v_ptr = &(src.chandle)
     return 0
 
 

--- a/python/tvm_ffi/cython/object.pxi
+++ b/python/tvm_ffi/cython/object.pxi
@@ -103,9 +103,8 @@ cdef class CObject:
         self.chandle = NULL
 
     def __dealloc__(self):
-        if self.chandle != NULL:
-            CHECK_CALL(TVMFFIObjectDecRef(self.chandle))
-            self.chandle = NULL
+        # Release the wrapper's +1 on the chandle and inactivate-or-free its allocation.
+        TVMFFIPyTpDealloc(<void**>&self.chandle, <PyObject*>self)
 
     def __ctypes_handle__(self) -> object:
         return ctypes_handle(self.chandle)
@@ -173,7 +172,14 @@ cdef class CObject:
         return isinstance(other, CObject) and self.chandle == (<CObject>other).chandle
 
     def __move_handle_from__(self, other: CObject) -> None:
-        self.chandle = (<CObject>other).chandle
+        cdef void* chandle = (<CObject>other).chandle
+        self.chandle = chandle
+        # Rebind the canonical binding other -> self BEFORE nulling other.chandle. The reverse
+        # order leaves a window (free-threaded) where the word still publishes Active(other) while
+        # other.chandle is already NULL: a concurrent make_ret Active-hit would then hand out a
+        # canonical wrapper with a NULL handle. After the rebind the word points at self (whose
+        # chandle is already set), so nulling other.chandle is safe.
+        TVMFFIPyCompareAndRebindPyObject(chandle, <PyObject*>other, <PyObject*>self)
         (<CObject>other).chandle = NULL
 
     def __init_handle_by_constructor__(self, fconstructor: Any, *args: Any) -> None:
@@ -183,6 +189,8 @@ cdef class CObject:
         ConstructorCall(
             (<CObject>fconstructor).chandle, <PyObject*>args, &chandle, NULL)
         self.chandle = chandle
+        # Attach self as the canonical wrapper iff the chandle is Detached (expect=NULL).
+        TVMFFIPyCompareAndRebindPyObject(chandle, NULL, <PyObject*>self)
 
 
 cdef class CContainerBase(CObject):
@@ -432,6 +440,11 @@ cdef inline object make_ret_opaque_object(TVMFFIAny result):
     (<CObject>obj).chandle = result.v_obj
     return obj.pyobject()
 
+cdef public void** TVMFFICyObjectGetCHandlePtr(PyObject* ptr) noexcept:
+    # Address of a CObject wrapper's ``chandle`` field, for the C++ helpers.
+    return &((<CObject>ptr).chandle)
+
+
 cdef inline object make_fallback_cls_for_type_index(int32_t type_index):
     cdef str type_key = _type_index_to_key(type_index)
     cdef object type_info = _lookup_or_register_type_info_from_type_key(type_key)
@@ -469,23 +482,29 @@ cdef inline object make_fallback_cls_for_type_index(int32_t type_index):
 
 
 cdef inline object make_ret_object(TVMFFIAny result):
-    cdef int32_t type_index
+    """Wrap a returned chandle into its canonical Python wrapper.
+
+    Caller must own +1 on ``result.v_obj``; ownership transfers to the
+    returned wrapper. The Active / Inactive / Detached transition is owned in
+    one frame by ``TVMFFIPyMakeRetObject`` (tvm_ffi_python_object.h); this
+    dispatcher only resolves ``cls`` and peels off the value-typed
+    ``PyNativeObject`` case, which does not participate in tying.
+    """
+    cdef int32_t type_index = result.type_index
     cdef object cls, obj
-    type_index = result.type_index
 
     if type_index < len(TYPE_INDEX_TO_CLS) and (cls := TYPE_INDEX_TO_CLS[type_index]) is not None:
         if issubclass(cls, PyNativeObject):
+            # Value-typed: the transient Object wrapper is discarded after
+            # __from_tvm_ffi_object__. No identity stability needed.
             obj = Object.__new__(Object)
             (<CObject>obj).chandle = result.v_obj
             return cls.__from_tvm_ffi_object__(cls, obj)
     else:
-        # Slow path: object is not found in registered entry
-        # In this case create a dummy stub class for future usage.
-        # For every unregistered class, this slow path will be triggered only once.
         cls = make_fallback_cls_for_type_index(type_index)
-    obj = cls.__new__(cls)
-    (<CObject>obj).chandle = result.v_obj
-    return obj
+    # Single choke point for the tying transition. Declared returning ``object``,
+    # so Cython adopts the owned reference and a NULL return raises.
+    return TVMFFIPyMakeRetObject(result.v_obj, <PyObject*>cls)
 
 
 cdef _get_method_from_method_info(const TVMFFIMethodInfo* method):
@@ -615,12 +634,42 @@ cdef _update_registry(int type_index, object type_key, object type_info, object 
     TYPE_KEY_TO_INFO[type_key] = type_info
     if type_cls is not None:
         TYPE_CLS_TO_INFO[type_cls] = type_info
+    # Universal choke point for every registered FFI type (core
+    # _register_object_by_index, dynamic _register_py_class, and
+    # make_fallback_cls_for_type_index all funnel here): install the custom
+    # tp_alloc / tp_free that drive PyObject-tying. tp_alloc / tp_free are
+    # not inherited by dynamic subtypes, so each type must be patched here.
+    # No-op unless ``type_cls`` is a ``CObject`` subclass.
+    if type_cls is not None and isinstance(type_cls, type) and issubclass(type_cls, CObject):
+        TVMFFIPyInstallTypeSlots(<PyObject*>type_cls)
 
 
 def _register_object_by_index(int type_index, object type_cls):
     global TYPE_INDEX_TO_INFO, TYPE_KEY_TO_INFO, TYPE_INDEX_TO_CLS
     cdef str type_key = _type_index_to_key(type_index)
-    cdef object info = _type_info_create_from_type_key(type_cls, type_key)
+    cdef object info
+    cdef object existing_cls
+    # A type may be re-registered with a new Python class -- e.g. the enum binder binds several
+    # ``Enum`` subclasses to one cxx ``type_key``, and an object may be materialized (auto-creating
+    # a base-size fallback stub) before its real class is registered. Re-registration is rejected
+    # only when the new wrapper is LARGER than the one already registered: the cache-&-revive path
+    # (``TVMFFIPyTpAlloc``) memsets a cached wrapper block up to the CURRENT class's tp_basicsize, so
+    # reviving a block cached for a smaller old class as a larger new class would overflow it.
+    # Because every accepted re-registration is <= the previous one, the registered size is
+    # monotonically non-increasing and each cached block is always >= any later revival's memset,
+    # so no overflow is reachable. Same-or-smaller re-registration (all __slots__=() wrappers share
+    # the base size) is therefore safe.
+    if type_index < len(TYPE_INDEX_TO_CLS):
+        existing_cls = TYPE_INDEX_TO_CLS[type_index]
+        if (existing_cls is not None and type_cls is not None
+                and type_cls.__basicsize__ > existing_cls.__basicsize__):
+            raise ValueError(
+                f"Type '{type_key}' already has a registered class ({existing_cls!r}); "
+                f"re-registering it with the larger wrapper class {type_cls!r} is not supported. "
+                f"Register the class before any object of this type is materialized (which "
+                f"auto-creates a fallback)."
+            )
+    info = _type_info_create_from_type_key(type_cls, type_key)
     _update_registry(type_index, type_key, info, type_cls)
     return info
 

--- a/python/tvm_ffi/cython/pycallback.pxi
+++ b/python/tvm_ffi/cython/pycallback.pxi
@@ -74,7 +74,29 @@ cdef int TVMFFIPyCallbackArgSetterObject_(
     const TVMFFIAny* arg,
     PyObject** out
 ) except -1:
-    """Callback arg setter for generic static object types (type_index >= kTVMFFIStaticObjectBegin)."""
+    """Convert a generic FFI object argument for a Python callback.
+
+    The input contains a borrowed chandle, so this function increments the
+    chandle's reference count before calling ``make_ret_object(arg[0])``.
+    ``make_ret_object`` consumes that reference and returns the Python value
+    passed to the callback.
+
+    For ``CObject``-based types that support wrapper tying,
+    ``make_ret_object`` returns the existing canonical wrapper, revives its
+    previous allocation when eligible, or creates and binds a new wrapper.
+    If a live canonical wrapper already exists, the callback receives that
+    exact Python object. Chandles without Python allocator metadata are
+    wrapped normally but cannot reuse a canonical wrapper.
+
+    ``PyNativeObject`` subclasses such as ``String``, ``Bytes``, and
+    ``Shape`` are instead converted to their Python-native representations
+    and do not participate in wrapper tying. ``Tensor`` and
+    ``OpaquePyObject`` are handled by dedicated callback argument setters
+    and therefore do not use this function.
+
+    When ``api`` is provided for a ``CContainerBase``, this function attaches
+    the exchange API to support lazy DLPack conversion.
+    """
     cdef TVMFFIObjectHandle chandle = arg.v_ptr
     TVMFFIObjectIncRef(chandle)
     try:

--- a/python/tvm_ffi/cython/tensor.pxi
+++ b/python/tvm_ffi/cython/tensor.pxi
@@ -542,7 +542,11 @@ cdef inline object make_tensor_from_chandle(
                 # call the deleter to free the memory since we will continue to use the chandle
                 dlpack.deleter(dlpack)
                 pass
-    # default return the tensor
+    # default return the tensor.
+    # NOTE: we deliberately do NOT bind this wrapper as canonical (no
+    # TVMFFIPyCompareAndRebindPyObject) — this factory may wrap the same chandle more than
+    # once (e.g. once per arg-setter callback), and rebinding would corrupt the
+    # tying cache. Tensors returned through the FFI go via make_ret_object instead.
     tensor = _CLASS_TENSOR.__new__(_CLASS_TENSOR)
     (<CObject>tensor).chandle = chandle
     (<Tensor>tensor).cdltensor = TVMFFITensorGetDLTensorPtr(chandle)

--- a/python/tvm_ffi/cython/tvm_ffi_python_object.h
+++ b/python/tvm_ffi/cython/tvm_ffi_python_object.h
@@ -1,0 +1,1121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * \file tvm_ffi_python_object.h
+ * \brief PyObject-tying state machine: binds one Python wrapper to one C++ FFI object
+ *        ("chandle") for the object's lifetime so identity is stable (``a.x is a.x``,
+ *        stable ``id()`` across drop+refetch, ``f(x) is x`` for FFI returns).
+ *
+ * Split out of tvm_ffi_python_helpers.h. The design overview is the banner comment below.
+ */
+#ifndef TVM_FFI_PYTHON_OBJECT_H_
+#define TVM_FFI_PYTHON_OBJECT_H_
+
+#include <Python.h>
+#include <tvm/ffi/c_api.h>
+#include <tvm/ffi/memory.h>
+
+// Define here to avoid dependencies on non-c headers for now
+#ifndef TVM_FFI_INLINE
+#if defined(_MSC_VER)
+#define TVM_FFI_INLINE [[msvc::forceinline]] inline
+#else
+#define TVM_FFI_INLINE [[gnu::always_inline]] inline
+#endif
+#endif
+
+// Managed-dict (`__slots__ = ("__dict__",)` without an explicit dictoffset)
+// is a CPython 3.11+ feature. On 3.9/3.10 such types instead use a regular
+// ``tp_dictoffset != 0``, which the inactive-eligibility check catches anyway,
+// so defining the flag as 0 here yields the correct (no-op) behavior.
+#ifndef Py_TPFLAGS_MANAGED_DICT
+#define Py_TPFLAGS_MANAGED_DICT 0
+#endif
+
+#include <atomic>
+#include <cassert>
+#include <cstring>
+#include <utility>
+
+// ``_Interlocked*`` intrinsics for the MSVC arm of the spin-lock leaves below. <intrin.h>, not
+// <windows.h>, to keep min/max etc. macros out of the Cython TU.
+#if defined(_MSC_VER) && defined(Py_GIL_DISABLED)
+#include <intrin.h>
+#endif
+
+//================================================================================
+// PyObject-tying state machine
+//
+// Ties one Python wrapper to one C++ FFI object ("chandle") for the chandle's
+// lifetime, so Python identity is stable:
+//   - ``a.x is a.x`` while the wrapper is live;
+//   - ``id(a.x)`` is stable across drop+refetch (while another C++ holder keeps
+//     the chandle alive);
+//   - ``f(x) is x`` whenever an FFI call returns a chandle that already has a
+//     canonical wrapper.
+// Works on both the GIL and free-threaded (``Py_GIL_DISABLED``) builds.
+//
+// Wrapper vs native object
+// ------------------------
+// A "wrapper" is the Python object that represents a native TVM-FFI object; it is
+// not the native object itself. For ``x = outer.x``:
+//
+//     Python wrapper W                         Native TVM-FFI object H
+//
+//     +----------------------+                 +----------------------+
+//     | PyObject header      |                 | refcounts            |
+//     |   ob_refcnt          |                 | type_index           |
+//     |   ob_type            |                 | actual object fields |
+//     | CObject.chandle  --------------------> +----------------------+
+//     +----------------------+                            |
+//                ^                                        |
+//                +--------- tagged_pyobj in header <------+
+//
+// ``W`` is a Cython ``CObject`` subclass (a container, reflected dataclass,
+// ``Function``, or other registered class). It provides Python identity, methods,
+// and Python reference counting; its ``chandle`` points to the native object
+// ``H``, which holds the real FFI data and TVM-FFI's own strong/weak refcounts.
+//
+// Canonical wrapper
+// -----------------
+// Without tying, one chandle could back several wrappers -- ``a = outer.x;
+// b = outer.x`` gives ``a.same_as(b)`` but ``a is not b``. Tying designates ONE
+// wrapper as canonical and records its address in the native allocation's
+// ``tagged_pyobj`` field, so ``a is b``. That field is a RAW pointer, not a
+// Python reference: storing ``W`` there does not bump ``W.ob_refcnt`` and does
+// not keep ``W`` alive.
+//
+// Memory layout
+// -------------
+// Every Object allocated through the registered Python allocator
+// (``TVMFFIPyAllocate``) is preceded by a fixed 16-byte ``PyCustomAllocHeader``:
+//
+//     malloc start
+//     +-------------------+--------------------------+--------+
+//     |   tagged_pyobj    | TVMFFIObjectAllocHeader  |   T    |
+//     |   (offset 0..8)   |   delete_space (8..16)   |        |
+//     +-------------------+--------------------------+--------+
+//                                                    ^ ptr = malloc + 16
+//
+// The body ``T`` starts at ``malloc + 16``, and ``base.delete_space`` sits at
+// ``ptr - sizeof(TVMFFIObjectAllocHeader)`` so the generic C++ deleter (which
+// knows nothing about Python) can find it. Objects NOT allocated through this
+// allocator (e.g. some C++-static objects) have no header and never tie.
+//
+// Pointer tagging
+// ---------------
+// A wrapper allocation is >= 16-byte aligned, so ``tagged_pyobj``'s low bits are
+// free to encode lifecycle state without growing the header. If ``W = 0x1000``:
+//
+//     Active:     0x1000       # W
+//     Inactive:   0x1001       # W | 1       (bit 0)
+//     InTransit:  0x1003       # W | 1 | 2   (bits 0 and 1)
+//     Locked:     0x1004       # W | 4       (bit 2, free-threaded only)
+//
+// Tagged values are not dereferenceable ``PyObject*``; ``TVMFFIPyRemoveTag`` masks
+// every tag bit to recover ``W``.
+//
+// The four states
+// ---------------
+// ``tagged_pyobj`` encodes four lifecycle states (Locked, bit 2, is a separate
+// free-threaded overlay described below, not a fifth state):
+//
+//   Detached (``NULL``)
+//     No canonical wrapper for this chandle: freshly created and not yet returned
+//     to Python, moved-from, an ineligible wrapper that died and was genuinely
+//     freed, or allocated-but-not-yet-wrapped. The next FFI return makes a fresh
+//     wrapper: Detached -> Active.
+//
+//   Active (``W``)
+//     ``W`` is the live canonical wrapper: ``W.chandle == H`` owns one strong
+//     native ref, while the header's back-pointer owns no Python ref. When an FFI
+//     call returns ``H``: find ``W``, ``Py_INCREF`` it, drop the redundant native
+//     ref from the return, return ``W`` (hence ``f(x) is x``). Exits: -> Inactive
+//     (last Python ref gone, another native owner keeps ``H`` alive); -> Detached
+//     (move, ineligible-wrapper death, or rebind); -> freed (wrapper and ``H``
+//     both end, via the InTransit handshake).
+//
+//   Inactive (``W | 1``)
+//     ``W``'s Python lifetime ended (refcount 0, dealloc ran, untracked from GC,
+//     no strong native ref, not yet ``PyObject_GC_Del``'d) but its raw allocation
+//     is retained because ``H`` is still alive. A later fetch revives it in place
+//     -- zero fields -> ``PyObject_Init`` -> ``PyObject_GC_Track`` -> restore
+//     chandle -- giving Inactive -> Active at the SAME address (stable ``id()``).
+//     This is a new object lifetime at that address, not resurrection of the old
+//     one. If ``H`` dies first, its deleter frees both the cached storage and
+//     ``H``.
+//
+//   InTransit (``W | 1 | 2``)
+//     A short-lived teardown baton (see "The dealloc handshake"). It overlays a
+//     non-live binding while the Python-side and C++-side teardown settle
+//     ownership; it never overlays a live Active wrapper.
+//
+// State flow:
+//
+//                            move / ineligible death
+//                       +------------------------------+
+//                       |                              v
+//     Detached ------> Active ------> InTransit ------> Detached/freed
+//       ^                |                |
+//       |                |                | native object survives
+//       |                |                v
+//       |                +----------> Inactive
+//       |                                 |
+//       +---------------------------------+
+//                  native object returned again
+//
+// Invariants
+// ----------
+//   I1. When a wrapper goes out of scope, its +1 on the chandle is always released
+//       (in ``__dealloc__`` -> ``TVMFFIPyTpDealloc``).
+//   I2. When a chandle is destroyed, its cached allocation (if any) is reclaimed.
+//   I3. ``wrapper.chandle`` is only ever a real C++ object pointer or NULL, never a
+//       sentinel. A non-NULL chandle owns +1, except inside the wrapper's own
+//       dealloc window (where it is kept only as a header locator).
+//   I4. Every ``PyObject*`` the Cython side passes to a helper here is a live
+//       wrapper (tag bits 0); only this header sets or clears the tag bits.
+//   I5. InTransit is the dealloc handshake's baton and nothing else: it overlays a
+//       non-live binding (Inactive(W) or Detached(NULL)) while the two teardown
+//       sides settle, never the live Active wrapper. Any reader that sees it -- a
+//       peer settler, or make_ret's classify -- waits the transition out.
+//
+// The dealloc handshake
+// ---------------------
+// An allocation can be torn down from two directions, and the handshake stops them
+// from racing into a double free or a leak:
+//   * from Python -- the wrapper's refcount hits 0, so ``tp_dealloc`` ->
+//     ``tp_free`` run;
+//   * from C++    -- the chandle's weak count hits 0, so its Weak deleter fires
+//     ``TVMFFIPyDeleteSpace``.
+// ``tp_dealloc`` cannot know which side is last (an FFI ``DecRef`` may race it from
+// another thread), so it pre-tags ``Inactive | InTransit`` and ``DecRef``s
+// unconditionally. The InTransit bit is a baton: the FIRST settler clears it and
+// defers, so the SECOND finds it clear and performs the free.
+//
+//   Flow 1 -- wrapper dies, chandle outlives it (cache the allocation):
+//     tp_dealloc   : Active -> Inactive, InTransit 0 -> 1,
+//                    DecRef (chandle still has refs, so no deleter fires)
+//     tp_free      : InTransit 1 -> 0, keep ``self`` cached Inactive
+//     ... later, the chandle dies:
+//     delete_space : InTransit == 0, reclaim the cached wrapper and free the block
+//
+//   Flow 2 -- wrapper held the last ref (free the allocation now):
+//     tp_dealloc   : Active -> Inactive, InTransit 0 -> 1,
+//                    DecRef (last ref dropped, so reentrantly fires delete_space)
+//     delete_space : InTransit 1 -> 0, defer the free back to tp_free
+//     tp_free      : InTransit == 0, free the C++ block here
+//
+// Where transitions happen
+// ------------------------
+//   ``TVMFFIPyMakeRetObject`` (behind ``make_ret_object``, object.pxi) owns the
+//     whole return-object transition in one frame:
+//       Detached / Active / Inactive -> Active (fresh / revived-in-place / cached).
+//   ``TVMFFIPyTpDealloc`` (CObject.__dealloc__), when the wrapper refcount hits 0:
+//       Active -> Inactive (eligible; tag Inactive | InTransit, then DecRef);
+//       Active -> Detached (ineligible; detach first, then DecRef).
+//   ``TVMFFIPyArgSetterObjectRValueRef_`` (function.pxi) and
+//     ``__move_handle_from__`` (object.pxi):
+//       Active -> Detached (detach before a move nulls the source chandle).
+//   ``TVMFFIPyDeleteSpace`` (Weak deleter), when the chandle weak count hits 0:
+//       Inactive | InTransit -> defer both frees to ``tp_free``;
+//       Inactive (settled)   -> reclaim the cached wrapper and free the block.
+//
+// Slot install
+// ------------
+// Two slot families, each unmissable over a different scope:
+//   * ``tp_dealloc`` (correctness, I1): installed once on ``CObject`` and inherited
+//     by every subtype -- nothing to install per type.
+//   * ``tp_alloc`` / ``tp_free`` (the cache-&-revive optimization): installed per
+//     registered type at the sole registration choke point ``_update_registry``
+//     (object.pxi), because these slots are not inherited by dynamic subtypes. An
+//     unregistered subtype simply fails eligibility and genuine-frees (losing
+//     stable-id-across-drop, not correctness).
+// ``tp_dealloc`` works with either pairing: with the custom ``tp_alloc`` /
+// ``tp_free`` it caches (eligible), and with the generic ones it detaches +
+// genuine-frees -- the eligibility gate keys on the same ``tp_free``, so the two
+// can never disagree.
+//
+// Shutdown guard
+// --------------
+// ``TVMFFIPyMarkPythonFinalizing`` is wired to atexit from Cython module init.
+// After it fires, inactive cached allocations on still-live chandles are
+// intentionally leaked (the process is exiting; the OS reclaims) rather than
+// reaching for ``PyGILState_Ensure`` on a teardown interpreter.
+//
+// Free-threaded builds (``Py_GIL_DISABLED``)
+// ------------------------------------------
+// Without the GIL the bare ``tagged_pyobj`` reads/writes race -- an Active-hit read
+// is a use-after-free (``make_ret`` reads the wrapper; a concurrent dealloc frees
+// it before the IncRef). The tie stays enabled; two FT-only mechanisms close the
+// gap, both behind ``#ifdef Py_GIL_DISABLED`` so the GIL build is byte-for-byte
+// unchanged:
+//   * The word is its own spin-lock: the Locked bit (bit 2) is CAS-acquired via the
+//     portable pointer-atomic leaves (``__atomic_*`` on GCC/Clang, ``_Interlocked*``
+//     on MSVC), so every transition serializes its word edits. A holder sets bit 2,
+//     reasons about the underlying state with the bit masked off, then publishes the
+//     new state without it. The GIL build never sets it.
+//   * The Active hit uses ``PyUnstable_TryIncRef`` (inc-if-nonzero), not
+//     ``Py_INCREF``, so it fails on a wrapper a concurrent dealloc is collecting.
+//     The Active lookup then: lock the word; ``TryIncRef``; if alive, return the
+//     wrapper; if its refcount already hit 0, wait for the dealloc to transition the
+//     state and retry as Inactive or Detached.
+//================================================================================
+
+/*!
+ * \brief Python-side derived allocation header, sitting immediately before the
+ *        object body (see "Memory layout" in the banner above).
+ *
+ * \c tagged_pyobj is the tagged pointer to the canonical wrapper (Detached /
+ * Active / Inactive / InTransit, plus the free-threaded Locked overlay -- see
+ * "Pointer tagging" and "The four states" in the banner). \c base is the generic
+ * ``TVMFFIObjectAllocHeader``; its \c delete_space sits at
+ * ``ptr - sizeof(TVMFFIObjectAllocHeader)`` so the C++ deleter (which knows
+ * nothing about Python) can find it. The ``TVMFFIPyTag*`` helpers below only
+ * inspect or transform the encoded word -- they never touch refcounts, allocate,
+ * or free.
+ */
+struct PyCustomAllocHeader {
+  PyObject* tagged_pyobj;
+  TVMFFIObjectAllocHeader base;
+};
+
+static_assert(sizeof(PyCustomAllocHeader) == 16,
+              "header must be 16 bytes so T at ptr = malloc + 16 is naturally "
+              "aligned for alignof(T) up to alignof(max_align_t)");
+static_assert(offsetof(PyCustomAllocHeader, base) ==
+                  sizeof(PyCustomAllocHeader) - sizeof(TVMFFIObjectAllocHeader),
+              "base must sit at ptr - sizeof(TVMFFIObjectAllocHeader) for the "
+              "C++ deleter to find it");
+
+/*! \brief Recover the ``PyCustomAllocHeader`` sitting immediately before an object body.
+ *  \param ptr The object (``T``) pointer returned by the allocator.
+ *  \return The header at ``ptr - sizeof(PyCustomAllocHeader)``. */
+TVM_FFI_INLINE PyCustomAllocHeader* TVMFFIPyHeader(void* ptr) {
+  return reinterpret_cast<PyCustomAllocHeader*>(static_cast<char*>(ptr) -
+                                                sizeof(PyCustomAllocHeader));
+}
+
+// The tag bits on ``tagged_pyobj`` (see "Pointer tagging" in the banner): bit 0 Inactive, bit 1
+// InTransit, bit 2 Locked (free-threaded spin-lock only; the GIL build never sets it).
+// ``TVMFFIPyRemoveTag`` masks every defined bit.
+constexpr uintptr_t kPyCachedInactiveTagBit = 1;
+constexpr uintptr_t kPyInTransitTagBit = 2;
+#ifdef Py_GIL_DISABLED
+constexpr uintptr_t kPyLockedTagBit = 4;
+constexpr uintptr_t kPyTagBitMask = kPyCachedInactiveTagBit | kPyInTransitTagBit | kPyLockedTagBit;
+#else
+constexpr uintptr_t kPyTagBitMask = kPyCachedInactiveTagBit | kPyInTransitTagBit;
+#endif
+
+/*! \brief True iff the Inactive bit is set on ``tagged``.
+ *  \param tagged The raw ``tagged_pyobj`` word.
+ *  \return Whether bit 0 (Inactive) is set. */
+TVM_FFI_INLINE bool TVMFFIPyTagIsInactive(PyObject* tagged) {
+  return (reinterpret_cast<uintptr_t>(tagged) & kPyCachedInactiveTagBit) != 0;
+}
+/*! \brief True iff the InTransit bit is set on ``tagged``.
+ *  \param tagged The raw ``tagged_pyobj`` word.
+ *  \return Whether bit 1 (InTransit) is set. */
+TVM_FFI_INLINE bool TVMFFIPyTagInTransit(PyObject* tagged) {
+  return (reinterpret_cast<uintptr_t>(tagged) & kPyInTransitTagBit) != 0;
+}
+/*! \brief Strip every tag bit, yielding the bare wrapper pointer.
+ *  \param tagged The raw ``tagged_pyobj`` word.
+ *  \return ``tagged`` with all defined tag bits cleared. */
+TVM_FFI_INLINE PyObject* TVMFFIPyRemoveTag(PyObject* tagged) {
+  return reinterpret_cast<PyObject*>(reinterpret_cast<uintptr_t>(tagged) & ~kPyTagBitMask);
+}
+/*! \brief Clear ONLY the InTransit bit (Inactive|InTransit -> Inactive, settled).
+ *  \param tagged The raw ``tagged_pyobj`` word.
+ *  \return ``tagged`` with bit 1 cleared, others kept. */
+TVM_FFI_INLINE PyObject* TVMFFIPyTagClearInTransit(PyObject* tagged) {
+  return reinterpret_cast<PyObject*>(reinterpret_cast<uintptr_t>(tagged) & ~kPyInTransitTagBit);
+}
+
+//---------------------------------------------------------------
+// Word-access leaves: the ONE place the GIL / free-threaded divergence lives. Every transition
+// body below (make_ret, the dealloc family, Rebind) is written once against the small vocabulary
+// below, so the logic reads identically on both builds and the build difference is confined here.
+//
+// Vocabulary -- two layers, two naming rules, never mixed:
+//   * Public ``TVMFFIPy*`` leaves name LOCK SEMANTICS -- what you hold on return:
+//       ``Lock...``   -> returns HOLDING the lock + the prior binding (``LockWord``,
+//                        ``LockClassifyActive``);
+//       ``Unlock...`` -> returns having RELEASED it, publishing the named new state
+//                        (``UnlockWord`` = arbitrary, ``UnlockKeep`` = unchanged);
+//       ``Peek...``   -> never touches the lock (``PeekWord``, a lock-free read).
+//     So "Acquire" as a lock verb never appears up here -- ``PeekWord`` is the lock-free read even
+//     though its body uses an acquire-ordered load. Two non-lock helpers complete the set:
+//     ``EnableTryIncRef`` (arm a wrapper for a racing reader's TryIncRef before publish) and
+//     ``SpinYield`` (GC-safe back-off on a wait; free-threaded only).
+//   * Detail ``pyobj_detail::Word*`` leaves name the MEMORY-ORDER MECHANISM --
+//     ``Load{Relaxed,Acquire}`` / ``StoreRelease`` / ``CASAcquire``. "Acquire"/"Release" mean the
+//     C++ memory order here, and live ONLY in this layer.
+//
+// Consumers -- three operations. Each ``lock #N`` ... ``unlock #N`` pair brackets one critical
+// section; indented branches are the mutually exclusive paths, each "condition: actions".
+//
+//   Return -- make_ret:
+//     LockClassifyActive                                  <- lock #1 (returns HELD)
+//     ├─ Active hit : UnlockKeep                          <- unlock #1; drop +1; return live
+//     └─ miss       : NewWrapper, then
+//                     UnlockWord(obj on ok / cur on OOM)  <- unlock #1 (publish Active / undo)
+//
+//   Rebind -- CompareAndRebindPyObject (move / construct / detach):
+//     LockWord                                            <- lock #2
+//     ├─ cur == expect or Detached : UnlockWord(new)      <- unlock #2 (swap the binding)
+//     └─ else (not ours / busy)    : UnlockKeep           <- unlock #2 (release unchanged)
+//
+//   Teardown -- the two-direction handshake (Flow 1 / Flow 2 above); three participants, each its
+//   own bracket. tp_dealloc opens (sets InTransit); tp_free / delete_space settle it.
+//     tp_dealloc:  LockWord                               <- lock #3
+//        ├─ ours + eligible : UnlockWord(Inactive|InTransit)  <- unlock #3 (then DecRef)
+//        ├─ ours, ineligible: UnlockWord(NULL)            <- unlock #3  (detach; then DecRef)
+//        └─ not ours        : UnlockKeep                  <- unlock #3  (then DecRef)
+//     tp_free:     LockWord                               <- lock #4
+//        ├─ InTransit == 1 : UnlockWord(clear it)         <- unlock #4  (keep self cached)
+//        └─ InTransit == 0 : UnlockKeep ; AlignedFree     <- unlock #4  (we free the block)
+//     delete_space: PeekWord                              <- lock-free peek
+//        ├─ Detached  : AlignedFree                       <- no bracket (fast path)
+//        └─ Inactive  : LockWord                          <- lock #5
+//           ├─ InTransit == 1 : UnlockWord(clear it)      <- unlock #5 (defer to tp_free)
+//           └─ InTransit == 0 : UnlockWord(NULL) ; reclaim wrapper + free  <- unlock #5
+//
+// On the GIL build the GIL already serializes every transition, so there is no spin-lock: each
+// leaf collapses to a plain field access (load / store / no-op), a lock-free simplification of the
+// free-threaded structure that emits byte-for-byte unchanged.
+//---------------------------------------------------------------
+
+#ifdef Py_GIL_DISABLED
+/*! \brief True iff the Locked spin-lock bit is set on ``tagged`` (free-threaded only).
+ *  \param tagged The raw ``tagged_pyobj`` word.
+ *  \return Whether bit 2 (Locked) is set. */
+TVM_FFI_INLINE bool TVMFFIPyTagIsLocked(PyObject* tagged) {
+  return (reinterpret_cast<uintptr_t>(tagged) & kPyLockedTagBit) != 0;
+}
+
+/*! \brief GC-safe back-off for any wait on the word (the spin-loop's yield -- not a lock op
+ *         itself). Must run with an attached thread state and WITHOUT the word lock held. */
+TVM_FFI_INLINE void TVMFFIPySpinYield() {
+  PyThreadState* tstate = PyEval_SaveThread();
+  PyEval_RestoreThread(tstate);
+}
+
+// Raw pointer-atomics on the word -- the only bare loads/stores/CAS (transitions go through
+// Lock/Unlock/Peek). Dual-coded ``_Interlocked*`` on MSVC / ``__atomic_*`` elsewhere.
+namespace tvm {
+namespace ffi {
+namespace pyobj_detail {
+
+/*! \brief Relaxed load of the word -- only ever the CAS seed, so a stale value just retries.
+ *  \param h The allocation header.
+ *  \return The current ``tagged_pyobj`` (relaxed). */
+TVM_FFI_INLINE PyObject* WordLoadRelaxed(PyCustomAllocHeader* h) {
+#if defined(_MSC_VER)
+  return reinterpret_cast<PyObject* const volatile*>(&h->tagged_pyobj)[0];  // NOLINT(*)
+#else
+  return __atomic_load_n(&h->tagged_pyobj, __ATOMIC_RELAXED);
+#endif
+}
+
+/*! \brief Acquire load of the word (standalone sync edge). On MSVC a CAS NULL/NULL: an
+ *         acquire-ordered read that never writes.
+ *  \param h The allocation header.
+ *  \return The current ``tagged_pyobj`` (acquire). */
+TVM_FFI_INLINE PyObject* WordLoadAcquire(PyCustomAllocHeader* h) {
+#if defined(_MSC_VER)
+  return reinterpret_cast<PyObject*>(_InterlockedCompareExchangePointer(
+      reinterpret_cast<void* volatile*>(&h->tagged_pyobj), nullptr, nullptr));
+#else
+  return __atomic_load_n(&h->tagged_pyobj, __ATOMIC_ACQUIRE);
+#endif
+}
+
+/*! \brief Release store of the word, publishing ``v`` to a later acquire.
+ *  \param h The allocation header.
+ *  \param v The new ``tagged_pyobj`` value to publish. */
+TVM_FFI_INLINE void WordStoreRelease(PyCustomAllocHeader* h, PyObject* v) {
+#if defined(_MSC_VER)
+  _InterlockedExchangePointer(reinterpret_cast<void* volatile*>(&h->tagged_pyobj), v);
+#else
+  __atomic_store_n(&h->tagged_pyobj, v, __ATOMIC_RELEASE);
+#endif
+}
+
+/*! \brief CAS, acquire-on-success (not acq_rel -- nothing synchronizes on the Locked-bit store it
+ *         publishes).
+ *  \param h The allocation header.
+ *  \param expect In: value to match; on failure, reloaded to the current word.
+ *  \param desired The value to store on a match.
+ *  \return True if ``*expect`` matched and ``desired`` stored; else false, ``*expect`` reloaded. */
+TVM_FFI_INLINE bool WordCASAcquire(PyCustomAllocHeader* h, PyObject** expect, PyObject* desired) {
+#if defined(_MSC_VER)
+  PyObject* prev = reinterpret_cast<PyObject*>(_InterlockedCompareExchangePointer(
+      reinterpret_cast<void* volatile*>(&h->tagged_pyobj), desired, *expect));
+  if (prev == *expect) return true;
+  *expect = prev;
+  return false;
+#else
+  return __atomic_compare_exchange_n(&h->tagged_pyobj, expect, desired, /*weak=*/true,
+                                     __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
+#endif
+}
+
+}  // namespace pyobj_detail
+}  // namespace ffi
+}  // namespace tvm
+
+/*! \brief Acquire the per-word spin-lock (CAS on the Locked bit); release it via
+ *         ``TVMFFIPyUnlockWord`` / ``TVMFFIPyUnlockKeep``.
+ *  \param h The allocation header whose word to lock.
+ *  \return The prior binding with the Locked bit cleared (the state to reason about while held). */
+TVM_FFI_INLINE PyObject* TVMFFIPyLockWord(PyCustomAllocHeader* h) {
+  for (;;) {
+    PyObject* cur = ::tvm::ffi::pyobj_detail::WordLoadRelaxed(h);
+    if (!TVMFFIPyTagIsLocked(cur)) {
+      PyObject* locked =
+          reinterpret_cast<PyObject*>(reinterpret_cast<uintptr_t>(cur) | kPyLockedTagBit);
+      // Acquire on success so the locked section happens-after the matching release.
+      if (::tvm::ffi::pyobj_detail::WordCASAcquire(h, &cur, locked)) {
+        return cur;
+      }
+      // CAS failed (lost the race or spurious); ``cur`` reloaded -- retry without
+      // yielding, the word was not Locked so contention is brief.
+      continue;
+    }
+    TVMFFIPySpinYield();
+  }
+}
+
+/*! \brief Release the lock, transitioning the binding to ``new_state``.
+ *  \param h The allocation header whose lock to release.
+ *  \param new_state The binding to publish (Active wrapper, Inactive|InTransit, or NULL). */
+TVM_FFI_INLINE void TVMFFIPyUnlockWord(PyCustomAllocHeader* h, PyObject* new_state) {
+  ::tvm::ffi::pyobj_detail::WordStoreRelease(h, new_state);
+}
+
+/*! \brief Release the lock leaving the binding unchanged (a no-op on the GIL arm).
+ *  \param h The allocation header whose lock to release.
+ *  \param cur The unchanged binding to republish (as returned by ``TVMFFIPyLockWord``). */
+TVM_FFI_INLINE void TVMFFIPyUnlockKeep(PyCustomAllocHeader* h, PyObject* cur) {
+  TVMFFIPyUnlockWord(h, cur);
+}
+
+/*! \brief Read the binding WITHOUT taking the lock (a lock-free peek). Acquire-ordered: this
+ *         standalone read is the sync edge, so an observed state happens-after its publishing
+ *         unlock. (The "acquire" is the memory order, not the lock; hence ``Peek``.)
+ *  \param h The allocation header.
+ *  \return The current binding (tag bits intact). */
+TVM_FFI_INLINE PyObject* TVMFFIPyPeekWord(PyCustomAllocHeader* h) {
+  return ::tvm::ffi::pyobj_detail::WordLoadAcquire(h);
+}
+
+/*! \brief Arm ``obj`` for a concurrent reader's ``TryIncRef``; sequence before publishing it Active
+ *         (no-op for NULL). ``PyUnstable_EnableTryIncRef`` is 3.14+ free-threading API, compiled
+ *         only on this arm.
+ *  \param obj The wrapper about to be published Active, or NULL. */
+TVM_FFI_INLINE void TVMFFIPyEnableTryIncRef(PyObject* obj) {
+  if (obj != nullptr) PyUnstable_EnableTryIncRef(obj);
+}
+
+/*! \brief Settle the binding and acquire the right to transition it. Returns with the lock
+ *         HELD in both outcomes:
+ *           (true,  cur)        Active   -- ``cur`` is the live wrapper, already inc-ref'd.
+ *           (false, W|Inactive) Inactive -- ``cur`` is a revivable cached allocation.
+ *           (false, NULL)       Detached -- no wrapper bound.
+ *           (true,  NULL)       cannot occur.
+ *         Waits out any in-flight dealloc handshake (marked InTransit) before settling.
+ *  \param h The allocation header.
+ *  \param out_pyobj Out: the settled binding (inc-ref'd live wrapper / cached alloc / NULL).
+ *  \return True on an Active hit (``*out_pyobj`` inc-ref'd); false for Inactive or Detached. */
+TVM_FFI_INLINE bool TVMFFIPyLockClassifyActive(PyCustomAllocHeader* h, PyObject** out_pyobj) {
+  for (;;) {
+    PyObject* cur = TVMFFIPyLockWord(h);
+    if (TVMFFIPyTagInTransit(cur)) {  // (1) a dealloc handshake is mid-transition
+      TVMFFIPyUnlockKeep(h, cur);
+      TVMFFIPySpinYield();
+      continue;
+    }
+    if (cur != nullptr && !TVMFFIPyTagIsInactive(cur)) {  // (2) Active candidate
+      // Branch (1) ruled out InTransit and this guard rules out Inactive, so no tag bits are
+      // set: ``cur`` is a bare, valid PyObject* -- safe to hand to TryIncRef.
+      if (PyUnstable_TryIncRef(cur)) {
+        *out_pyobj = cur;
+        return true;  // Active hit -- lock HELD, cur inc-ref'd
+      }
+      TVMFFIPyUnlockKeep(h, cur);  // dying: let its dealloc settle the word, then retry
+      TVMFFIPySpinYield();
+      continue;
+    }
+    *out_pyobj = cur;  // (3) Inactive(W) clean, or (4) Detached(NULL)
+    return false;      // lock HELD
+  }
+}
+
+#else
+// GIL build: the word is a plain field; the GIL is the lock. Each leaf is the exact field access
+// the pre-merge code performed (or a no-op where it did nothing); see the free-threaded arm above
+// for the full per-function contracts these mirror.
+/*! \brief GIL arm of ``TVMFFIPyLockWord``: a plain field read (the GIL is the lock). */
+TVM_FFI_INLINE PyObject* TVMFFIPyLockWord(PyCustomAllocHeader* h) { return h->tagged_pyobj; }
+/*! \brief GIL arm of ``TVMFFIPyUnlockWord``: a plain field store. */
+TVM_FFI_INLINE void TVMFFIPyUnlockWord(PyCustomAllocHeader* h, PyObject* new_state) {
+  h->tagged_pyobj = new_state;
+}
+/*! \brief GIL arm of ``TVMFFIPyUnlockKeep``: unchanged binding, so a no-op (no store). */
+TVM_FFI_INLINE void TVMFFIPyUnlockKeep(PyCustomAllocHeader*, PyObject*) {}
+/*! \brief GIL arm of ``TVMFFIPyPeekWord``: a plain field read. */
+TVM_FFI_INLINE PyObject* TVMFFIPyPeekWord(PyCustomAllocHeader* h) { return h->tagged_pyobj; }
+/*! \brief GIL arm of ``TVMFFIPyEnableTryIncRef``: no TryIncRef synchronizer on the GIL, a no-op. */
+TVM_FFI_INLINE void TVMFFIPyEnableTryIncRef(PyObject*) {}
+
+/*! \brief GIL arm of ``TVMFFIPyLockClassifyActive``: a plain field read + Py_INCREF on an Active
+ *         hit. The FT arm's TryIncRef + InTransit-wait loop has no GIL analog (the GIL serializes
+ *         everything), so this leaf stays split.
+ *  \param h The allocation header.
+ *  \param out_pyobj Out: the binding (INCREF'd live wrapper / cached alloc / NULL).
+ *  \return True on an Active hit; false for Inactive or Detached. */
+TVM_FFI_INLINE bool TVMFFIPyLockClassifyActive(PyCustomAllocHeader* h, PyObject** out_pyobj) {
+  PyObject* cur = h->tagged_pyobj;
+  if (cur != nullptr && !TVMFFIPyTagIsInactive(cur)) {  // Active: live canonical wrapper
+    Py_INCREF(cur);
+    *out_pyobj = cur;
+    return true;
+  }
+  *out_pyobj = cur;  // Inactive(W) or Detached(NULL)
+  return false;
+}
+#endif  // Py_GIL_DISABLED
+
+/*!
+ * \brief Per-thread vehicle carrying the inactive cached allocation address from
+ *        ``make_ret_object`` (which knows the chandle) down into
+ *        ``TVMFFIPyTpAlloc`` (which is handed only ``type`` and an item count).
+ *
+ * The slot's sole access primitive is a swap: store ``next``, return the prior
+ * value. Taking the block is thus ``TVMFFIPyTLSReviveSlot(nullptr)`` --
+ * read-and-clear in one step, with no separate clear to forget. Per-thread ->
+ * free-threading safe.
+ *
+ * \param next The value to store into the slot (a cached alloc to arm, or NULL to clear).
+ * \return The prior slot value (the armed block on a take, else NULL).
+ */
+inline PyObject* TVMFFIPyTLSReviveSlot(PyObject* next) {
+  static thread_local PyObject* slot = nullptr;
+  std::swap(slot, next);
+  return next;
+}
+
+/*! \brief Arm the cached allocation to be reused by the next ``tp_alloc`` on
+ *         this thread. Called by ``make_ret_object`` immediately before ``cls.__new__``.
+ *  \param cached_alloc The inactive cached allocation to revive on the next ``tp_alloc``. */
+TVM_FFI_INLINE void TVMFFIPySetReviveBlock(PyObject* cached_alloc) {
+  TVMFFIPyTLSReviveSlot(cached_alloc);
+}
+
+// Forward decl; defined below.
+//
+// NOTE: deliberately *not* TVM_FFI_INLINE. TVM_FFI_INLINE expands to
+// [[gnu::always_inline]] which forbids taking the function's address as
+// a stable, callable pointer — and we hand the address to the C++ side
+// (stored in PyCustomAllocHeader::base.delete_space at allocate time).
+inline void TVMFFIPyDeleteSpace(void* ptr);
+
+// Atexit-driven shutdown guard. ``TVMFFIPyMarkPythonFinalizing`` flips
+// the flag to false from an atexit hook registered in Cython module init;
+// ``TVMFFIPyDeleteSpace`` reads it via ``TVMFFIPyIsPythonAlive`` before
+// ``PyGILState_Ensure`` to avoid touching a teardown interpreter.
+/*! \brief The process-wide "Python still alive" flag storage (function-static).
+ *  \return Reference to the atomic flag (true until finalization begins). */
+inline std::atomic<bool>& TVMFFIPyAliveFlagStorage() {
+  static std::atomic<bool> flag{true};
+  return flag;
+}
+
+/*! \brief Whether Python is still alive (finalization has not begun).
+ *  \return True until ``TVMFFIPyMarkPythonFinalizing`` has fired. */
+inline bool TVMFFIPyIsPythonAlive() noexcept {
+  return TVMFFIPyAliveFlagStorage().load(std::memory_order_acquire);
+}
+
+/*! \brief Mark Python as finalizing (atexit hook); after this, ``delete_space`` skips the GIL. */
+inline void TVMFFIPyMarkPythonFinalizing() noexcept {
+  TVMFFIPyAliveFlagStorage().store(false, std::memory_order_release);
+}
+
+/*!
+ * \brief True iff ``chandle`` was allocated through the Python custom
+ *        allocator (full ``PyCustomAllocHeader`` ahead of it). False for
+ *        allocations that came through libtvm_ffi's builtin default
+ *        (only the base ``TVMFFIObjectAllocHeader``).
+ *
+ * Detection is by comparing ``base.delete_space`` against
+ * ``TVMFFIPyDeleteSpace``: each frontend recognizes its own deleter
+ * pointer, so multiple frontends can coexist without a flag bit on
+ * ``TVMFFIObject``.
+ *
+ * \param chandle The FFI object handle to test (NULL yields false).
+ * \return True iff ``chandle`` carries a ``PyCustomAllocHeader`` (our deleter).
+ */
+TVM_FFI_INLINE bool TVMFFIPyIsCanonical(void* chandle) {
+  if (chandle == nullptr) return false;
+  TVMFFIObjectAllocHeader* base = reinterpret_cast<TVMFFIObjectAllocHeader*>(
+      static_cast<char*>(chandle) - sizeof(TVMFFIObjectAllocHeader));
+  return base->delete_space == &TVMFFIPyDeleteSpace;
+}
+
+//---------------------------------------------------------------
+// Forward declarations shared by SECTION A (make_ret) and the lifecycle sections.
+//---------------------------------------------------------------
+
+/*! \brief Address of a CObject wrapper's ``chandle`` field (defined in object.pxi).
+ *  \param ptr The wrapper object.
+ *  \return Pointer to its ``chandle`` field. */
+__PYX_EXTERN_C void** TVMFFICyObjectGetCHandlePtr(PyObject* ptr);
+
+inline void TVMFFIPyTpFree(void* self);
+
+//---------------------------------------------------------------
+// SECTION A -- alloc / revival / make_ret (HOT: per construction / per FFI return).
+//---------------------------------------------------------------
+
+/*!
+ * \brief Allocator entry registered with TVMFFISetCustomAllocator at
+ *        Cython module init. Allocates ``sizeof(PyCustomAllocHeader) + size`` bytes
+ *        with ``alignment``, zero-inits the header to the Detached
+ *        state, wires ``base.delete_space = &TVMFFIPyDeleteSpace``, and
+ *        returns the T location.
+ *
+ * Handler::New static_asserts ``alignof(T) <= alignof(max_align_t)``, so
+ * the runtime ``alignment`` is bounded and ``base + sizeof(PyCustomAllocHeader)``
+ * (= ``base + 16``) lands T naturally aligned for any T we allocate.
+ *
+ * \param size The object body (``T``) size requested by the core allocator.
+ * \param alignment The required alignment of ``T``.
+ * \param type_index (unused) The FFI type index of the allocation.
+ * \param context (unused) The allocator context registered alongside this entry.
+ * \return Pointer to the ``T`` body (header prepended, Detached).
+ */
+inline void* TVMFFIPyAllocate(size_t size, size_t alignment, int32_t /*type_index*/,
+                              void* /*context*/) {
+  void* base_alloc =
+      ::tvm::ffi::details::AlignedAlloc(sizeof(PyCustomAllocHeader) + size, alignment);
+  auto* h = static_cast<PyCustomAllocHeader*>(base_alloc);
+  h->tagged_pyobj = nullptr;  // Detached
+  h->base.delete_space = &TVMFFIPyDeleteSpace;
+  return static_cast<char*>(base_alloc) + sizeof(PyCustomAllocHeader);
+}
+
+/*! \brief Allocate (fresh) or revive (in place, at ``revive``'s address) a wrapper of
+ *         type ``tp`` via ``tp_new``. Build-agnostic: touches no word state, only the per-thread
+ *         revive slot + ``tp_new``; shared by both builds' ``TVMFFIPyMakeRetObject``.
+ *
+ * On return ``*out_revive_consumed`` reports whether ``revive`` was taken out of the slot by a
+ * ``tp_alloc`` (revived in place). The caller needs this on the failure path: a consumed block no
+ * longer exists (the failed instance's ``tp_free`` freed it), so the word must NOT be republished
+ * as ``Inactive(revive)`` -- that would dangle. May be NULL when ``revive`` is NULL.
+ *
+ *  \param tp The wrapper type to instantiate.
+ *  \param revive An inactive cached allocation to revive in place, or NULL for a fresh alloc.
+ *  \param out_revive_consumed Out: set true iff ``revive`` (non-NULL) was consumed by a tp_alloc.
+ *  \return A new reference (refcount 1), or NULL with a Python error set. */
+inline PyObject* TVMFFIPyNewWrapper(PyTypeObject* tp, PyObject* revive, bool* out_revive_consumed) {
+  if (out_revive_consumed != nullptr) *out_revive_consumed = false;
+  if (revive != nullptr) TVMFFIPySetReviveBlock(revive);
+  PyObject* args = PyTuple_New(0);
+  // Near-dead (() is an immortal singleton) but required: tp_new does PyTuple_GET_SIZE(args)
+  // unchecked, so a NULL here would segfault rather than report.
+  if (args == nullptr) {
+    TVMFFIPySetReviveBlock(nullptr);  // disarm: tp_new will not run
+    return nullptr;
+  }
+  PyObject* obj = tp->tp_new(tp, args, nullptr);
+  Py_DECREF(args);
+  // Clear the slot and observe whether tp_alloc consumed the armed block: a cleared slot
+  // (leftover != revive) means the block was revived in place -- and on a tp_new failure its bytes
+  // were then freed by tp_free -- so the caller must not republish it as Inactive(revive).
+  PyObject* leftover = TVMFFIPyTLSReviveSlot(nullptr);
+  if (out_revive_consumed != nullptr) {
+    *out_revive_consumed = (revive != nullptr && leftover != revive);
+  }
+  return obj;
+}
+
+/*!
+ * \brief Set ``chandle``'s cached canonical PyObject to ``new_object``, but only if the word is
+ *        still what the caller expected (``cur == expect``, or Detached); otherwise leave it
+ *        untouched. ``new_object == NULL`` clears the binding. No-op for non-canonical chandles.
+ *
+ * All three callers are the same conditional set -- "make ``new_object`` canonical iff the word is
+ * still ``expect``" -- differing only in the arguments:
+ *   - construct (object.pxi, ``expect=NULL, new=self``): a fresh wrapper claims a just-constructed
+ *     chandle; Detached is expected because nothing else holds this brand-new chandle yet.
+ *   - move (object.pxi ``__move_handle_from__``, ``expect=other, new=self``): hand canonical status
+ *     from ``other`` to ``self``.
+ *   - detach (function.pxi rvalue-ref setter, ``expect=src, new=NULL``): clear the binding before a
+ *     move nulls the source chandle.
+ *
+ * If the word is NOT ``expect`` (a concurrent make_ret or move rebound it first), the set simply
+ * no-ops -- ``new_object`` stays a valid wrapper that owns the chandle but is not the canonical
+ * one. The only cost is a missed identity share; its ``tp_dealloc`` sees ``cur != wrapper``, takes
+ * the not-ours branch, and genuine-frees without touching the cache.
+ *
+ * \param chandle    FFI object handle whose cached-wrapper word is (re)bound; non-canonical: no-op.
+ * \param expect     Rebind only if the current binding equals this (Detached also matches).
+ * \param new_object Wrapper to publish as canonical, or NULL to detach.
+ */
+TVM_FFI_INLINE void TVMFFIPyCompareAndRebindPyObject(void* chandle, PyObject* expect,
+                                                     PyObject* new_object) {
+  if (!TVMFFIPyIsCanonical(chandle)) return;
+  PyCustomAllocHeader* h = TVMFFIPyHeader(chandle);
+  // Arm before publishing Active, so a racing Active-hit make_ret can safely TryIncRef
+  // ``new_object`` (no-op for new_object == NULL and on the GIL build).
+  TVMFFIPyEnableTryIncRef(new_object);
+  PyObject* cur = TVMFFIPyLockWord(h);
+  if (cur == expect || cur == nullptr) {
+    TVMFFIPyUnlockWord(h, new_object);  // publish new_object (Active, or Detached when NULL)
+  } else {
+    TVMFFIPyUnlockKeep(h, cur);  // not ours / busy: release unchanged (GIL: no store)
+  }
+}
+
+/*!
+ * \brief Wrap a returned ``chandle`` into its canonical Python wrapper -- the
+ *        whole Detached / Active / Inactive transition in one frame, behind
+ *        Cython's ``make_ret_object``.
+ *
+ * The caller owns +1 (strong) on ``chandle``; ownership transfers to the
+ * returned wrapper. Returns a new owned reference, or NULL with a Python error
+ * set (the Cython side declares this ``object``, so NULL propagates as an
+ * exception).
+ *
+ * \param chandle The returned object handle (caller owns +1 strong).
+ * \param cls_type The wrapper class to instantiate (a ``PyTypeObject*``).
+ * \return New owned wrapper reference, or NULL with a Python error set.
+ */
+// make_ret: one shared body over the four word states, written against the make_ret leaves.
+//   Non-canonical  -> fresh wrapper, no tie (FT cannot even locate a header here).
+//   Active         -> return the live canonical wrapper (classify inc-ref'd it).
+//   Inactive(W)    -> revive W in place at the same address (stable id()).
+//   Detached(NULL) -> fresh wrapper, bound canonical.
+inline PyObject* TVMFFIPyMakeRetObject(void* chandle, PyObject* cls_type) {
+  PyTypeObject* tp = reinterpret_cast<PyTypeObject*>(cls_type);
+  // Non-canonical chandle (no Python alloc header, e.g. a C++-static registry object):
+  // never tied -- wrap fresh, transferring the caller's +1.
+  if (!TVMFFIPyIsCanonical(chandle)) {
+    PyObject* obj = TVMFFIPyNewWrapper(tp, nullptr, nullptr);
+    if (obj == nullptr) {  // live OOM/tp_new failure: release the caller's +1 before propagating
+      TVMFFIObjectDecRef(chandle);
+      return nullptr;
+    }
+    *TVMFFICyObjectGetCHandlePtr(obj) = chandle;
+    return obj;
+  }
+  PyCustomAllocHeader* h = TVMFFIPyHeader(chandle);
+  PyObject* cur;
+  // Active hit: return the live canonical wrapper (classify inc-ref'd it); drop caller's +1.
+  if (TVMFFIPyLockClassifyActive(h, &cur)) {
+    TVMFFIPyUnlockKeep(h, cur);
+    TVMFFIObjectDecRef(chandle);
+    return cur;
+  }
+  // Inactive(W) -> revive at W's address, Detached(NULL) -> fresh. ``classify`` returned the lock
+  // HELD and we KEEP it across the alloc, so a peer make_ret just spins on ``LockWord`` until we
+  // publish -- one critical section, no InTransit needed here (like the GIL build).
+  PyObject* reused_pyobj_space = TVMFFIPyRemoveTag(cur);
+  // NOTE: alloc runs UNDER the lock, so a tied ``__cinit__`` must not re-enter the tie on this same
+  // chandle (would self-deadlock). Holds today: tied ``__cinit__`` only nulls the chandle field.
+  bool revive_consumed = false;
+  PyObject* obj = TVMFFIPyNewWrapper(tp, reused_pyobj_space,
+                                     &revive_consumed);  // alloc / revive WITH LOCK HELD
+  if (obj == nullptr) {
+    // OOM/tp_new failure. If a tp_alloc already revived (and thus, on failure, freed) the cached
+    // block, ``reused_pyobj_space`` no longer exists: publish Detached, NOT Inactive(W), or the
+    // word would dangle at freed bytes (double free when the chandle later dies). If it was
+    // untouched (failure before tp_alloc), restore the original word (Inactive(W) / Detached).
+    TVMFFIPyUnlockWord(h, revive_consumed ? nullptr : cur);
+    TVMFFIObjectDecRef(chandle);
+    return nullptr;
+  }
+  *TVMFFICyObjectGetCHandlePtr(obj) = chandle;  // caller's +1 transfers to obj
+  TVMFFIPyEnableTryIncRef(obj);
+  TVMFFIPyUnlockWord(h, obj);  // release, publish Active(obj)
+  return obj;
+}
+
+/*!
+ * \brief True iff a wrapper of ``wrapper``'s type may be cached & revived.
+ *
+ * Requirements (all must hold, else we genuinely free and lose only
+ * stable-id-across-drop):
+ *  - GC type: revival re-tracks and genuine free / reclaim use GC_Del.
+ *  - our custom ``tp_free`` is installed: otherwise the generic free would
+ *    reclaim the block while ``tagged_pyobj`` still points at it (UAF).
+ *  - no instance ``__dict__`` (plain or managed): reusing a cached allocation whose dict
+ *    region was cleared would need dict re-init we do not perform. Lean
+ *    wrappers (the common, tested case) have ``tp_dictoffset == 0``.
+ *  - no finalizer (``tp_finalize``, i.e. a Python ``__del__``): CPython sets
+ *    a permanent GC-finalized bit the first time ``tp_finalize`` runs and
+ *    never runs it again on that block. Reusing an inactive cached allocation would silently
+ *    suppress ``__del__`` for every revived generation (the cached allocation's bit is
+ *    already set and there is no public API to clear it). Excluding these
+ *    types makes ``__del__`` fire correctly once per drop (genuine free each
+ *    time); the only cost is no stable-id-across-drop.
+ *
+ * \param wrapper A live wrapper whose type is examined.
+ * \return True iff its type may be cached and revived (all requirements above hold).
+ */
+TVM_FFI_INLINE bool TVMFFIPyIsInactiveEligible(PyObject* wrapper) {
+  PyTypeObject* tp = Py_TYPE(wrapper);
+  if (!PyType_IS_GC(tp)) return false;
+  if (tp->tp_free != &TVMFFIPyTpFree) return false;
+  if (tp->tp_dictoffset != 0) return false;
+  if ((tp->tp_flags & Py_TPFLAGS_MANAGED_DICT) != 0) return false;
+  if (tp->tp_finalize != nullptr) return false;
+  return true;
+}
+
+/*!
+ * \brief Custom ``tp_alloc``. On the revival path (an inactive cached allocation was handed
+ *        to this thread via ``TVMFFIPySetReviveBlock``) it revives the cached allocation
+ *        in place — same address, so ``id()`` is stable — re-initializing it
+ *        to match ``PyType_GenericAlloc``'s contract. Otherwise (miss) it
+ *        forwards to ``PyType_GenericAlloc`` for a fresh, tracked object.
+ *
+ * Revive-path contract (must match what ``tp_new`` expects from
+ * ``PyType_GenericAlloc``):
+ *  1. zero the body ``[sizeof(PyObject), tp_basicsize)`` so ``__cinit__``
+ *     sees clean fields;
+ *  2. ``PyObject_Init`` -> ob_refcnt = 1, ob_type, INCREF(type);
+ *  3. ``PyObject_GC_Track`` -> GenericAlloc returns a *tracked* object and
+ *     ``tp_new`` does not track again, so the revive path must track.
+ * (No stale GC-finalized bit to clear: the design uses no tp_finalize.)
+ *
+ * Fixed-size only: ``PyObject_Init`` resets ``ob_refcnt``/``ob_type`` but not
+ * ``ob_size``. Every registered FFI wrapper is a fixed-size cdef class
+ * (``tp_itemsize == 0``), asserted below; a future variable-sized type would
+ * need ``PyObject_InitVar(.., nitems)`` here and a matching basicsize check.
+ *
+ * \param type The wrapper type being allocated.
+ * \param nitems Item count for variable-sized types (0 for our fixed-size wrappers);
+ *        forwarded to ``PyType_GenericAlloc`` on the miss path.
+ * \return The revived cached allocation (same address) on a hit, else a fresh tracked object.
+ */
+inline PyObject* TVMFFIPyTpAlloc(PyTypeObject* type, Py_ssize_t nitems) {
+  // Take the revive block and leave the slot NULL in one step (per-thread).
+  PyObject* blk = TVMFFIPyTLSReviveSlot(nullptr);
+  if (blk != nullptr) {
+    // REVIVAL: revive the inactive cached allocation at the same address. The body memset
+    // below assumes ``type->tp_basicsize`` equals the cached allocation's original
+    // basicsize. This holds because a chandle's ``type_index`` maps to one
+    // stable wrapper class for the life of the process, and ``make_ret_object``
+    // derives both the cached allocation (from the chandle) and ``type`` (= cls for that
+    // same type_index) from the very same chandle on the revival path.
+    assert(type->tp_itemsize == 0 &&
+           "cache-&-revive supports only fixed-size wrappers; a variable-sized "
+           "type needs PyObject_InitVar and a per-instance basicsize check");
+    std::memset(reinterpret_cast<char*>(blk) + sizeof(PyObject), 0,
+                static_cast<size_t>(type->tp_basicsize) - sizeof(PyObject));
+    PyObject_Init(blk, type);
+    PyObject_GC_Track(blk);
+    return blk;
+  }
+  return PyType_GenericAlloc(type, nitems);  // MISS: fresh (already tracked)
+}
+
+//---------------------------------------------------------------
+// SECTION B -- dealloc (HOT: per wrapper death).
+//---------------------------------------------------------------
+
+/*!
+ * \brief Custom ``tp_free``, the second step of the dealloc handshake. The InTransit bit
+ *        (read here) says whether the chandle's deleter fired during the
+ *        ``TVMFFIPyTpDealloc`` DecRef: still set => the chandle outlived us, settle to
+ *        Inactive and keep ``self`` cached; cleared => free the C++ block too. The
+ *        ``chandle == NULL`` / non-canonical path is a plain genuine free, dispatching on
+ *        GC-ness like CPython's default.
+ *
+ * \param self The wrapper being freed (CPython's ``tp_free`` argument).
+ */
+inline void TVMFFIPyTpFree(void* self) {
+  void** chandle_ptr = TVMFFICyObjectGetCHandlePtr(static_cast<PyObject*>(self));
+  void* chandle = *chandle_ptr;
+  if (chandle != nullptr && TVMFFIPyIsCanonical(chandle)) {
+    PyCustomAllocHeader* h = TVMFFIPyHeader(chandle);  // header read BEFORE any free below
+    PyObject* cur = TVMFFIPyLockWord(h);
+    if (TVMFFIPyTagInTransit(cur)) {
+      // Case 0 (Flow 1): chandle outlived us -- settle to stable Inactive, keep ``self`` cached.
+      // continuation: delete_space reclaims this block when the chandle later dies.
+      // ``*chandle_ptr = nullptr`` MUST precede the publish (still under the lock): else a
+      // make_ret revive could grab the Inactive word and re-set the chandle, only for this
+      // stale NULL to clobber it (Active wrapper with chandle == NULL -> crash).
+      *chandle_ptr = nullptr;
+      TVMFFIPyUnlockWord(h, TVMFFIPyTagClearInTransit(cur));
+      return;
+    }
+    // Case 1 (Flow 2): deleter already fired and deferred the block free to us.
+    // continuation: none -- we are the last settler and free the block here.
+    *chandle_ptr = nullptr;
+    TVMFFIPyUnlockKeep(h, cur);
+    ::tvm::ffi::details::AlignedFree(static_cast<char*>(chandle) - sizeof(PyCustomAllocHeader));
+  }
+  PyObject* op = static_cast<PyObject*>(self);
+  if (PyObject_IS_GC(op)) {
+    PyObject_GC_Del(op);
+  } else {
+    PyObject_Free(op);
+  }
+}
+
+/*!
+ * \brief delete_space callback (installed by TVMFFIPyAllocate), invoked from the C++ Weak
+ *        deleter when the chandle's block's weak count hits 0. Detached => free the block
+ *        (lock-free fast path, the common C++-only-object case). Inactive => read InTransit:
+ *        set => an in-flight ``tp_free`` will free the block, so defer; clear => reclaim the
+ *        cached wrapper and free the block here.
+ *
+ * At weak->0 there are no live refs, so the binding is only ever Detached or
+ * Inactive(|InTransit) -- never Active/Locked.
+ *
+ * \param ptr The object (``T``) pointer whose C++ block reached weak-count 0.
+ */
+inline void TVMFFIPyDeleteSpace(void* ptr) {
+  void* base_alloc = static_cast<char*>(ptr) - sizeof(PyCustomAllocHeader);
+  auto* h = static_cast<PyCustomAllocHeader*>(base_alloc);
+  PyObject* cur0 = TVMFFIPyPeekWord(h);
+  if (!TVMFFIPyTagIsInactive(cur0)) {  // Detached: lock-free free
+    ::tvm::ffi::details::AlignedFree(base_alloc);
+    return;
+  }
+  if (TVMFFIPyIsPythonAlive()) {
+    PyGILState_STATE gstate = PyGILState_Ensure();
+    if (TVMFFIPyIsPythonAlive()) {
+      PyObject* cur = TVMFFIPyLockWord(h);
+      if (TVMFFIPyTagInTransit(cur)) {
+        // In-flight: defer both frees to tp_free; keep the block.
+        TVMFFIPyUnlockWord(h, TVMFFIPyTagClearInTransit(cur));
+        PyGILState_Release(gstate);
+        return;
+      }
+      // Settled: detach, reclaim the cached wrapper (outside the word lock), then
+      // free the block below.
+      PyObject* wrapper = TVMFFIPyRemoveTag(cur);
+      TVMFFIPyUnlockWord(h, nullptr);
+      PyObject_GC_Del(wrapper);
+      PyGILState_Release(gstate);
+    } else {
+      PyGILState_Release(gstate);
+    }
+  } else if (TVMFFIPyTagInTransit(cur0)) {
+    // Teardown, same-thread in-flight: defer the block free. No lock is held here (Python is
+    // finalizing single-threaded, no thread state to lock under) -- this is the one word
+    // store in the file with no matching TVMFFIPyLockWord; the release-store is still correct.
+    TVMFFIPyUnlockWord(h, TVMFFIPyTagClearInTransit(cur0));
+    return;
+  }
+  ::tvm::ffi::details::AlignedFree(base_alloc);
+}
+
+/*!
+ * \brief ``__dealloc__`` hook (Cython's ``CObject.__dealloc__`` calls it). Build-agnostic: the same
+ *        binding transition runs on both the GIL and free-threaded builds.
+ *
+ * Releases the wrapper's +1 on the chandle and opens the cache-vs-free handshake for an eligible
+ * canonical wrapper. Four cases, keyed on the wrapper's relationship to the chandle's binding word:
+ *   - chandle already NULL: an eager move (``__move_handle_from__`` / rvalue-ref setter) already
+ *     detached and released this wrapper's ref -- nothing owed, return.
+ *   - eligible canonical Active binding (``cur == wrapper``): Active -> Inactive | InTransit, keep
+ *     the cached allocation for in-place revival, then DecRef (``tp_free`` settles the handshake).
+ *   - ineligible canonical Active binding (``cur == wrapper``): Active -> Detached before the
+ *     DecRef, then fall through to the genuine-free tail.
+ *   - not our binding (``cur != wrapper``) or non-canonical chandle: some other wrapper is (or no
+ *     wrapper is) canonical for this chandle -- leave the word untouched and fall through to the
+ *     genuine-free tail.
+ * The DecRef MUST run outside the lock: it can fire the chandle deleter (``TVMFFIPyDeleteSpace``),
+ * which re-locks the same non-reentrant word.
+ *
+ * \param ptr_to_chandle Address of the wrapper's ``chandle`` field (nulled here before the DecRef).
+ * \param wrapper The dying wrapper (used to check it is still the canonical binding).
+ */
+TVM_FFI_INLINE void TVMFFIPyTpDealloc(void** ptr_to_chandle, PyObject* wrapper) {
+  void* chandle = *ptr_to_chandle;
+  // Case: chandle already NULL. Released by an eager move (detached to NULL); nothing to do. NULL
+  // is the only released state here -- the transit marker lives in ``tagged_pyobj``, not here.
+  if (chandle == nullptr) return;
+  if (TVMFFIPyIsCanonical(chandle)) {
+    PyCustomAllocHeader* h = TVMFFIPyHeader(chandle);
+    PyObject* cur = TVMFFIPyLockWord(h);
+    if (cur == wrapper) {
+      // We ARE the canonical wrapper for this chandle.
+      if (TVMFFIPyIsInactiveEligible(wrapper)) {
+        // Case: eligible canonical binding. Active -> Inactive | InTransit, then DecRef outside the
+        // lock. continuation: the DecRef either leaves the chandle alive (-> tp_free keeps it
+        // cached, delete_space frees later: Flow 1) or drops its last ref (-> delete_space fires
+        // reentrantly and defers, tp_free frees: Flow 2). See the handshake flows up top.
+        TVMFFIPyUnlockWord(
+            h, reinterpret_cast<PyObject*>(reinterpret_cast<uintptr_t>(wrapper) |
+                                           kPyCachedInactiveTagBit | kPyInTransitTagBit));
+        TVMFFIObjectDecRef(chandle);
+        return;
+      }
+      // Case: ineligible canonical binding. Active -> Detached. Publish NULL before the DecRef so a
+      // deleter firing inside it sees no stale Active binding; then fall to the genuine-free tail.
+      TVMFFIPyUnlockWord(h, nullptr);
+    } else {
+      // Case: not our binding (``cur != wrapper``). A concurrent make_ret / move made a DIFFERENT
+      // wrapper canonical for this chandle (or it is Detached/Inactive). Leave the word as-is --
+      // this wrapper only owns its +1 -- and fall to the genuine-free tail. (GIL: no store.)
+      TVMFFIPyUnlockKeep(h, cur);
+    }
+  }
+  // Tail (ineligible / not-ours / non-canonical): no handshake -- genuine free. Null
+  // ``wrapper.chandle`` BEFORE the DecRef so the deleter chain observes a consistent
+  // (chandle == NULL, no +1 owed) state. tp_free then genuine-frees the wrapper storage.
+  *ptr_to_chandle = nullptr;
+  TVMFFIObjectDecRef(chandle);
+}
+
+//---------------------------------------------------------------
+// SECTION C -- installation (COLD: once per registered type / once per process).
+//---------------------------------------------------------------
+
+/*! \brief Install the custom ``tp_alloc`` / ``tp_free`` (cache-&-revive) slots on ``type_obj``.
+ *         Called once per registered FFI type from ``_update_registry`` (object.pxi).
+ *  \param type_obj The registered wrapper type (must be a type object; ignored otherwise). */
+TVM_FFI_INLINE void TVMFFIPyInstallTypeSlots(PyObject* type_obj) {
+  if (type_obj == nullptr || !PyType_Check(type_obj)) return;
+  PyTypeObject* tp = reinterpret_cast<PyTypeObject*>(type_obj);
+  tp->tp_alloc = &TVMFFIPyTpAlloc;
+  tp->tp_free = &TVMFFIPyTpFree;
+}
+
+/*!
+ * \brief Install ``TVMFFIPyAllocate`` as the process-wide custom allocator.
+ *        Storage for the registered entry is a function-static so the
+ *        address is process-stable.
+ * \return The status code from ``TVMFFISetCustomAllocator`` (0 on success).
+ */
+TVM_FFI_INLINE int TVMFFIPyRegisterDefaultAllocator() {
+  // Installed on both the GIL and free-threaded builds; on free-threaded builds the
+  // header state machine is lock-synchronized (see "Free-threaded builds" above).
+  static TVMFFICustomAllocator allocator{&TVMFFIPyAllocate, /*context=*/nullptr};
+  return TVMFFISetCustomAllocator(&allocator);
+}
+
+#endif  // TVM_FFI_PYTHON_OBJECT_H_

--- a/rust/tvm-ffi-sys/src/c_api.rs
+++ b/rust/tvm-ffi-sys/src/c_api.rs
@@ -384,7 +384,31 @@ pub struct TVMFFITypeInfo {
     pub metadata: *const TVMFFITypeMetadata,
 }
 
+/// Mandatory header preceding each Object body. See `TVMFFIObjectAllocHeader`
+/// in `tvm/ffi/c_api.h`.
+#[repr(C)]
+pub struct TVMFFIObjectAllocHeader {
+    pub delete_space: Option<unsafe extern "C" fn(ptr: *mut c_void)>,
+}
+
+/// Custom allocator entry. See `TVMFFICustomAllocator` in `tvm/ffi/c_api.h`.
+#[repr(C)]
+pub struct TVMFFICustomAllocator {
+    pub allocate: Option<
+        unsafe extern "C" fn(
+            size: usize,
+            alignment: usize,
+            type_index: i32,
+            context: *mut c_void,
+        ) -> *mut c_void,
+    >,
+    pub context: *mut c_void,
+}
+
 unsafe extern "C" {
+    pub fn TVMFFIGetCustomAllocator() -> *mut TVMFFICustomAllocator;
+    pub fn TVMFFISetCustomAllocator(allocator: *mut TVMFFICustomAllocator) -> i32;
+
     pub fn TVMFFITypeKeyToIndex(type_key: *const TVMFFIByteArray, out_tindex: *mut i32) -> i32;
     pub fn TVMFFIFunctionGetGlobal(
         name: *const TVMFFIByteArray,

--- a/rust/tvm-ffi/src/object.rs
+++ b/rust/tvm-ffi/src/object.rs
@@ -22,7 +22,7 @@ use std::sync::atomic::AtomicU64;
 use crate::derive::ObjectRef;
 pub use tvm_ffi_sys::TVMFFITypeIndex as TypeIndex;
 /// Object related ABI handling
-use tvm_ffi_sys::{TVMFFIObject, COMBINED_REF_COUNT_BOTH_ONE};
+use tvm_ffi_sys::{TVMFFIGetCustomAllocator, TVMFFIObject, COMBINED_REF_COUNT_BOTH_ONE};
 
 /// Object type is by default the TVMFFIObject
 #[repr(C)]
@@ -120,7 +120,7 @@ pub(crate) mod unsafe_ {
 
     use std::ffi::c_void;
     use std::sync::atomic::{fence, Ordering};
-    use tvm_ffi_sys::TVMFFIObject;
+    use tvm_ffi_sys::{TVMFFIObject, TVMFFIObjectAllocHeader};
     use tvm_ffi_sys::TVMFFIObjectDeleterFlagBitMask::{
         kTVMFFIObjectDeleterFlagBitMaskBoth, kTVMFFIObjectDeleterFlagBitMaskStrong,
         kTVMFFIObjectDeleterFlagBitMaskWeak,
@@ -197,63 +197,24 @@ pub(crate) mod unsafe_ {
         (obj.combined_ref_count.load(Ordering::Relaxed) >> 32) as usize
     }
 
-    /// Generic object deleter that works for object allocated from Box then into_raw
+    /// Generic object deleter for objects allocated through the registered
+    /// `TVMFFICustomAllocator`.
     pub unsafe extern "C" fn object_deleter_for_new<T>(ptr: *mut c_void, flags: i32)
     where
         T: super::ObjectCore,
     {
         let obj = ptr as *mut T;
         if flags & kTVMFFIObjectDeleterFlagBitMaskStrong as i32 != 0 {
-            // calling destructor of the object, does not free the memory
             std::ptr::drop_in_place(obj);
         }
         if flags & kTVMFFIObjectDeleterFlagBitMaskWeak as i32 != 0 {
-            // free the memory
-            std::alloc::dealloc(ptr as *mut u8, std::alloc::Layout::new::<T>());
-        }
-    }
-
-    pub unsafe extern "C" fn object_deleter_for_new_with_extra_items<T, U>(
-        ptr: *mut c_void,
-        flags: i32,
-    ) where
-        T: super::ObjectCoreWithExtraItems<ExtraItem = U>,
-    {
-        let obj = ptr as *mut T;
-        if flags == kTVMFFIObjectDeleterFlagBitMaskBoth as i32 {
-            // must get extra items count before dropping the object
-            let extra_items_count = T::extra_items_count(&(*obj));
-            std::ptr::drop_in_place(obj);
-            let layout = std::alloc::Layout::from_size_align(
-                std::mem::size_of::<T>() + extra_items_count * std::mem::size_of::<U>(),
-                std::mem::align_of::<T>(),
-            )
-            .unwrap();
-            // free the memory
-            std::alloc::dealloc(ptr as *mut u8, layout);
-        } else {
-            assert_eq!(std::mem::size_of::<T>() % std::mem::size_of::<u64>(), 0);
-            if flags & kTVMFFIObjectDeleterFlagBitMaskStrong as i32 != 0 {
-                // must get extra items count before dropping the object
-                let extra_items_count = T::extra_items_count(&(*obj));
-                // calling destructor of the object, does not free the memory
-                std::ptr::drop_in_place(obj);
-                // record extra count in the original memory
-                std::ptr::write(obj as *mut u64, extra_items_count as u64);
-            }
-            if flags & kTVMFFIObjectDeleterFlagBitMaskWeak as i32 != 0 {
-                // read extra items count from the original memory
-                // note we can no longer read it by calling T::extra_items_count(&(*obj))
-                // because the object is already dropped
-                let extra_items_count = std::ptr::read(obj as *mut u64) as usize;
-                let layout = std::alloc::Layout::from_size_align(
-                    std::mem::size_of::<T>() + extra_items_count * std::mem::size_of::<U>(),
-                    std::mem::align_of::<T>(),
-                )
-                .unwrap();
-                // free the memory
-                std::alloc::dealloc(ptr as *mut u8, layout);
-            }
+            let header_ptr = (ptr as *mut u8)
+                .sub(std::mem::size_of::<TVMFFIObjectAllocHeader>())
+                as *mut TVMFFIObjectAllocHeader;
+            let delete_space = (*header_ptr)
+                .delete_space
+                .expect("TVMFFIObjectAllocHeader::delete_space must be set by the allocator");
+            delete_space(ptr);
         }
     }
 }
@@ -285,14 +246,24 @@ unsafe impl ObjectCore for Object {
 //---------------------
 // ObjectArc
 //---------------------
+
+/// Allocate via the process-wide `TVMFFICustomAllocator`.
+unsafe fn allocate_via_registry(size: usize, alignment: usize, type_index: i32) -> *mut u8 {
+    let alloc = TVMFFIGetCustomAllocator();
+    let allocate_fn = (*alloc)
+        .allocate
+        .expect("TVMFFICustomAllocator::allocate must be set");
+    allocate_fn(size, alignment, type_index, (*alloc).context) as *mut u8
+}
+
 impl<T: ObjectCore> ObjectArc<T> {
     pub fn new(data: T) -> Self {
         unsafe {
-            let layout = std::alloc::Layout::new::<T>();
-            let raw_data_ptr = std::alloc::alloc(layout);
-            if raw_data_ptr.is_null() {
-                std::alloc::handle_alloc_error(layout);
-            }
+            let raw_data_ptr = allocate_via_registry(
+                std::mem::size_of::<T>(),
+                std::mem::align_of::<T>(),
+                T::type_index(),
+            );
             let ptr = raw_data_ptr as *mut T;
             std::ptr::write(ptr, data);
             // now override the header directly
@@ -322,15 +293,9 @@ impl<T: ObjectCore> ObjectArc<T> {
             assert_eq!(std::mem::align_of::<T>() % std::mem::align_of::<U>(), 0);
             assert_eq!(std::mem::size_of::<T>() % std::mem::align_of::<U>(), 0);
             let extra_items_count = T::extra_items_count(&data);
-            let layout = std::alloc::Layout::from_size_align(
-                std::mem::size_of::<T>() + extra_items_count * std::mem::size_of::<U>(),
-                std::mem::align_of::<T>(),
-            )
-            .unwrap();
-            let raw_data_ptr = std::alloc::alloc(layout);
-            if raw_data_ptr.is_null() {
-                std::alloc::handle_alloc_error(layout);
-            }
+            let total_size = std::mem::size_of::<T>() + extra_items_count * std::mem::size_of::<U>();
+            let raw_data_ptr =
+                allocate_via_registry(total_size, std::mem::align_of::<T>(), T::type_index());
             let ptr = raw_data_ptr as *mut T;
             std::ptr::write(ptr, data);
             // now override the header directly
@@ -340,7 +305,7 @@ impl<T: ObjectCore> ObjectArc<T> {
                     combined_ref_count: AtomicU64::new(COMBINED_REF_COUNT_BOTH_ONE),
                     type_index: T::type_index(),
                     __padding: 0,
-                    deleter: Some(unsafe_::object_deleter_for_new_with_extra_items::<T, U>),
+                    deleter: Some(unsafe_::object_deleter_for_new::<T>),
                 },
             );
             // move into the object arc ptr

--- a/src/ffi/custom_allocator.cc
+++ b/src/ffi/custom_allocator.cc
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * \file src/ffi/custom_allocator.cc
+ * \brief Process-wide registry for the custom Object allocator and the
+ *        builtin default allocator behind it. See ObjAllocatorBase /
+ *        Handler::New in <tvm/ffi/memory.h> for the allocator contract.
+ */
+#include <tvm/ffi/base_details.h>
+#include <tvm/ffi/c_api.h>
+#include <tvm/ffi/error.h>
+#include <tvm/ffi/function.h>
+#include <tvm/ffi/memory.h>
+
+namespace tvm {
+namespace ffi {
+namespace {
+
+// Fixed body offset: the deleter gets only the body pointer (no size/alignment),
+// so allocate and free must agree on a single offset. alignof(max_align_t) is a
+// multiple of every supported object alignment (capped there in memory.h) and is
+// >= the header, so the body stays aligned and the header fits before it.
+constexpr size_t kBuiltinDefaultBodyOffset = alignof(std::max_align_t);
+static_assert(kBuiltinDefaultBodyOffset >= sizeof(TVMFFIObjectAllocHeader));
+
+void BuiltinDefaultDeleteSpace(void* ptr) {
+  details::AlignedFree(static_cast<char*>(ptr) - kBuiltinDefaultBodyOffset);
+}
+
+void* BuiltinDefaultAllocate(size_t size, size_t alignment, int32_t /*type_index*/,
+                             void* /*context*/) {
+  void* base_alloc = details::AlignedAlloc(kBuiltinDefaultBodyOffset + size, alignment);
+  void* ptr = static_cast<char*>(base_alloc) + kBuiltinDefaultBodyOffset;
+  details::ObjectUnsafe::GetObjectAllocHeaderFromPtr(ptr)->delete_space =
+      &BuiltinDefaultDeleteSpace;
+  return ptr;
+}
+
+class CustomAllocatorRegistry {
+ public:
+  CustomAllocatorRegistry() : current_(BuiltinDefault()) {}
+
+  TVMFFICustomAllocator* Get() const { return current_; }
+
+  void Set(TVMFFICustomAllocator* allocator) {
+    current_ = allocator != nullptr ? allocator : BuiltinDefault();
+  }
+
+  static CustomAllocatorRegistry* Global() {
+    static CustomAllocatorRegistry inst;
+    return &inst;
+  }
+
+ private:
+  static TVMFFICustomAllocator* BuiltinDefault() {
+    static TVMFFICustomAllocator builtin{&BuiltinDefaultAllocate, /*context=*/nullptr};
+    return &builtin;
+  }
+
+  TVMFFICustomAllocator* current_;
+};
+
+}  // namespace
+}  // namespace ffi
+}  // namespace tvm
+
+TVMFFICustomAllocator* TVMFFIGetCustomAllocator(void) {
+  TVM_FFI_LOG_EXCEPTION_CALL_BEGIN();
+  return tvm::ffi::CustomAllocatorRegistry::Global()->Get();
+  TVM_FFI_LOG_EXCEPTION_CALL_END(TVMFFIGetCustomAllocator);
+}
+
+int TVMFFISetCustomAllocator(TVMFFICustomAllocator* allocator) {
+  TVM_FFI_SAFE_CALL_BEGIN();
+  tvm::ffi::CustomAllocatorRegistry::Global()->Set(allocator);
+  TVM_FFI_SAFE_CALL_END();
+}

--- a/src/ffi/extra/dataclass.cc
+++ b/src/ffi/extra/dataclass.cc
@@ -32,6 +32,7 @@
 #include <tvm/ffi/device.h>
 #include <tvm/ffi/enum.h>
 #include <tvm/ffi/extra/dataclass.h>
+#include <tvm/ffi/memory.h>
 #include <tvm/ffi/reflection/accessor.h>
 #include <tvm/ffi/reflection/creator.h>
 #include <tvm/ffi/reflection/registry.h>
@@ -1741,7 +1742,9 @@ PyClassFieldStorageKind GetPyClassFieldStorageKind(const TVMFFIFieldInfo* finfo)
  *
  * For the "strong" phase, iterates all reflected fields and destructs
  * Any/ObjectRef values in-place (to release references).  For the "weak"
- * phase, frees the underlying calloc'd memory.
+ * phase, forwards to the prepended ``TVMFFIObjectAllocHeader``'s
+ * ``delete_space`` (every Object carries one — libtvm_ffi's builtin
+ * default allocator ensures it).
  */
 void PyClassDeleter(void* self_void, int flags) {
   TVMFFIObject* self = static_cast<TVMFFIObject*>(self_void);
@@ -1765,7 +1768,7 @@ void PyClassDeleter(void* self_void, int flags) {
     });
   }
   if (flags & kTVMFFIObjectDeleterFlagBitMaskWeak) {
-    std::free(self_void);
+    details::ObjectUnsafe::GetObjectAllocHeaderFromPtr(self_void)->delete_space(self_void);
   }
 }
 
@@ -2115,11 +2118,16 @@ void PyClassRegisterTypeAttrColumns(int32_t type_index, int32_t total_size) {
   RegisterFFIInit(type_index);
   // Step 2. Register `__ffi_new__`
   Function new_fn = Function::FromTyped([type_index, total_size, type_info]() -> ObjectRef {
-    void* obj_ptr = std::calloc(1, static_cast<size_t>(total_size));
-    if (!obj_ptr) {
-      TVM_FFI_THROW(RuntimeError) << "Failed to allocate " << total_size << " bytes for type "
-                                  << TypeIndexToTypeKey(type_index);
-    }
+    // Route through the custom-allocator registry so the prepended
+    // TVMFFIObjectAllocHeader is in place for PyClassDeleter's Weak
+    // branch. Then memset to zero-init the payload (mirrors the original
+    // calloc-based path); ConstructPyClassFields below placement-news the
+    // non-trivial fields while the memset covers the POD ones.
+    size_t alloc_size = static_cast<size_t>(total_size);
+    TVMFFICustomAllocator* alloc = TVMFFIGetCustomAllocator();
+    void* obj_ptr =
+        alloc->allocate(alloc_size, alignof(::std::max_align_t), type_index, alloc->context);
+    std::memset(obj_ptr, 0, alloc_size);
     TVMFFIObject* ffi_obj = reinterpret_cast<TVMFFIObject*>(obj_ptr);
     ffi_obj->type_index = type_index;
     ffi_obj->combined_ref_count = details::kCombinedRefCountBothOne;
@@ -2134,10 +2142,12 @@ void PyClassRegisterTypeAttrColumns(int32_t type_index, int32_t total_size) {
   // Step 3. Register `__ffi_shallow_copy__`
   Function copy_fn =
       Function::FromTyped([type_index, total_size, type_info](const Object* src) -> ObjectRef {
-        void* obj_ptr = std::calloc(1, static_cast<size_t>(total_size));
-        if (!obj_ptr) {
-          TVM_FFI_THROW(RuntimeError) << "Failed to allocate for shallow copy";
-        }
+        // Allocator + memset mirror RegisterFFINew above.
+        size_t alloc_size = static_cast<size_t>(total_size);
+        TVMFFICustomAllocator* alloc = TVMFFIGetCustomAllocator();
+        void* obj_ptr =
+            alloc->allocate(alloc_size, alignof(::std::max_align_t), type_index, alloc->context);
+        std::memset(obj_ptr, 0, alloc_size);
         TVMFFIObject* ffi_obj = reinterpret_cast<TVMFFIObject*>(obj_ptr);
         ffi_obj->type_index = type_index;
         ffi_obj->combined_ref_count = details::kCombinedRefCountBothOne;

--- a/tests/python/test_dataclass_py_class.py
+++ b/tests/python/test_dataclass_py_class.py
@@ -3669,7 +3669,11 @@ class TestNativeParentInheritance:
         stored = holder.value
         assert stored is not None
         assert stored.same_as(target)
-        assert use_count(target) == 3
+        # Under PyObject-tying the field accessor returns the canonical wrapper,
+        # so ``stored`` aliases ``target`` (no fresh wrapper, no extra C++ ref) and
+        # the use count stays 2 rather than climbing to 3.
+        assert stored is target
+        assert use_count(target) == 2
         del stored
         gc.collect()
         assert use_count(target) == 2

--- a/tests/python/test_function.py
+++ b/tests/python/test_function.py
@@ -192,39 +192,41 @@ def test_global_func() -> None:
 
 
 def test_rvalue_ref() -> None:
+    # Under universal cache-on the callback's arg aliases the caller's
+    # wrapper, so use_count inside is 1 (one wrapper, one chandle ref).
+    # ``_move()`` on either side detaches that wrapper's binding before
+    # the C++ AnyViewToOwnedAny transfer nulls the source chandle.
     use_count = tvm_ffi.get_global_func("testing.object_use_count")
 
     def callback(x: Any, expected_count: int) -> Any:
-        # The use count of TVM FFI objects is decremented as part of
-        # `ObjectRef.__del__`, which runs when the Python object is
-        # destructed.  However, Python object destruction is not
-        # deterministic, and even CPython's reference-counting is
-        # considered an implementation detail.  Therefore, to ensure
-        # correct results from this test, `gc.collect()` must be
-        # explicitly called.
+        # ``gc.collect()`` ensures Python destructors have run so
+        # use_count reflects only live wrappers.
         gc.collect()
         assert expected_count == use_count(x)
         return x._move()
 
     f = tvm_ffi.convert(callback)
 
-    def check0() -> None:
+    def check_caller_move() -> None:
+        # Caller passes ``x._move()``: callback receives a fresh canonical
+        # wrapper for the moved-in chandle.
         x = tvm_ffi.convert([1, 2])
         assert use_count(x) == 1
-        f(x, 2)
         f(x._move(), 1)
         assert x.__ctypes_handle__().value is None
 
-    def check1() -> None:
+    def check_callback_move() -> None:
+        # Callback returns ``x._move()``: caller sees a fresh canonical
+        # wrapper, distinct from the now-empty ``x``.
         x = tvm_ffi.convert([1, 2])
         assert use_count(x) == 1
-        y = f(x, 2)
-        f(x._move(), 2)
+        y = f(x, 1)
+        assert y is not x
         assert x.__ctypes_handle__().value is None
         assert y.__ctypes_handle__().value is not None
 
-    check0()
-    check1()
+    check_caller_move()
+    check_callback_move()
 
 
 def test_echo_with_opaque_object() -> None:

--- a/tests/python/test_pyobject_tying.py
+++ b/tests/python/test_pyobject_tying.py
@@ -1,0 +1,771 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for the PyObject-tying feature (cache & revive).
+
+A 16-byte ``PyCustomAllocHeader`` is prepended to every Object that goes
+through the Python custom allocator. Its ``tagged_pyobj`` field is a tagged
+pointer to the canonical Python wrapper, encoding a three-state machine
+driven by the custom ``tp_alloc`` / ``tp_free`` slots and the
+``make_ret_object`` dispatcher in ``tvm_ffi_python_object.h``:
+
+  Detached  no Python wrapper bound to the chandle (raw == NULL)
+  Active    canonical wrapper alive; ``wrapper.chandle == chandle`` (tag 0)
+  Inactive  wrapper dropped but its memory is cached as a dead,
+            untracked allocation (tag 1); revived in place at the same address
+            on the next ``make_ret_object``
+
+Active gives ``a.x is a.x``. Inactive gives stable ``id()`` across a
+drop-then-rewrap cycle when the C++ object outlives the wrapper — without a
+leak: the cached allocation is revived (``tp_alloc``), not resurrected.
+"""
+
+from __future__ import annotations
+
+import gc
+import itertools
+import pickle
+import sys
+import threading
+import weakref
+from typing import Any
+
+import pytest
+import tvm_ffi
+import tvm_ffi.testing
+from tvm_ffi import dataclasses as dc
+
+# ---------------------------------------------------------------------------
+# Test type registration
+# ---------------------------------------------------------------------------
+_counter = itertools.count()
+
+
+def _unique_key(base: str) -> str:
+    return f"testing.pyobject_tying.{base}_{next(_counter)}"
+
+
+def _is_free_threaded_python() -> bool:
+    return hasattr(sys, "_is_gil_enabled") and not sys._is_gil_enabled()
+
+
+# PyObject-tying (wrapper identity stickiness: ``a.x is a.x``, stable ``id()`` across
+# drop+revive, ``f(x) is x``) relies on a custom allocator + tp_alloc / tp_free /
+# tp_dealloc slots whose header state machine is GIL-serialized on the classic build
+# and lock-synchronized on free-threaded builds (see the "Free-threaded builds" note
+# in ``tvm_ffi_python_object.h``). The feature is enabled on both, so the identity
+# tests below run unconditionally on every build.
+
+
+# Module-level fixtures so the registered types persist across all tests
+# in a file (re-registering with the same key is an error).
+
+
+@dc.py_class(_unique_key("Inner"))
+class Inner(dc.Object):
+    val: int
+
+
+@dc.py_class(_unique_key("Outer"))
+class Outer(dc.Object):
+    x: Inner
+
+
+@dc.py_class(_unique_key("MutableOuter"), frozen=False)
+class MutableOuter(dc.Object):
+    x: Inner
+
+
+# ---------------------------------------------------------------------------
+# Active: identity stable while wrapper is alive
+# ---------------------------------------------------------------------------
+class TestActiveIdentity:
+    """``a.x is a.x`` and ``id(a.x)`` stable while ``a`` lives."""
+
+    def test_attr_access_is_same_object(self) -> None:
+        """Repeated (and chained) attribute access returns the same wrapper object."""
+        a = Outer(Inner(42))
+        assert a.x is a.x
+        # id() is stable across many accesses, and chained access reuses the
+        # intermediate wrapper rather than minting transient garbage.
+        assert len({id(a.x) for _ in range(100)}) == 1
+        assert a.x.val == 42
+
+    def test_two_outers_distinct_inners(self) -> None:
+        """Distinct C++ objects produce distinct Python wrappers."""
+        a = Outer(Inner(1))
+        b = Outer(Inner(2))
+        assert a.x is not b.x
+        assert id(a.x) != id(b.x)
+
+
+# ---------------------------------------------------------------------------
+# Universal cache-on: function returns alias the canonical wrapper
+# ---------------------------------------------------------------------------
+class TestFunctionReturns:
+    """Every FFI return funnels through ``make_ret_object``: the wrapper
+    for a chandle that already has a canonical Python wrapper *is* that
+    wrapper.
+
+    Note: ``get_global_func("name")`` does NOT participate in this cache
+    (most registry entries are allocated at C++ static init, before the
+    Python custom allocator is registered, so their chandle has no
+    PyCustomAllocHeader). Stable ``id()`` for ``get_global_func`` is
+    deferred — see TODO in ``function.pxi::_get_global_func``.
+    """
+
+    def test_function_return_aliases_arg(self) -> None:
+        """An FFI return aliases the canonical wrapper of its argument."""
+        identity = tvm_ffi.convert(lambda x: x)
+        x = tvm_ffi.convert([1, 2])
+        assert identity(x) is x
+
+
+# ---------------------------------------------------------------------------
+# Active -> Inactive -> Active: identity preserved across wrapper drop
+# ---------------------------------------------------------------------------
+class TestRevive:
+    """When the C++ object outlives the wrapper, re-fetching it via the
+    cached field-getter path reuses the preserved memory (same address,
+    same chandle, correct value).
+    """
+
+    def test_id_chandle_and_value_preserved_across_revive(self) -> None:
+        """id(), chandle, and field value all survive a drop-and-revive cycle."""
+        outer = Outer(Inner(123))
+        first = outer.x  # Active: canonical wrapper installed
+        first_id = id(first)
+        first_chandle = first.__chandle__()
+        del first
+        gc.collect()  # transitions to Inactive
+
+        revived = outer.x  # revive at the same address
+        assert id(revived) == first_id
+        assert revived.__chandle__() == first_chandle
+        assert revived.val == 123
+
+    def test_no_leak_churn_2k_cycles(self) -> None:
+        """Revive must reuse exactly one address across many cycles."""
+        outer = Outer(Inner(1))
+        addresses: set[int] = set()
+        for i in range(2000):
+            ref = outer.x
+            addresses.add(id(ref))
+            del ref
+            if i % 500 == 499:
+                gc.collect()
+        gc.collect()
+        assert len(addresses) == 1, (
+            f"Inactive -> Active revive should yield exactly one wrapper address; "
+            f"saw {len(addresses)}"
+        )
+
+    def test_chandle_dies_while_inactive(self) -> None:
+        """A chandle dying while Inactive reclaims the cached allocation safely."""
+        # When the chandle finally dies while its wrapper is Inactive,
+        # ``TVMFFIPyDeleteSpace`` must reclaim the cached (untracked)
+        # allocation under the GIL via ``PyObject_GC_Del`` and then free the
+        # malloc block. A regression here typically manifests as a
+        # segfault — getting past ``gc.collect()`` and the follow-up
+        # alloc means the path stayed safe.
+        #
+        # A UAF/corruption here is deterministic -- it trips within the first
+        # few iterations (the alloc-after-free that surfaces heap damage needs
+        # only a handful of repeats), so a small count suffices. Each iter runs
+        # two gc.collect()s (~13ms each in this env), so keep the count modest.
+        for _ in range(8):
+            outer = Outer(Inner(7))
+            _ = outer.x  # Detached -> Active
+            gc.collect()  # wrapper drops; Active -> Inactive
+            del outer  # drops the last C++ ref; deleter fires on the inactive cached allocation
+            gc.collect()
+        # If we got here, the cached-allocation cleanup path is safe.
+        fresh = Outer(Inner(11))
+        assert fresh.x.val == 11
+
+
+# ---------------------------------------------------------------------------
+# No unbounded wrapper leak across many distinct chandles
+# ---------------------------------------------------------------------------
+class TestNoUnboundedLeak:
+    """Many distinct chandles, each pinned alive by a parent's field, must
+    not accumulate one live Python wrapper per chandle.
+
+    ``TestRevive.test_no_leak_churn_2k_cycles`` cycles a *single* chandle and
+    asserts address reuse; this asserts the complementary property -- across
+    *many distinct* chandles the count of live wrappers stays flat, because
+    cache & revive reuses the cached allocation instead of pinning it (rather
+    than keeping one live wrapper alive per chandle for as long as the chandle
+    survives).
+    """
+
+    def test_distinct_chandles_no_wrapper_leak(self) -> None:
+        """Many distinct chandles do not pin one live wrapper each."""
+
+        # Locally-registered types: the gc.get_objects() scan below counts
+        # only instances of *this* InnerLeak, so leftover instances from other
+        # tests (which use the module-level Inner) cannot pollute the count.
+        @dc.py_class(_unique_key("InnerLeak"))
+        class InnerLeak(dc.Object):
+            val: int
+
+        @dc.py_class(_unique_key("OuterLeak"))
+        class OuterLeak(dc.Object):
+            x: InnerLeak
+
+        def live_inner_count() -> int:
+            return sum(1 for ob in gc.get_objects() if type(ob) is InnerLeak)
+
+        # n is deliberately modest: a leak here would be strictly linear (one
+        # pinned wrapper per distinct chandle), so leaked == 0 trips at any n
+        # under a regression -- a larger n buys no detection power, only time.
+        n = 1000
+        parents = []
+        gc.collect()
+        before = live_inner_count()
+        for i in range(n):
+            outer = OuterLeak(InnerLeak(i))
+            parents.append(outer)  # keep the chandle legitimately alive
+            w = outer.x  # Active wrapper for this distinct chandle
+            del w  # -> Inactive (revivable cached allocation, must not pin the wrapper)
+        gc.collect()
+        leaked = live_inner_count() - before
+        assert leaked == 0, (
+            f"PyObject-tying leak: {leaked} wrappers pinned alive (expected 0; "
+            f"one pinned wrapper per distinct chandle == unbounded leak)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Finalizer (__del__) types are excluded from inactivation
+# ---------------------------------------------------------------------------
+class TestFinalizerNotInactivated:
+    """A subclass that defines ``__del__`` gets a ``tp_finalize`` slot, and
+    CPython sets a *permanent* GC-finalized bit the first time it runs —
+    never running it again on that block. Reviving an inactive cached allocation would
+    therefore silently suppress ``__del__`` for every revived generation.
+    ``TVMFFIPyIsInactiveEligible`` excludes such types, so they genuinely free on
+    every drop and ``__del__`` fires once per generation. The cost is no
+    stable-``id``-across-drop for finalizer types (acceptable, documented).
+    """
+
+    def test_del_fires_every_generation(self) -> None:
+        """__del__ fires on every drop of a finalizer type, not once-ever."""
+        calls: list[int] = []
+
+        @dc.py_class(_unique_key("InnerDel"))
+        class InnerDel(dc.Object):
+            val: int
+
+            def __del__(self) -> None:
+                # ``self`` is being finalized; record that __del__ ran.
+                calls.append(1)
+
+        @dc.py_class(_unique_key("OuterDel"))
+        class OuterDel(dc.Object):
+            x: InnerDel
+
+        outer = OuterDel(InnerDel(5))
+        for _ in range(5):
+            w = outer.x  # fresh wrapper (finalizer type is never inactivated)
+            assert w.val == 5
+            del w
+            gc.collect()  # genuine free -> __del__ runs
+        # __del__ fired once per drop (5), not once-ever (the cached-allocation bug).
+        assert len(calls) >= 5, (
+            f"__del__ must fire on every drop of a finalizer type; saw {len(calls)}"
+        )
+
+    def test_finalizer_type_value_correct_across_refetch(self) -> None:
+        """A finalizer type's value and live identity hold across refetch."""
+
+        # Even without stable id(), the value and live identity must hold.
+        @dc.py_class(_unique_key("InnerDel"))
+        class InnerDel2(dc.Object):
+            val: int
+
+            def __del__(self) -> None:
+                pass
+
+        @dc.py_class(_unique_key("OuterDel"))
+        class OuterDel2(dc.Object):
+            x: InnerDel2
+
+        outer = OuterDel2(InnerDel2(7))
+        assert outer.x is outer.x  # live identity still holds
+        assert outer.x.val == 7
+        gc.collect()
+        assert outer.x.val == 7  # refetch after drop still correct
+
+
+# ---------------------------------------------------------------------------
+# Inactivation only happens when other C++ holders exist
+# ---------------------------------------------------------------------------
+class TestLastRefCleanFree:
+    """When the wrapper is the last C++ ref, ``__dealloc__`` must NOT
+    inactivate — it detaches and genuinely frees the allocation (``tp_free`` runs
+    the real free). Regression guard for use-after-free in the deleter.
+    """
+
+    def test_drop_last_ref_no_crash(self) -> None:
+        """The bare convert-and-drop pattern must not segfault."""
+        for _ in range(100):
+            x = tvm_ffi.convert([1, 2, 3])
+            del x
+        gc.collect()
+
+    def test_drop_then_realloc_value_correct(self) -> None:
+        """Dropping the last ref frees the memory; a fresh alloc is correct."""
+        # Inner has no other holder -> __dealloc__ with strong_count == 1 ->
+        # genuine free (no inactivation), memory reclaimed. Next Inner is fresh.
+        a = Inner(1)
+        del a
+        gc.collect()
+        b = Inner(2)
+        assert b.val == 2
+
+
+# ---------------------------------------------------------------------------
+# RValue-ref move path (regression for the test_rvalue_ref segfault)
+# ---------------------------------------------------------------------------
+class TestRValueRef:
+    """The ``_move()`` path nulls the source's ``chandle`` while the
+    Python wrapper stays alive. The RValueRef arg setter detaches the
+    canonical-wrapper binding eagerly so a downstream cache lookup
+    doesn't see a stale back-pointer to a wrapper whose chandle is NULL.
+    """
+
+    def test_move_into_callback_no_crash(self) -> None:
+        """Moving an arg into a callback that re-moves it does not crash."""
+        # Universal cache-on: callback arg aliases caller's ``x`` (one
+        # wrapper, one chandle ref). The original blocker was a UAF in
+        # the deleter path triggered by the eager-detach + chandle-null
+        # interplay during a callback that returns ``x._move()`` — so we
+        # exercise that path here, asserting only that we don't crash
+        # and the post-call chandle is null.
+        use_count = tvm_ffi.get_global_func("testing.object_use_count")
+
+        def callback(x: Any, expected: int) -> Any:
+            gc.collect()
+            assert expected == use_count(x)
+            return x._move()
+
+        f = tvm_ffi.convert(callback)
+        x = tvm_ffi.convert([1, 2])
+        # Caller-side _move: the rvalue setter detaches and the
+        # callback receives a fresh canonical wrapper for the chandle.
+        f(x._move(), 1)
+        assert x.__ctypes_handle__().value is None
+
+    def test_ffi_move_then_re_fetch_works(self) -> None:
+        """Re-fetching a field after an FFI move yields a valid wrapper."""
+        # The rvalue setter only runs when an FFI call consumes the
+        # ObjectRValueRef. ``discard`` provides that consumption — the
+        # setter detaches the canonical-wrapper binding (clearing
+        # ``tagged_pyobj`` to NULL) and the C++ side nulls the
+        # source wrapper's ``chandle``. ``outer``'s field still owns
+        # its strong ref, so re-fetching produces a valid wrapper.
+        outer = Outer(Inner(5))
+        discard = tvm_ffi.convert(lambda _: None)
+        discard(outer.x._move())
+        assert outer.x.val == 5
+
+    def test_active_caching_after_ffi_move(self) -> None:
+        """Active caching resumes on a fresh wrapper after an FFI move."""
+        # Eager-detach during the move clears the header binding, so
+        # the chandle returns to Detached. The next access installs a fresh
+        # canonical wrapper, which then participates in Active caching
+        # like any other freshly-wrapped chandle.
+        outer = Outer(Inner(5))
+        discard = tvm_ffi.convert(lambda _: None)
+        discard(outer.x._move())
+        assert outer.x is outer.x
+        assert outer.x.val == 5
+
+
+# ---------------------------------------------------------------------------
+# Pickle round-trip: must not corrupt the binding
+# ---------------------------------------------------------------------------
+class TestPickle:
+    """Pickle uses ``__init_handle_by_constructor__`` which calls
+    ``_install_chandle_binding`` — the binding must end in a valid
+    Active configuration.
+    """
+
+    def test_pickle_roundtrip_basic(self) -> None:
+        """A basic pickle round-trip preserves the value."""
+        a = tvm_ffi.convert([1, 2, 3])
+        s = pickle.dumps(a)
+        b = pickle.loads(s)
+        assert list(b) == [1, 2, 3]
+
+    def test_pickle_roundtrip_preserves_attr_identity(self) -> None:
+        """A restored wrapper has stable attribute identity."""
+        outer = Outer(Inner(77))
+        s = pickle.dumps(outer)
+        outer2 = pickle.loads(s)
+        # Restored wrapper is fully functional and identity is stable
+        # within the new instance.
+        assert outer2.x is outer2.x
+        assert outer2.x.val == 77
+
+
+# ---------------------------------------------------------------------------
+# PyNativeObject (String / Bytes) — exempt from the header binding
+# ---------------------------------------------------------------------------
+class TestPyNativeExempt:
+    """PyNativeObject types (``String``, ``Bytes``) are value-typed: the
+    transient ``Object`` wrapper is discarded after construction.
+    They MUST NOT install a header binding.
+    """
+
+    def test_string_construction_and_compare(self) -> None:
+        """A converted String behaves as a native str."""
+        s = tvm_ffi.convert("hello")
+        assert isinstance(s, str)
+        assert s == "hello"
+
+    def test_bytes_construction_and_compare(self) -> None:
+        """A converted Bytes behaves as native bytes."""
+        b = tvm_ffi.convert(b"world")
+        assert isinstance(b, bytes)
+        assert b == b"world"
+
+    def test_string_repeated_construction(self) -> None:
+        """Repeated String construction does not corrupt adjacent headers."""
+        # Repeatedly constructing strings shouldn't break the header on
+        # adjacent objects.
+        for _ in range(100):
+            s = tvm_ffi.convert("x" * 16)
+            assert s == "x" * 16
+
+
+# ---------------------------------------------------------------------------
+# Type-mismatch fallthrough on revive
+# ---------------------------------------------------------------------------
+class TestTypeMismatchOnRevive:
+    """Registering many unrelated types between attribute accesses must
+    not corrupt existing wrappers' bindings, and the revive path must
+    still hit Inactive for the original wrapper.
+    """
+
+    def test_field_access_works_after_many_unrelated_registrations(self) -> None:
+        """Unrelated type registrations don't corrupt an existing binding."""
+        outer = Outer(Inner(1))
+        first_id = id(outer.x)
+        # Register a bunch of unrelated classes (no shared chandle).
+        for _ in range(20):
+
+            @dc.py_class(_unique_key("Tmp"))
+            class Tmp(dc.Object):
+                v: int
+
+            _ = Tmp(0)
+        gc.collect()
+        # Original outer's revive cycle still works.
+        revived = outer.x
+        assert id(revived) == first_id
+        assert revived.val == 1
+
+
+# ---------------------------------------------------------------------------
+# Field setter after revive
+# ---------------------------------------------------------------------------
+class TestFieldSetterAfterRevive:
+    """Replacing a field after a revive cycle should bind the new value
+    cleanly without disturbing the prior preserved wrapper for the
+    *previous* chandle (which may still be alive elsewhere).
+    """
+
+    def test_assign_then_access(self) -> None:
+        """Replacing a field after a revive cycle binds the new value cleanly."""
+        outer = MutableOuter(Inner(1))
+        first_inner = outer.x
+        first_chandle = first_inner.__chandle__()
+        del first_inner
+
+        # Replace x with a fresh Inner.
+        new_inner = Inner(2)
+        outer.x = new_inner
+        gc.collect()
+
+        # The new outer.x has a different chandle (= new_inner's), so it
+        # must produce a wrapper that is NOT the preserved address of
+        # the original (which had a different chandle).
+        revised = outer.x
+        assert revised.val == 2
+        assert revised.__chandle__() != first_chandle
+        # The new wrapper is canonical for its own chandle.
+        assert outer.x is revised
+
+
+# ---------------------------------------------------------------------------
+# Pickle stress: repeated round-trips
+# ---------------------------------------------------------------------------
+class TestPickleStress:
+    """Pickle round-trips go through ``__init_handle_by_constructor__``
+    which calls ``_install_chandle_binding``. Repeated round-trips must
+    not leak wrappers or corrupt the binding state.
+    """
+
+    def test_many_roundtrips(self) -> None:
+        """Repeated pickle round-trips keep the binding state valid."""
+        for _ in range(200):
+            outer = Outer(Inner(7))
+            restored = pickle.loads(pickle.dumps(outer))
+            assert restored.x.val == 7
+            assert restored.x is restored.x  # Active on restored binding
+
+    def test_roundtrip_then_revive(self) -> None:
+        """A pickle-installed binding survives a finalize-and-revive cycle."""
+        # Round-trip, then exercise Inactive -> Active revive on the restored
+        # wrapper to confirm the binding installed by pickle survives
+        # finalize+rewrap.
+        outer = pickle.loads(pickle.dumps(Outer(Inner(99))))
+        first_id = id(outer.x)
+        gc.collect()
+        assert id(outer.x) == first_id
+        assert outer.x.val == 99
+
+
+# ---------------------------------------------------------------------------
+# Threading stress: concurrent attribute access
+# ---------------------------------------------------------------------------
+class TestThreadingStress:
+    """Multi-threaded smoke test for the cache-hit / Inactive revive
+    paths. Under classic CPython the GIL serializes Python bytecode so
+    most races are confined to the FFI call's nogil block; this test
+    exercises enough iterations to surface obvious crashes from any
+    GIL-released DecRef on the C++ side.
+    """
+
+    def test_concurrent_shared_churn_no_crash(self) -> None:
+        """Many threads hammering ``outer.x`` on ONE shared object must not crash.
+
+        This is the high-pressure free-threaded reproducer: a single ``Outer`` is
+        shared across all threads, so every thread's ``outer.x`` drop+refetch races
+        the others' through the same ``tagged_pyobj`` word. The cached ``Inner``
+        wrapper churns Active <-> Inactive while ``make_ret`` Active-hits read it and
+        ``tp_dealloc`` mutates it. On free-threaded builds with no synchronization
+        this segfaults within ~1s; it is the exact race the lock-synchronized state
+        machine plus the pre-bump ``tp_dealloc`` binding-clear close. Also asserts the
+        live wrapper identity (``outer.x is outer.x``) holds under contention.
+        """
+        outer = Outer(Inner(123))
+        # More threads than cores maximizes interleaving; iteration count is sized to
+        # surface the crash reliably on FT while keeping the GIL build well under a
+        # second. Drop the count a bit on the GIL build (the race cannot occur there).
+        nthreads = 16
+        iters = 20_000 if _is_free_threaded_python() else 2_000
+        barrier = threading.Barrier(nthreads)
+        errors: list[BaseException] = []
+
+        def worker() -> None:
+            try:
+                barrier.wait()
+                for _ in range(iters):
+                    a = outer.x  # Detached/Inactive -> Active, or Active hit
+                    b = outer.x  # Active hit on the just-installed wrapper
+                    assert a is b, "live wrapper identity must hold under contention"
+                    assert a.val == 123
+                    del a, b
+            except BaseException as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(nthreads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert not errors, f"worker(s) raised: {errors!r}"
+
+
+# ---------------------------------------------------------------------------
+# Carrier family: tying covers all CObject subtypes, not just dataclasses
+# ---------------------------------------------------------------------------
+class TestCarrierTypes:
+    """``tp_dealloc`` is defined once on ``CObject`` and inherited by every
+    subtype (``Function``, ``Error``, heap subclasses, ``OpaquePyObject``), so
+    tying and clean teardown must hold for the whole family, not only the
+    dataclass ``Inner`` path. Each carrier is pinned alive and re-fetched; the
+    Active-hit aliases the canonical wrapper.
+    """
+
+    def test_function_and_error_carrier_alias(self) -> None:
+        """Function and Error carriers re-fetched from a container alias one wrapper."""
+        fn_box = tvm_ffi.convert([tvm_ffi.convert(lambda z: z)])
+        assert fn_box[0] is fn_box[0]
+        err_box = tvm_ffi.convert([tvm_ffi.convert(ValueError("boom"))])
+        assert err_box[0] is err_box[0]
+
+    def test_multilevel_heap_subtype_alias(self) -> None:
+        """A 2-level heap dataclass subtype ties like any other CObject."""
+
+        # ``Derived``'s tp_dealloc is CPython's subtype_dealloc, which walks to
+        # the inherited CObject slot -- so tying still applies.
+        @dc.py_class(_unique_key("CarrierBase"))
+        class Base(dc.Object):
+            a: int
+
+        @dc.py_class(_unique_key("CarrierDerived"))
+        class Derived(Base):
+            pass
+
+        @dc.py_class(_unique_key("CarrierHolder"))
+        class Holder(dc.Object):
+            x: Base
+
+        holder = Holder(Derived(9))
+        assert holder.x is holder.x
+        assert holder.x.a == 9
+
+
+# ---------------------------------------------------------------------------
+# OpaquePyObject carrier
+# ---------------------------------------------------------------------------
+class TestOpaquePyObjectCarrier:
+    """``OpaquePyObject`` carries an arbitrary (non-FFI) Python value across the
+    FFI boundary. Its round-trip must preserve identity and its teardown must
+    release the held value (the inherited ``CObject`` dealloc runs the chandle
+    DecRef), so payloads are reclaimed rather than leaked.
+    """
+
+    def test_opaque_roundtrip_preserves_identity(self) -> None:
+        """A Python value round-tripped through an FFI echo is the same object."""
+        echo = tvm_ffi.convert(lambda x: x)
+
+        class Payload:
+            __slots__ = ("v",)
+
+            def __init__(self, v: int) -> None:
+                self.v = v
+
+        p = Payload(7)
+        r = echo(p)
+        assert r is p
+        assert r.v == 7
+
+    def test_opaque_roundtrip_does_not_leak(self) -> None:
+        """Echoed payloads are reclaimed after drop — the carrier DecRef runs."""
+        echo = tvm_ffi.convert(lambda x: x)
+
+        class Payload:
+            __slots__ = ("__weakref__", "v")
+
+            def __init__(self, v: int) -> None:
+                self.v = v
+
+        refs: list[weakref.ref[Any]] = []
+        for i in range(50):
+            p = Payload(i)
+            wr = weakref.ref(p)
+            r = echo(p)  # p crosses the FFI as an OpaquePyObject
+            assert r is p
+            del r, p
+            refs.append(wr)
+        gc.collect()
+        leaked = sum(1 for wr in refs if wr() is not None)
+        assert leaked == 0, f"OpaquePyObject carrier leaked {leaked}/50 payloads"
+
+
+# ---------------------------------------------------------------------------
+# GC integration with Inactive
+# ---------------------------------------------------------------------------
+class TestReviveWithCyclicGC:
+    """Inactive cached allocations are dead, untracked memory (``subtype_dealloc``
+    untracks before inactivation, and ``tp_alloc`` re-tracks only on revival).
+    ``gc.collect()`` between a drop and a refetch must not crash: it must
+    neither traverse the untracked cached allocation nor trip over the revived object.
+    """
+
+    def test_gc_collect_inside_revive_loop(self) -> None:
+        """gc.collect() between drop and refetch does not crash."""
+        outer = Outer(Inner(5))
+        # A bad traversal of the untracked cached allocation crashes deterministically on
+        # the first collect, so a modest count suffices; the cost here is the
+        # gc.collect() itself (~13ms each in this env), not the FFI work.
+        for _ in range(10):
+            ref = outer.x
+            del ref
+            gc.collect()  # cached allocation is inactive (untracked) between drops
+        assert outer.x.val == 5
+
+    def test_gc_collect_with_holder_keeping_chandle(self) -> None:
+        """gc.collect() around inactive memory keeps id() stable."""
+        # The Inner chandle is held by ``outer``'s field for the lifetime
+        # of the test, so wrapper drops always inactivate the allocation. gc.collect
+        # between drops exercises GC stability around the inactive memory.
+        outer = Outer(Inner(11))
+        first_id = id(outer.x)
+        # GC stability around the inactive cached allocation is deterministic per cycle;
+        # a modest count surfaces it. Dominated by gc.collect() (~13ms each).
+        for _ in range(10):
+            _ = outer.x
+            gc.collect()
+        assert id(outer.x) == first_id
+
+
+# ---------------------------------------------------------------------------
+# Isolation: many distinct chandles each Inactive at once
+# ---------------------------------------------------------------------------
+class TestMultipleChandlesIsolation:
+    """A revive on one chandle must not corrupt the cached binding on
+    another. Each chandle's header is independent — verify by cycling
+    many in parallel.
+    """
+
+    def test_distinct_chandles_revive_independently(self) -> None:
+        """Each chandle revives to its own address and value independently."""
+        outers = [Outer(Inner(i * 10)) for i in range(50)]
+        # Capture Active addresses, then drop to Inactive.
+        b_ids = [id(o.x) for o in outers]
+        gc.collect()
+        # Revive each independently; each must return its own preserved
+        # address with its own value.
+        for i, o in enumerate(outers):
+            revived = o.x
+            assert id(revived) == b_ids[i]
+            assert revived.val == i * 10
+
+    def test_interleaved_revives_do_not_cross_contaminate(self) -> None:
+        """Reviving in a different order keeps ids matched per-chandle."""
+        # Build N outers, capture ids, drop all, then revive in a
+        # different order. Ids must still match per-chandle.
+        outers = [Outer(Inner(i)) for i in range(30)]
+        ids = [id(o.x) for o in outers]
+        gc.collect()
+        for i in reversed(range(30)):
+            assert id(outers[i].x) == ids[i]
+
+
+# ---------------------------------------------------------------------------
+# Weakref limitation (sentinel)
+# ---------------------------------------------------------------------------
+class TestWeakrefNotSupported:
+    """``CObject`` is a Cython cdef class without a ``__weakref__`` slot,
+    so weakrefs are not supported. This test documents that limitation:
+    if it ever starts passing, the Inactive-state interaction needs
+    design review (a weakref to an Active wrapper transitioning to Inactive
+    must behave correctly — the wrapper genuinely dies at refcount 0, so
+    old weakrefs should observe death and a revived wrapper should bind a
+    fresh weakref).
+    """
+
+    def test_weakref_raises_typeerror(self) -> None:
+        """Taking a weakref to a wrapper raises TypeError (documented limit)."""
+        outer = Outer(Inner(1))
+        with pytest.raises(TypeError):
+            weakref.ref(outer.x)


### PR DESCRIPTION
## Summary

Bind one Python wrapper to one C++ FFI object ("chandle") for the object's lifetime, so identity is stable: `a.x is a.x`, `id(a.x)` stable across drop+refetch, and `f(x) is x` for FFI returns. Works on **both the GIL and free-threaded (3.14t) builds**. Implements the *PyObjectTying* design.

Before:
```python
a = MyClass(Inner(...))
assert a.x is a.x          # False — fresh wrapper per attribute access
assert id(a.x) == id(a.x)  # flaky
```

After: both hold, and identity is preserved across a wrapper death-and-revive cycle whenever the C++ object outlives the wrapper.

## Allocation layout

A two-layer custom-allocator hook lives in core libtvm_ffi:

- `TVMFFIObjectAllocHeader { delete_space }` — 8-byte base header preceding every Object body.
- `TVMFFICustomAllocator { allocate, context }` — process-wide registry; libtvm_ffi installs a builtin default at registry init so `TVMFFIGetCustomAllocator` never returns NULL.
- `TVMFFIGetCustomAllocator` / `TVMFFISetCustomAllocator` — frontends override the default at module load.

The Python Cython module overrides the global default with `TVMFFIPyAllocate`, which prepends a 16-byte `PyCustomAllocHeader` encoding the wrapper binding. The Rust crate (`ObjectArc::new[_with_extra_items]`) and the Python-defined types in `extra/dataclass.cc` route through the same registry, so layout and lifetime semantics are uniform across frontends.

## Binding state machine

State is concentrated in `python/tvm_ffi/cython/tvm_ffi_python_helpers.h`. Each header word (`tagged_pyobj`) holds the wrapper back-pointer plus low tag bits, giving a four-state machine:

| State     | Meaning |
|-----------|---------|
| Detached  | No wrapper bound |
| Active    | Wrapper bound and owns a +1 on the chandle |
| Inactive  | Wrapper dead, but its allocation is cached for in-place revival |
| InTransit | A dealloc is mid-flight (handshake bit) |

Every FFI return funnels through `make_ret_object` (C++ entry `TVMFFIPyMakeRetObject`), which returns the canonical wrapper for a chandle when one exists, **reviving an Inactive cached allocation in place** so a re-fetched wrapper keeps a stable `id()` at the same address. The cache-vs-free handshake spans three slots — a pre-bump `tp_dealloc` opens it, `tp_free` settles it, and the C++ weak deleter (`TVMFFIPyDeleteSpace`) reclaims the block — coordinated so a chandle that outlives its wrapper keeps the cached bytes, and a genuinely dead chandle frees them exactly once.

Frontend-allocation is detected by `delete_space` pointer comparison (`TVMFFIPyIsCanonical`), avoiding a flag bit on `TVMFFIObject`. Chandles created before the Python allocator is registered (statically-initialized global functions in libtvm_ffi.so) carry only the base header and are skipped.

## Free-threaded build

The same tying runs on `Py_GIL_DISABLED`. All free-threaded machinery is behind `#ifdef Py_GIL_DISABLED`; **the GIL build is byte-identical** (verified by a function-body-map diff).

- **Per-word spin-lock.** The `tagged_pyobj` word doubles as a spin-lock (a Locked tag bit, `__atomic_*` CAS) serializing every binding transition. The lock is held only across short, park-free word/header edits; alloc/revival run lock-released. The back-off (`TVMFFIPyLockYield`) detaches the thread state so a concurrent stop-the-world GC is never starved.
- **The revival UAF, and the fix.** Cython's generated `tp_dealloc` bumps the wrapper refcount before running `__dealloc__`. On free-threaded builds that bump makes `PyUnstable_TryIncRef` spuriously succeed on a wrapper being torn down, so a concurrent `make_ret` Active-hit could revive a corpse (borrowed-ref UAF). The fix **replaces** Cython's `tp_dealloc` on each cdef CObject-family carrier with one hand-built `TVMFFIPyTpDeallocSlot` that runs the binding transition (bracketed by `PyErr_Get/SetRaisedException`) **before** any bump, then — stripped of the now-dead bump — GC-untrack (guarded by GC-ness), a generic `__dict__` clear (guarded by a real `tp_dictoffset`), and `tp_free`. A plain carrier runs exactly `transition; tp_free`; Function fires both guards; both are faithful to Cython's originals minus the bump.
- **Total carrier coverage.** The six carriers (CObject, CContainerBase, OpaquePyObject, Error, Tensor, Function) are a closed compile-time set, each wrapped once at init via `TVMFFIPyWrapDealloc`; every heap subtype is covered for free through `subtype_dealloc`'s base-walk to the nearest carrier. An import-time **layout guard** `Py_FatalError`s if a non-GC carrier ever gains a `__dict__`, turning silent owned-member drift into a loud failure.
- **Active-hit revival** uses `PyUnstable_TryIncRef` / `EnableTryIncRef` to close the borrowed-read UAF (the CPython "weakmap" pattern, whose `tp_dealloc` support requirement this implements).

Verified safe through CPython 3.15/3.16: the `PyUnstable_TryIncRef`/`PyMutex` contract is unchanged, and the 3.15 rule that managed dict/weakref implies `HAVE_GC` does not affect us — no carrier uses a managed dict.

## Robustness

- **align>8 double-free fix (latent).** The builtin allocator offset the body by `round_up(header, alignment)` but free subtracted a fixed `sizeof(header)`, symmetric only for alignment ≤ 8. A 16-aligned reflection dataclass (`alignof(max_align_t)=16`) was freed 8 bytes early. Both sides now use a fixed `alignof(max_align_t)` body offset. It was masked on the GIL build because the symmetric custom allocator shadows the builtin one for all Python objects.
- **Shutdown guard.** `TVMFFIPyMarkPythonFinalizing` (wired to atexit) flips an atomic flag read before any `PyGILState_Ensure`, to avoid acquiring the GIL after Python finalization has begun. Wrapper bytes on chandles still alive at exit are intentionally leaked — the process is exiting.

## `_move()` semantics

Under universal cache-on, callback args alias the caller's wrapper and FFI returns of the same chandle alias the caller's wrapper (one wrapper, one chandle ref). `_move()` is kept as an API: the rvalue setter on either side eager-detaches the canonical binding before the C++ `AnyViewToOwnedAny` transfer nulls the source chandle, so a downstream cache lookup never sees a stale back-pointer.

## Test plan

- [x] New `tests/python/test_pyobject_tying.py` covers Active/Inactive/InTransit transitions, cache-on aliasing, `_move()` under cache-on, pickle stress, threading stress, GC integration, multi-chandle isolation, the weakref limitation, free-threaded concurrent carrier-type stress (Function/Error/multi-level-heap), and OpaquePyObject roundtrip/leak.
- [x] `test_function.py::test_rvalue_ref` refactored for cache-on aliasing semantics.
- [x] Free-threaded (3.14t): crash oracle clean, full suite **2333 passed**, tying tests **43/43**.
- [x] GIL (3.13): full suite **2358 passed**, tying tests **43/43**.
- [x] Rust suite passes.
- [ ] CI: lint, clang-tidy, doc, C++/Python/Rust on Linux x86_64 + aarch64, macOS arm64, Windows AMD64.

## Out-of-scope follow-ups

- Name-keyed dict cache for `_get_global_func` to deliver id-stability for static-init Functions (whose chandles predate the Python allocator and so carry only the base header). Tracked as a TODO in `function.pxi::_get_global_func`.
