### PR TITLE
[CI] Use uv tool run for sdist build instead of pipx

### DIFF
--- a/.github/actions/build-wheel-for-publish/action.yml
+++ b/.github/actions/build-wheel-for-publish/action.yml
@@ -110,5 +110,5 @@ runs:
       if: ${{ inputs.build_sdist == 'true' }}
       shell: bash
       run: |
-        pipx run build --sdist --outdir dist .
-        pipx run twine check dist/*
+        uv tool run --from build pyproject-build --sdist --outdir dist .
+        uv tool run twine check dist/*


### PR DESCRIPTION
## Summary

The `Build sdist` step in `.github/actions/build-wheel-for-publish/action.yml`
was invoking `pipx run build` and `pipx run twine`, which broke against the
runner's current uv toolchain. The rest of the composite action already
provisions uv via `astral-sh/setup-uv`, so this PR switches the sdist step
to `uv tool run` and removes the pipx dependency.

## Changes

- `.github/actions/build-wheel-for-publish/action.yml`:
  - `pipx run build --sdist ...` -> `uv tool run --from build pyproject-build --sdist ...`
  - `pipx run twine check ...` -> `uv tool run --from twine twine check ...`