### PR TITLE
docs: surface TVM_FFI_CUDA_ARCH_LIST override for JIT CUDA target selection

### DIFF
--- a/docs/guides/kernel_library_guide.rst
+++ b/docs/guides/kernel_library_guide.rst
@@ -173,6 +173,20 @@ This creates a symbol ``__tvm_ffi_scale`` in the shared library.
        $(tvm-ffi-config --ldflags) \
        $(tvm-ffi-config --libs)
 
+.. note::
+
+   When using Python JIT build helpers such as :py:func:`tvm_ffi.cpp.load`,
+   :py:func:`tvm_ffi.cpp.load_inline`, or :py:func:`tvm_ffi.cpp.build_inline`
+   with CUDA sources, TVM-FFI automatically detects the GPU compute capability
+   for NVCC. On machines with old CUDA drivers or GPUs that cannot be detected,
+   set ``TVM_FFI_CUDA_ARCH_LIST`` before building:
+
+   .. code-block:: bash
+
+      export TVM_FFI_CUDA_ARCH_LIST="8.9"
+
+   The value is a space-separated architecture list, for example ``"8.9 9.0a"``.
+
 **Optional arguments.** Wrap any argument type with :cpp:class:`tvm::ffi::Optional`
 to accept ``None`` from the Python side:
 

--- a/python/tvm_ffi/cpp/extension.py
+++ b/python/tvm_ffi/cpp/extension.py
@@ -162,7 +162,11 @@ def _find_cuda_home() -> str:
 
 
 def _get_cuda_target() -> str:
-    """Get the CUDA target architecture flag."""
+    """Get the CUDA target architecture flag.
+
+    Set ``TVM_FFI_CUDA_ARCH_LIST`` to override automatic detection with a
+    space-separated architecture list, for example ``"8.9 9.0a"``.
+    """
     if "TVM_FFI_CUDA_ARCH_LIST" in os.environ:
         arch_list = os.environ["TVM_FFI_CUDA_ARCH_LIST"].split()  # e.g., "8.9 9.0a"
         flags = []
@@ -202,7 +206,9 @@ def _get_cuda_target() -> str:
             except (subprocess.CalledProcessError, FileNotFoundError):
                 pass
             raise RuntimeError(
-                "Could not detect CUDA compute_cap automatically. Please set TVM_FFI_CUDA_ARCH_LIST environment variable."
+                "Could not detect CUDA compute_cap automatically. Set "
+                "TVM_FFI_CUDA_ARCH_LIST to a space-separated CUDA architecture list, "
+                'for example "8.9 9.0a".'
             )
 
 


### PR DESCRIPTION
## Summary

Users whose CUDA driver is too old for automatic compute-capability detection can now find the `TVM_FFI_CUDA_ARCH_LIST` override without reading the source, both in the JIT build guide and in the error message they hit.

## Why this matters

In issue [#430](https://github.com/apache/tvm-ffi/issues/430) a user on driver 470.82.01 hit a failure in `_get_cuda_target()` in `python/tvm_ffi/cpp/extension.py` because compute-capability auto-detection fails on stale driver metadata, and asked how to set the arch manually. Maintainer tqchen confirmed `TVM_FFI_CUDA_ARCH_LIST` already covers this and suggested surfacing it first before changing the API. The auto-detection gap itself was handled by merged #440; what was left was discoverability of the manual escape hatch.

## Testing

The `_get_cuda_target()` docstring in `python/tvm_ffi/cpp/extension.py` now documents the env-var override and its `"8.9 9.0a"` space-separated format, and the "Could not detect CUDA compute_cap automatically" branch now names `TVM_FFI_CUDA_ARCH_LIST` as the remedy with the format example. A matching note was added to `docs/guides/kernel_library_guide.rst` for old-driver and undetectable-GPU cases. The override parsing path is unchanged, so existing `TVM_FFI_CUDA_ARCH_LIST` behavior is preserved. Documentation and message change only; doc build runs in CI.

Fixes #430
