### PR TITLE
[CI] Update Jimver/cuda-toolkit to allowed ref v0.2.35

### DIFF
--- a/.github/workflows/torch_c_dlpack.yml
+++ b/.github/workflows/torch_c_dlpack.yml
@@ -81,7 +81,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           path: tvm-ffi
-      - uses: Jimver/cuda-toolkit@6008063726ffe3309d1b22e413d9e88fed91a2f2
+      - uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76  # v0.2.35
         id: cuda-toolkit
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
       - name: build wheels


### PR DESCRIPTION
## Motivation

The ASF `infrastructure-actions` allowlist was updated and the `Jimver/cuda-toolkit` ref currently pinned in our CI was removed:

- Removed: `Jimver/cuda-toolkit@6008063726ffe3309d1b22e413d9e88fed91a2f2`

Since this ref is no longer on the approved list, the ASF action-allowlist check fails for `torch_c_dlpack.yml`.

## Change

Bump `Jimver/cuda-toolkit` to the latest allowed ref:

- New: `Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76` (v0.2.35)

This is the newest `cuda-toolkit` ref on the allowlist and the only one without an `expires_at`, so it is the most durable choice. The step only consumes the stable `CUDA_PATH` output (no `with:` inputs), so the bump needs no other changes.

## Notes

This is a follow-up to the action-ref hygiene sweep. The previously-expired `astral-sh/setup-uv` (#624) and `pypa/cibuildwheel` (#626) refs have already been bumped on `main`; `Jimver/cuda-toolkit` was the only remaining ref flagged by the ASF allowlist checker.

Verified with the official `apache/infrastructure-actions` `check_asf_allowlist.py` against the current `approved_patterns.yml`: 0 violations after this change.