### PR TITLE
[CI] Bump pinned GitHub Action hashes

### DIFF
--- a/.github/actions/build-orcjit-wheel/action.yml
+++ b/.github/actions/build-orcjit-wheel/action.yml
@@ -88,7 +88,7 @@ runs:
 
     # ---- Build and test wheels ----
     - name: Build and test wheels
-      uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e  # v3.3.1
+      uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55  # v4.1.0
       with:
         package-dir: addons/tvm_ffi_orcjit
         output-dir: wheelhouse

--- a/.github/actions/build-wheel-for-publish/action.yml
+++ b/.github/actions/build-wheel-for-publish/action.yml
@@ -93,7 +93,7 @@ runs:
 
     - name: Build wheels
       if: ${{ inputs.build_wheels == 'true' }}
-      uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e  # v3.3.1
+      uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55  # v4.1.0
       env:
         CIBW_ARCHS_MACOS: ${{ inputs.arch }}
         CIBW_ARCHS_LINUX: ${{ inputs.arch }}


### PR DESCRIPTION
Bump the pinned cibuildwheel GitHub Action hash to pypa/cibuildwheel v4.1.0.

The pypa/gh-action-pypi-publish and pre-commit/action pins were already at the requested hashes.