### PR TITLE
[PY] Support pickling ffi.String without cached FFI object

### DIFF
--- a/python/tvm_ffi/cython/string.pxi
+++ b/python/tvm_ffi/cython/string.pxi
@@ -70,6 +70,9 @@ class Bytes(bytes, PyNativeObject):
         val._tvm_ffi_cached_object = None
         return val
 
+    def __reduce_ex__(self, protocol):
+        return (type(self), (bytes(self),))
+
     # pylint: disable=no-self-argument
     def __from_tvm_ffi_object__(cls, obj):
         """Construct from a given tvm object."""

--- a/python/tvm_ffi/cython/string.pxi
+++ b/python/tvm_ffi/cython/string.pxi
@@ -42,6 +42,9 @@ class String(str, PyNativeObject):
         val._tvm_ffi_cached_object = None
         return val
 
+    def __reduce_ex__(self, protocol):
+        return (type(self), (str(self),))
+
     # pylint: disable=no-self-argument
     def __from_tvm_ffi_object__(cls, obj):
         """Construct from a given tvm object."""

--- a/tests/python/test_string.py
+++ b/tests/python/test_string.py
@@ -18,6 +18,7 @@
 import pickle
 
 import tvm_ffi
+from tvm_ffi.core import TypeSchema, _to_py_class_value
 
 
 def test_string() -> None:
@@ -33,6 +34,15 @@ def test_string() -> None:
 
     s4 = pickle.loads(pickle.dumps(s))
     assert s4 == "hello"
+
+    cached = _to_py_class_value(TypeSchema("str").convert("x" * 200))
+    assert isinstance(cached, tvm_ffi.core.String)
+    assert cached._tvm_ffi_cached_object is not None
+
+    cached_roundtrip = pickle.loads(pickle.dumps(cached))
+    assert isinstance(cached_roundtrip, tvm_ffi.core.String)
+    assert cached_roundtrip == cached
+    assert cached_roundtrip._tvm_ffi_cached_object is None
 
 
 def test_bytes() -> None:

--- a/tests/python/test_string.py
+++ b/tests/python/test_string.py
@@ -18,7 +18,7 @@
 import pickle
 
 import tvm_ffi
-from tvm_ffi.core import TypeSchema, _to_py_class_value
+import tvm_ffi.testing
 
 
 def test_string() -> None:
@@ -35,7 +35,7 @@ def test_string() -> None:
     s4 = pickle.loads(pickle.dumps(s))
     assert s4 == "hello"
 
-    cached = _to_py_class_value(TypeSchema("str").convert("x" * 200))
+    cached = fecho("x" * 200)
     assert isinstance(cached, tvm_ffi.core.String)
     assert cached._tvm_ffi_cached_object is not None
 
@@ -63,3 +63,12 @@ def test_bytes() -> None:
     b5 = pickle.loads(pickle.dumps(b))
     assert b5 == b"hello"
     assert isinstance(b5, tvm_ffi.core.Bytes)
+
+    cached = fecho(b"x" * 200)
+    assert isinstance(cached, tvm_ffi.core.Bytes)
+    assert cached._tvm_ffi_cached_object is not None
+
+    cached_roundtrip = pickle.loads(pickle.dumps(cached))
+    assert isinstance(cached_roundtrip, tvm_ffi.core.Bytes)
+    assert cached_roundtrip == cached
+    assert cached_roundtrip._tvm_ffi_cached_object is None


### PR DESCRIPTION
## Summary
- Add a custom pickle reduction for `tvm_ffi.core.String` so only the Python string payload is serialized.
- Drop the hidden `_tvm_ffi_cached_object` on unpickle, since `String` is effectively `str` with optional FFI backing.
- Add a regression test for long FFI strings that carry a cached backing object.