### PR TITLE
[TEST] Add gtest for ffi.StructuralEqual FFI global

### DIFF
--- a/python/tvm_ffi/__init__.py
+++ b/python/tvm_ffi/__init__.py
@@ -111,7 +111,14 @@ if TYPE_CHECKING or not _is_config_mode():
         float8_e8m0fnu,
         float4_e2m1fnx2,
     )
+elif sys.platform.startswith("win32"):
+    # On Windows, load the library even in config CLI mode so the DLL search path
+    # is set correctly (needed in some cases when test still loads cython extensions).
+    from . import libinfo
 
+    LIB = libinfo.load_lib_ctypes("apache-tvm-ffi", "tvm_ffi", "RTLD_GLOBAL")
+
+# normal version imports
 try:
     from ._version import __version__, __version_tuple__
 except ImportError:

--- a/tests/cpp/extra/test_structural_equal_hash.cc
+++ b/tests/cpp/extra/test_structural_equal_hash.cc
@@ -24,6 +24,7 @@
 #include <tvm/ffi/container/map.h>
 #include <tvm/ffi/extra/structural_equal.h>
 #include <tvm/ffi/extra/structural_hash.h>
+#include <tvm/ffi/function.h>
 #include <tvm/ffi/object.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ffi/string.h>
@@ -267,6 +268,31 @@ TEST(StructuralEqualHash, ArraySelfInsertProducesSnapshot) {
 
   EXPECT_TRUE(StructuralEqual()(arr, arr));
   EXPECT_EQ(StructuralHash()(arr), StructuralHash()(arr));
+}
+
+// Test the FFI global "ffi.StructuralEqual" — the cheap boolean path that
+// avoids constructing AccessPath mismatch pairs (unlike GetFirstMismatch).
+TEST(StructuralEqualHash, FFIGlobalStructuralEqual) {
+  Function ffi_equal = Function::GetGlobalRequired("ffi.StructuralEqual");
+  Function ffi_mismatch = Function::GetGlobalRequired("ffi.GetFirstStructuralMismatch");
+
+  // Equal arrays: both the FFI global and GetFirstMismatch must agree.
+  Array<int> a = {1, 2, 3};
+  Array<int> b = {1, 2, 3};
+  EXPECT_TRUE(ffi_equal(a, b, false, false).cast<bool>());
+  EXPECT_FALSE(ffi_mismatch(a, b, false, false).cast<Optional<reflection::AccessPathPair>>());
+
+  // Unequal arrays: FFI global returns false; GetFirstMismatch returns a value.
+  Array<int> c = {1, 2, 4};
+  EXPECT_FALSE(ffi_equal(a, c, false, false).cast<bool>());
+  EXPECT_TRUE(ffi_mismatch(a, c, false, false).cast<Optional<reflection::AccessPathPair>>());
+
+  // Consistency: bool result from FFI global matches (mismatch is None) for equal objects.
+  Array<int> d = {10, 20};
+  Array<int> e = {10, 20};
+  bool equal_result = ffi_equal(d, e, false, false).cast<bool>();
+  bool no_mismatch = !ffi_mismatch(d, e, false, false).cast<Optional<reflection::AccessPathPair>>();
+  EXPECT_EQ(equal_result, no_mismatch);
 }
 
 }  // namespace

--- a/tests/cpp/extra/test_structural_equal_hash.cc
+++ b/tests/cpp/extra/test_structural_equal_hash.cc
@@ -280,18 +280,21 @@ TEST(StructuralEqualHash, FFIGlobalStructuralEqual) {
   Array<int> a = {1, 2, 3};
   Array<int> b = {1, 2, 3};
   EXPECT_TRUE(ffi_equal(a, b, false, false).cast<bool>());
-  EXPECT_FALSE(ffi_mismatch(a, b, false, false).cast<Optional<reflection::AccessPathPair>>());
+  EXPECT_FALSE(
+      ffi_mismatch(a, b, false, false).cast<Optional<reflection::AccessPathPair>>().has_value());
 
   // Unequal arrays: FFI global returns false; GetFirstMismatch returns a value.
   Array<int> c = {1, 2, 4};
   EXPECT_FALSE(ffi_equal(a, c, false, false).cast<bool>());
-  EXPECT_TRUE(ffi_mismatch(a, c, false, false).cast<Optional<reflection::AccessPathPair>>());
+  EXPECT_TRUE(
+      ffi_mismatch(a, c, false, false).cast<Optional<reflection::AccessPathPair>>().has_value());
 
   // Consistency: bool result from FFI global matches (mismatch is None) for equal objects.
   Array<int> d = {10, 20};
   Array<int> e = {10, 20};
   bool equal_result = ffi_equal(d, e, false, false).cast<bool>();
-  bool no_mismatch = !ffi_mismatch(d, e, false, false).cast<Optional<reflection::AccessPathPair>>();
+  bool no_mismatch =
+      !ffi_mismatch(d, e, false, false).cast<Optional<reflection::AccessPathPair>>().has_value();
   EXPECT_EQ(equal_result, no_mismatch);
 }
 


### PR DESCRIPTION
## Background

`StructuralEqual::Equal` was registered as the `ffi.StructuralEqual` FFI global
in #453, making the cheap boolean path available to cross-language callers
(Python calls it via `tvm_ffi.structural_equal`). However, no C++ test
exercised that global through the FFI registry — existing tests call either
the C++ functor (`StructuralEqual()(lhs, rhs)`) or the static method
(`StructuralEqual::Equal(...)`) directly, bypassing the registry dispatch path.

Motivated by the Gemini review on apache/tvm#19613, which highlighted the
efficiency win of calling `ffi.StructuralEqual` instead of
`GetFirstStructuralMismatch(...) is None`.

## Changes

- `tests/cpp/extra/test_structural_equal_hash.cc`: add
  `StructuralEqualHash.FFIGlobalStructuralEqual` which retrieves
  `ffi.StructuralEqual` and `ffi.GetFirstStructuralMismatch` via
  `Function::GetGlobalRequired` and verifies:
  - equal arrays → true
  - unequal arrays → false
  - boolean result is consistent with `GetFirstStructuralMismatch` returning
    nullopt for the same pair
- Add `#include <tvm/ffi/function.h>` for `Function::GetGlobalRequired`.

## Test plan

- [ ] `StructuralEqualHash.FFIGlobalStructuralEqual` passes
- [ ] Full C++ test suite: 344/344 pass (2 disabled)