### PR TITLE
[DOC] Restore tensor method docs (ndim, numel, size, is_contiguous)

### DIFF
--- a/docs/reference/python/index.rst
+++ b/docs/reference/python/index.rst
@@ -49,6 +49,15 @@ Tensor
   DLDeviceType
   device
 
+.. rubric:: Tensor methods
+
+.. autosummary::
+
+  Tensor.ndim
+  Tensor.numel
+  Tensor.size
+  Tensor.is_contiguous
+
 Function
 ~~~~~~~~
 .. autosummary::


### PR DESCRIPTION
[DOC] Restore tensor method docs (ndim, numel, size, is_contiguous) without warnings

PR #607 commit ae58d90 removed ndim/numel/size/is_contiguous from the Python API
index page after a previous qualified-name attempt produced "duplicate object
description" warnings. However the assumption that "the Tensor autoclass already
documents them" only held for the Tensor sub-page (generated/tvm_ffi.Tensor.html);
those four methods had no individual entries on the top-level index page.

Fix: add a "Tensor methods" rubric with an `autosummary` block (no :toctree:) for
the four qualified names (Tensor.ndim etc.). Without :toctree:, sphinx generates no
stub pages, so there is no second sphinx-domain registration and no duplicate warning.
The entries produce a summary table on the index page with links to the existing
Tensor class page anchors (generated/tvm_ffi.Tensor.html#tvm_ffi.Tensor.*).

Verification: baseline 0 warnings, after-fix 0 warnings; all four methods render on
the index page with correct href anchors.

