### PR TITLE
[CI] Update astral-sh/setup-uv to allowed ref v8.2.0

### DIFF
--- a/.github/actions/build-wheel-for-publish/action.yml
+++ b/.github/actions/build-wheel-for-publish/action.yml
@@ -54,7 +54,7 @@ runs:
         python-version: 3.8
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098  # v7.3.1
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
 
     - name: Check out source
       uses: actions/checkout@v5

--- a/.github/workflows/ci_mainline_only.yml
+++ b/.github/workflows/ci_mainline_only.yml
@@ -50,7 +50,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       - name: Set up uv
-        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098  # v7.3.1
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
       - uses: ./.github/actions/detect-env-vars
         id: env_vars
       - name: Run clang-tidy
@@ -110,7 +110,7 @@ jobs:
           fetch-tags: true
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098  # v7.3.1
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           python-version: ${{ matrix.python_version }}
           activate-environment: true

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       - name: Set up uv
-        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098  # v7.3.1
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
       - name: Set up Python environment
         run: uv sync --group dev --no-install-project
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
@@ -88,7 +88,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       - name: Set up uv
-        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098  # v7.3.1
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           python-version: 3.13
       - uses: ./.github/actions/detect-env-vars
@@ -111,7 +111,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       - name: Set up uv
-        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098  # v7.3.1
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           python-version: 3.13
       - name: Generate docs
@@ -182,7 +182,7 @@ jobs:
 
       # Run Python tests
       - name: Setup Python ${{ matrix.python_version }}
-        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098  # v7.3.1
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           python-version: ${{ matrix.python_version }}
           activate-environment: true

--- a/.github/workflows/torch_c_dlpack.yml
+++ b/.github/workflows/torch_c_dlpack.yml
@@ -83,7 +83,7 @@ jobs:
           path: tvm-ffi
       - uses: Jimver/cuda-toolkit@6008063726ffe3309d1b22e413d9e88fed91a2f2
         id: cuda-toolkit
-      - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098  # v7.3.1
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
       - name: build wheels
         env:
           CUDA_HOME: ${{steps.cuda-toolkit.outputs.CUDA_PATH}}
@@ -109,7 +109,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           path: tvm-ffi
-      - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098  # v7.3.1
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
       - name: build torch libs and wheels
         working-directory: ./tvm-ffi
         run: |
@@ -128,7 +128,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           path: tvm-ffi
-      - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098  # v7.3.1
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           python-version: "3.12"
           activate-environment: true


### PR DESCRIPTION
## Motivation

The ASF `infrastructure-actions` allowlist was updated and the previously pinned `astral-sh/setup-uv` ref was removed:

- Removed: `astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098` (v7.3.1)

Since this ref is no longer on the approved list, the action allowlist check will reject our workflows until it is bumped to a currently allowed ref.

## Change

Bump all usages of `astral-sh/setup-uv` to the latest allowed ref:

- New: `astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39` (v8.2.0)

This is the newest ref currently on the allowlist and the only `setup-uv` entry without an `expires_at`, so it is the most durable choice. The v7.x allowed refs expire on 2026-06-27.

The change is a straightforward pin update — the workflows only use the stable `python-version` and `activate-environment` inputs, which are unchanged across the v7 → v8 major bump.

### Files updated (10 occurrences)

- `.github/actions/build-wheel-for-publish/action.yml`
- `.github/workflows/ci_mainline_only.yml`
- `.github/workflows/ci_test.yml`
- `.github/workflows/torch_c_dlpack.yml`