### PR TITLE
Avoid unused type_index local in structural visit

### DIFF
--- a/include/tvm/ffi/extra/structural_visit.h
+++ b/include/tvm/ffi/extra/structural_visit.h
@@ -572,8 +572,7 @@ class StructuralWalkCallbackVisitorObj : public StructuralVisitorObj {
     if constexpr (order == WalkOrder::kPreOrder) {
       auto result = dispatch_(value, this->def_region_kind());
       TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN_WITH_ERROR_CONTEXT(result, value);
-      int32_t type_index = result.type_index();
-      TVM_FFI_UNSAFE_ASSUME(type_index == TypeIndex::kTVMFFIInt);
+      TVM_FFI_UNSAFE_ASSUME(result.type_index() == TypeIndex::kTVMFFIInt);
       if (TVM_FFI_PREDICT_FALSE(details::ExpectedUnsafe::ValueAs<int32_t>(result) ==
                                 WalkResult::kSkipTag)) {
         return details::ExpectedUnsafe::MoveToTVMFFIAny(


### PR DESCRIPTION
This removes the local `type_index` variable in `StructuralWalkCallbackVisitorObj::VisitImpl` and passes the type predicate directly to `TVM_FFI_UNSAFE_ASSUME`.

The previous local could trigger `-Wunused-variable` under configurations where the unsafe-assume macro compiles away or does not count as a use, causing warning-as-error builds to fail.

Validation:
- `git diff --check`
- `pre-commit run --files include/tvm/ffi/extra/structural_visit.h`