### PR TITLE
[BUILD] Hide symbols from linked static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ endif ()
 
 tvm_ffi_add_msvc_flags(tvm_ffi_objs)
 tvm_ffi_add_target_from_obj(tvm_ffi tvm_ffi_objs)
+tvm_ffi_hide_static_linked_lib_symbols(tvm_ffi_shared)
 
 if (TVM_FFI_USE_THREADS)
   find_package(Threads REQUIRED)
@@ -178,6 +179,7 @@ set_target_properties(
 target_link_libraries(tvm_ffi_testing PRIVATE tvm_ffi_shared)
 target_link_libraries(tvm_ffi_testing PUBLIC tvm_ffi_header)
 tvm_ffi_add_msvc_flags(tvm_ffi_testing)
+tvm_ffi_hide_static_linked_lib_symbols(tvm_ffi_testing)
 tvm_ffi_add_apple_dsymutil(tvm_ffi_testing)
 
 # Set the install RPATH for tvm_ffi_testing so it can find tvm_ffi.so relatively
@@ -296,6 +298,7 @@ if (TVM_FFI_BUILD_PYTHON_MODULE)
   target_link_libraries(tvm_ffi_cython PRIVATE tvm_ffi_shared)
   # link against testing to ensure right unloading order (cython first then testing)
   target_link_libraries(tvm_ffi_cython PRIVATE tvm_ffi_testing)
+  tvm_ffi_hide_static_linked_lib_symbols(tvm_ffi_cython)
   # Set RPATH for tvm_ffi_cython to find tvm_ffi_shared.so relatively
   if (APPLE)
     # macOS uses @loader_path

--- a/cmake/Utils/Library.cmake
+++ b/cmake/Utils/Library.cmake
@@ -78,6 +78,29 @@ function (tvm_ffi_add_msvc_flags target_name)
 endfunction ()
 
 # ~~~
+# tvm_ffi_hide_static_linked_lib_symbols(target_name)
+# Prevent symbols from static archives linked into a shared library from being exported by that
+# shared library.
+#
+# This matters when a toolchain links helper archives into a shared target, for example
+# libstdc++_nonshared.a. Without this guard, symbols pulled from those archives can become dynamic
+# exports of libtvm_ffi.so and unexpectedly interpose with symbols from downstream libraries.
+#
+# Linux, Android, and BSD targets generally use GNU-compatible linkers that support this through
+# `--exclude-libs,ALL`. Other platforms are left unchanged.
+#
+# Parameters:
+#   target_name: CMake target to modify
+# ~~~
+function (tvm_ffi_hide_static_linked_lib_symbols target_name)
+  if (CMAKE_SYSTEM_NAME MATCHES "Linux|Android|FreeBSD|NetBSD|OpenBSD"
+      AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"
+  )
+    target_link_options(${target_name} PRIVATE "-Wl,--exclude-libs,ALL")
+  endif ()
+endfunction ()
+
+# ~~~
 # tvm_ffi_add_target_from_obj(target_name, obj_target_name)
 # Create static and shared library targets from an object library and set output directories
 # consistently across platforms. Also runs dsymutil on Apple for the shared target.


### PR DESCRIPTION
To avoid downstream mistakenly picking up symbols from static libstdc++_nonshared, always hide symbols from static libraries linked into tvm-ffi shared objects.

This adds a CMake helper for the policy and applies it to tvm_ffi_shared, tvm_ffi_testing, and the optional tvm_ffi_cython target on ELF platforms.

Local validation:
- Configured and built tvm_ffi_shared and tvm_ffi_testing with TVM_FFI_USE_LIBBACKTRACE=OFF.
- Verified generated Ninja link flags include -Wl,--exclude-libs,ALL for libtvm_ffi.so and libtvm_ffi_testing.so.