### PR TITLE
[API] Add type index query mode

### DIFF
--- a/include/tvm/ffi/c_api.h
+++ b/include/tvm/ffi/c_api.h
@@ -1358,15 +1358,17 @@ TVM_FFI_DLL const TVMFFIByteArray* TVMFFIBacktrace(const char* filename, int lin
  * If the static_tindex is non-negative, the function will
  * allocate a runtime type index.
  * Otherwise, we will populate the type table and return the static index.
+ * If parent_type_index is -2, the function queries the existing type index:
+ * it returns the registered index for type_key, or -2 if type_key is not registered.
  *
  * \param type_key The type key.
  * \param type_depth The type depth.
  * \param static_type_index Static type index if any, can be -1, which means this is a dynamic index
  * \param num_child_slots Number of slots reserved for its children.
  * \param child_slots_can_overflow Whether to allow child to overflow the slots.
- * \param parent_type_index Parent type index, pass in -1 if it is root.
+ * \param parent_type_index Parent type index, pass in -1 if it is root, or -2 to query only.
  *
- * \return The allocated type index.
+ * \return The existing or allocated type index; -2 when query-only mode misses.
  */
 TVM_FFI_DLL int32_t TVMFFITypeGetOrAllocIndex(const TVMFFIByteArray* type_key,
                                               int32_t static_type_index, int32_t type_depth,

--- a/src/ffi/object.cc
+++ b/src/ffi/object.cc
@@ -195,6 +195,14 @@ class TypeTable {
     return static_cast<int32_t>((*it).second);
   }
 
+  int32_t QueryTypeIndex(const String& type_key) {
+    auto it = type_key2index_.find(type_key);
+    if (it == type_key2index_.end()) {
+      return -2;
+    }
+    return static_cast<int32_t>((*it).second);
+  }
+
   Entry* GetTypeEntry(int32_t type_index) {
     Entry* entry = nullptr;
     if (type_index >= 0 && static_cast<size_t>(type_index) < type_table_.size()) {
@@ -587,6 +595,9 @@ int32_t TVMFFITypeGetOrAllocIndex(const TVMFFIByteArray* type_key, int32_t stati
                                   int32_t child_slots_can_overflow, int32_t parent_type_index) {
   TVM_FFI_LOG_EXCEPTION_CALL_BEGIN();
   tvm::ffi::String s_type_key(type_key->data, type_key->size);
+  if (parent_type_index == -2) {
+    return tvm::ffi::TypeTable::Global()->QueryTypeIndex(s_type_key);
+  }
   return tvm::ffi::TypeTable::Global()->GetOrAllocTypeIndex(
       s_type_key, static_type_index, type_depth, num_child_slots, child_slots_can_overflow,
       parent_type_index);

--- a/src/ffi/object.cc
+++ b/src/ffi/object.cc
@@ -126,6 +126,9 @@ class TypeTable {
     if (it != type_key2index_.end()) {
       return type_table_[(*it).second]->type_index;
     }
+    if (parent_type_index == -2) {
+      return -2;
+    }
 
     // get parent's entry
     Entry* parent = [&]() -> Entry* {
@@ -192,14 +195,6 @@ class TypeTable {
     String type_key_str(type_key->data, type_key->size);
     auto it = type_key2index_.find(type_key_str);
     TVM_FFI_ICHECK(it != type_key2index_.end()) << "Cannot find type `" << type_key_str << "`";
-    return static_cast<int32_t>((*it).second);
-  }
-
-  int32_t QueryTypeIndex(const String& type_key) {
-    auto it = type_key2index_.find(type_key);
-    if (it == type_key2index_.end()) {
-      return -2;
-    }
     return static_cast<int32_t>((*it).second);
   }
 
@@ -595,9 +590,6 @@ int32_t TVMFFITypeGetOrAllocIndex(const TVMFFIByteArray* type_key, int32_t stati
                                   int32_t child_slots_can_overflow, int32_t parent_type_index) {
   TVM_FFI_LOG_EXCEPTION_CALL_BEGIN();
   tvm::ffi::String s_type_key(type_key->data, type_key->size);
-  if (parent_type_index == -2) {
-    return tvm::ffi::TypeTable::Global()->QueryTypeIndex(s_type_key);
-  }
   return tvm::ffi::TypeTable::Global()->GetOrAllocTypeIndex(
       s_type_key, static_type_index, type_depth, num_child_slots, child_slots_can_overflow,
       parent_type_index);

--- a/tests/cpp/test_object.cc
+++ b/tests/cpp/test_object.cc
@@ -86,6 +86,21 @@ TEST(Object, CRTPObjectInfo) {
   EXPECT_GE(info->type_index, TypeIndex::kTVMFFIDynObjectBegin);
 }
 
+TEST(Object, TypeGetOrAllocIndexQueryRegistered) {
+  TVMFFIByteArray type_key{TIntObj::_type_key, std::char_traits<char>::length(TIntObj::_type_key)};
+  EXPECT_EQ(TVMFFITypeGetOrAllocIndex(&type_key, -1, 0, 0, 0, -2), TIntObj::RuntimeTypeIndex());
+}
+
+TEST(Object, TypeGetOrAllocIndexQueryMissDoesNotRegister) {
+  const char* type_key_data = "test.TypeGetOrAllocIndexQueryMiss";
+  TVMFFIByteArray type_key{type_key_data, std::char_traits<char>::length(type_key_data)};
+  EXPECT_EQ(TVMFFITypeGetOrAllocIndex(&type_key, -1, 0, 0, 0, -2), -2);
+
+  int32_t type_index = -1;
+  EXPECT_NE(TVMFFITypeKeyToIndex(&type_key, &type_index), 0);
+  EXPECT_EQ(type_index, -1);
+}
+
 TEST(Object, InstanceCheck) {
   ObjectPtr<Object> a = make_object<TIntObj>(11);
   ObjectPtr<Object> b = make_object<TFloatObj>(11);


### PR DESCRIPTION
## Summary
- Add query-only behavior to TVMFFITypeGetOrAllocIndex when parent_type_index == -2.
- Return the existing registered type index on hit, or -2 on miss without allocating/registering or mutating parent metadata.
- Document the concrete -2 C API behavior and add focused C++ coverage for hit and miss/no-registration behavior.

This query mode is reserved for a future release update that may optionally query type indices at startup.
