### PR TITLE
[CMake] Format static symbol helper condition

### DIFF
--- a/cmake/Utils/Library.cmake
+++ b/cmake/Utils/Library.cmake
@@ -93,8 +93,8 @@ endfunction ()
 #   target_name: CMake target to modify
 # ~~~
 function (tvm_ffi_hide_static_linked_lib_symbols target_name)
-  if (CMAKE_SYSTEM_NAME MATCHES "Linux|Android|FreeBSD|NetBSD|OpenBSD"
-      AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"
+  if (CMAKE_SYSTEM_NAME MATCHES "Linux|Android|FreeBSD|NetBSD|OpenBSD" AND CMAKE_CXX_COMPILER_ID
+                                                                           MATCHES "GNU|Clang"
   )
     target_link_options(${target_name} PRIVATE "-Wl,--exclude-libs,ALL")
   endif ()


### PR DESCRIPTION
Apply cmake-format to the condition introduced for hiding symbols from linked static libraries.

Validation:
- pre-commit run cmake-format --files cmake/Utils/Library.cmake
- git diff --check