### PR TITLE
[DOCS] Clarify CStrParts error handling usage

### DIFF
--- a/docs/concepts/abi_overview.rst
+++ b/docs/concepts/abi_overview.rst
@@ -475,7 +475,7 @@ The following C code sets the TLS error and returns ``-1`` via :cpp:func:`TVMFFI
   :start-after: [Error.RaiseException.begin]
   :end-before: [Error.RaiseException.end]
 
-For non-null-terminated strings, use :cpp:func:`TVMFFIErrorSetRaisedFromCStrParts`, which accepts explicit string lengths.
+When an error message is assembled from reusable parts, use :cpp:func:`TVMFFIErrorSetRaisedFromCStrParts` to avoid duplicating common message fragments.
 
 .. note::
    You rarely need to create a :cpp:class:`~tvm::ffi::ErrorObj` directly.


### PR DESCRIPTION
Summary:
- Clarify that TVMFFIErrorSetRaisedFromCStrParts is for assembling error messages from reusable parts, not for non-null-terminated strings with explicit lengths.