### PR TITLE
[FIX][CI] Pin OrcJIT publish wheel to main, drop unused tag input

### DIFF
--- a/.github/workflows/publish_orcjit_wheel.yml
+++ b/.github/workflows/publish_orcjit_wheel.yml
@@ -18,11 +18,11 @@
 name: Publish OrcJIT wheel
 
 on:
+  # The OrcJIT addon is a standalone package versioned by
+  # addons/tvm_ffi_orcjit/pyproject.toml, independent of the tvm-ffi repo tags.
+  # Always build from main (see checkout_ref below); the wheel version comes
+  # from that pyproject.toml, so no tag input is needed.
   workflow_dispatch:
-    inputs:
-      tag:
-        description: "Tag to publish (manual run)"
-        required: true
 
 jobs:
   build_wheels:
@@ -48,7 +48,7 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
           build: ${{ matrix.build }}
-          checkout_ref: ${{ inputs.tag }}
+          checkout_ref: main
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Problem

The **Publish OrcJIT wheel** workflow failed on its last manual run
([run 27092992406](https://github.com/apache/tvm-ffi/actions/runs/27092992406),
dispatched with `tag: v0.1.0`). All four build legs failed with:

```
cibuildwheel: Could not find any of {setup.py, setup.cfg, pyproject.toml} at root of package
```

## Root cause

`publish_orcjit_wheel.yml` was copy-pasted from the main-package
`publish_wheel.yml` and inherited a `tag` `workflow_dispatch` input wired into the
`build-orcjit-wheel` action's `checkout_ref`. The composite action then does an inner
`actions/checkout { ref: <tag> }` that **replaces the working tree** with the repo
state at that tag.

But the OrcJIT addon (`apache-tvm_ffi_orcjit`) is a **standalone package**, versioned
by its own `addons/tvm_ffi_orcjit/pyproject.toml` (currently `0.1.0`), independent of
the tvm-ffi repo tags. The addon was added in #254 (2026-03-27) and first appears in
tag `v0.1.10`. Dispatching with any older tag — `v0.1.0` here — checks out a tree with
**no addon directory**, so cibuildwheel finds no `pyproject.toml`. (The overwrite also
clobbers the action's own `action.yml`, producing the confusing secondary
"Can't find 'action.yml'" post-step error.)

The repo tag was never the addon's version source — only a (wrong) checkout source.

## Fix

Single-file change to `publish_orcjit_wheel.yml`:

- Remove the unused `tag` `workflow_dispatch` input.
- Pin the build to `checkout_ref: main`, so publish always builds the current addon
  source. The wheel version comes from the addon's `pyproject.toml`.

The `build-orcjit-wheel` action keeps its `checkout_ref` input unchanged, because the
`orcjit` job in `ci_test.yml` still uses it (`checkout_ref: ${{ github.sha }}`) to build
the addon at the PR head SHA. The action's inner `submodules: recursive` checkout is
load-bearing: `CIBW_TEST_COMMAND` does `pip install --force-reinstall {project}`, which
rebuilds the main `apache-tvm-ffi` from the repo root and needs `3rdparty/dlpack` +
`libbacktrace`.

## Validation

Dispatched on a fork with the patched workflow
([run 27130310085](https://github.com/cyx-6/tvm-ffi/actions/runs/27130310085)): all four
`build_wheels` legs — ubuntu x86_64, ubuntu aarch64, macOS arm64, Windows AMD64 — built,
tested, and uploaded wheels successfully. `upload_pypi` fails on the fork only because it
has no PyPI trusted-publisher mapping (`invalid-publisher`); that step works on
`apache/tvm-ffi`, which has the `pypi` environment configured. `actionlint` passes clean.