### PR TITLE
[PY] Support pickling FFI String and Bytes

### DIFF
--- a/python/tvm_ffi/cython/string.pxi
+++ b/python/tvm_ffi/cython/string.pxi
@@ -58,9 +58,7 @@ class String(str, PyNativeObject):
         return val
 
     def __reduce_ex__(self, protocol):
-        state = self.__dict__.copy() if hasattr(self, "__dict__") else {}
-        state.pop("_tvm_ffi_cached_object", None)
-        return (type(self), (str(self),), state or None)
+        return (str, (str(self),))
 
     # pylint: disable=no-self-argument
     def __from_tvm_ffi_object__(cls, obj: Any) -> "String":
@@ -86,9 +84,7 @@ class Bytes(bytes, PyNativeObject):
         return val
 
     def __reduce_ex__(self, protocol):
-        state = self.__dict__.copy() if hasattr(self, "__dict__") else {}
-        state.pop("_tvm_ffi_cached_object", None)
-        return (type(self), (bytes(self),), state or None)
+        return (bytes, (bytes(self),))
 
     # pylint: disable=no-self-argument
     def __from_tvm_ffi_object__(cls, obj: Any) -> "Bytes":

--- a/python/tvm_ffi/cython/string.pxi
+++ b/python/tvm_ffi/cython/string.pxi
@@ -57,6 +57,9 @@ class String(str, PyNativeObject):
         val._tvm_ffi_cached_object = None
         return val
 
+    def __reduce_ex__(self, protocol):
+        return (type(self), (str(self),))
+
     # pylint: disable=no-self-argument
     def __from_tvm_ffi_object__(cls, obj: Any) -> "String":
         """Construct a ``String`` from an FFI object (internal)."""
@@ -79,6 +82,9 @@ class Bytes(bytes, PyNativeObject):
         val = bytes.__new__(cls, value)
         val._tvm_ffi_cached_object = None
         return val
+
+    def __reduce_ex__(self, protocol):
+        return (type(self), (bytes(self),))
 
     # pylint: disable=no-self-argument
     def __from_tvm_ffi_object__(cls, obj: Any) -> "Bytes":

--- a/python/tvm_ffi/cython/string.pxi
+++ b/python/tvm_ffi/cython/string.pxi
@@ -58,7 +58,9 @@ class String(str, PyNativeObject):
         return val
 
     def __reduce_ex__(self, protocol):
-        return (type(self), (str(self),))
+        state = self.__dict__.copy() if hasattr(self, "__dict__") else {}
+        state.pop("_tvm_ffi_cached_object", None)
+        return (type(self), (str(self),), state or None)
 
     # pylint: disable=no-self-argument
     def __from_tvm_ffi_object__(cls, obj: Any) -> "String":
@@ -84,7 +86,9 @@ class Bytes(bytes, PyNativeObject):
         return val
 
     def __reduce_ex__(self, protocol):
-        return (type(self), (bytes(self),))
+        state = self.__dict__.copy() if hasattr(self, "__dict__") else {}
+        state.pop("_tvm_ffi_cached_object", None)
+        return (type(self), (bytes(self),), state or None)
 
     # pylint: disable=no-self-argument
     def __from_tvm_ffi_object__(cls, obj: Any) -> "Bytes":

--- a/tests/python/test_string.py
+++ b/tests/python/test_string.py
@@ -18,6 +18,7 @@
 import pickle
 
 import tvm_ffi
+import tvm_ffi.testing
 
 
 def test_string() -> None:
@@ -33,6 +34,15 @@ def test_string() -> None:
 
     s4 = pickle.loads(pickle.dumps(s))
     assert s4 == "hello"
+
+    cached = fecho("x" * 200)
+    assert isinstance(cached, tvm_ffi.core.String)
+    assert cached._tvm_ffi_cached_object is not None
+
+    cached_roundtrip = pickle.loads(pickle.dumps(cached))
+    assert isinstance(cached_roundtrip, tvm_ffi.core.String)
+    assert cached_roundtrip == cached
+    assert cached_roundtrip._tvm_ffi_cached_object is None
 
 
 def test_bytes() -> None:
@@ -53,6 +63,15 @@ def test_bytes() -> None:
     b5 = pickle.loads(pickle.dumps(b))
     assert b5 == b"hello"
     assert isinstance(b5, tvm_ffi.core.Bytes)
+
+    cached = fecho(b"x" * 200)
+    assert isinstance(cached, tvm_ffi.core.Bytes)
+    assert cached._tvm_ffi_cached_object is not None
+
+    cached_roundtrip = pickle.loads(pickle.dumps(cached))
+    assert isinstance(cached_roundtrip, tvm_ffi.core.Bytes)
+    assert cached_roundtrip == cached
+    assert cached_roundtrip._tvm_ffi_cached_object is None
 
 
 def test_string_find_substr() -> None:

--- a/tests/python/test_string.py
+++ b/tests/python/test_string.py
@@ -21,6 +21,10 @@ import tvm_ffi
 import tvm_ffi.testing
 
 
+class TaggedString(tvm_ffi.core.String):
+    pass
+
+
 def test_string() -> None:
     fecho = tvm_ffi.get_global_func("testing.echo")
     s = tvm_ffi.core.String("hello")
@@ -43,6 +47,14 @@ def test_string() -> None:
     assert isinstance(cached_roundtrip, tvm_ffi.core.String)
     assert cached_roundtrip == cached
     assert cached_roundtrip._tvm_ffi_cached_object is None
+
+    tagged = TaggedString("hello")
+    setattr(tagged, "note", "keep")
+    tagged_roundtrip = pickle.loads(pickle.dumps(tagged))
+    assert isinstance(tagged_roundtrip, TaggedString)
+    assert tagged_roundtrip == tagged
+    assert getattr(tagged_roundtrip, "note") == "keep"
+    assert tagged_roundtrip._tvm_ffi_cached_object is None
 
 
 def test_bytes() -> None:
@@ -67,10 +79,12 @@ def test_bytes() -> None:
     cached = fecho(b"x" * 200)
     assert isinstance(cached, tvm_ffi.core.Bytes)
     assert cached._tvm_ffi_cached_object is not None
+    setattr(cached, "note", "keep")
 
     cached_roundtrip = pickle.loads(pickle.dumps(cached))
     assert isinstance(cached_roundtrip, tvm_ffi.core.Bytes)
     assert cached_roundtrip == cached
+    assert getattr(cached_roundtrip, "note") == "keep"
     assert cached_roundtrip._tvm_ffi_cached_object is None
 
 

--- a/tests/python/test_string.py
+++ b/tests/python/test_string.py
@@ -21,10 +21,6 @@ import tvm_ffi
 import tvm_ffi.testing
 
 
-class TaggedString(tvm_ffi.core.String):
-    pass
-
-
 def test_string() -> None:
     fecho = tvm_ffi.get_global_func("testing.echo")
     s = tvm_ffi.core.String("hello")
@@ -38,23 +34,15 @@ def test_string() -> None:
 
     s4 = pickle.loads(pickle.dumps(s))
     assert s4 == "hello"
+    assert type(s4) is str
 
     cached = fecho("x" * 200)
     assert isinstance(cached, tvm_ffi.core.String)
     assert cached._tvm_ffi_cached_object is not None
 
     cached_roundtrip = pickle.loads(pickle.dumps(cached))
-    assert isinstance(cached_roundtrip, tvm_ffi.core.String)
     assert cached_roundtrip == cached
-    assert cached_roundtrip._tvm_ffi_cached_object is None
-
-    tagged = TaggedString("hello")
-    setattr(tagged, "note", "keep")
-    tagged_roundtrip = pickle.loads(pickle.dumps(tagged))
-    assert isinstance(tagged_roundtrip, TaggedString)
-    assert tagged_roundtrip == tagged
-    assert getattr(tagged_roundtrip, "note") == "keep"
-    assert tagged_roundtrip._tvm_ffi_cached_object is None
+    assert type(cached_roundtrip) is str
 
 
 def test_bytes() -> None:
@@ -74,18 +62,15 @@ def test_bytes() -> None:
 
     b5 = pickle.loads(pickle.dumps(b))
     assert b5 == b"hello"
-    assert isinstance(b5, tvm_ffi.core.Bytes)
+    assert type(b5) is bytes
 
     cached = fecho(b"x" * 200)
     assert isinstance(cached, tvm_ffi.core.Bytes)
     assert cached._tvm_ffi_cached_object is not None
-    setattr(cached, "note", "keep")
 
     cached_roundtrip = pickle.loads(pickle.dumps(cached))
-    assert isinstance(cached_roundtrip, tvm_ffi.core.Bytes)
     assert cached_roundtrip == cached
-    assert getattr(cached_roundtrip, "note") == "keep"
-    assert cached_roundtrip._tvm_ffi_cached_object is None
+    assert type(cached_roundtrip) is bytes
 
 
 def test_string_find_substr() -> None:


### PR DESCRIPTION
## Summary
- Add pickle reductions for `tvm_ffi.core.String` and `tvm_ffi.core.Bytes` so only the Python payload is serialized.
- Ensure unpickled values drop the hidden `_tvm_ffi_cached_object` backing object.
- Add regression coverage for cached FFI String/Bytes returned from `testing.echo`.

## Notes
- This is a clean branch based on the latest `apache/main` and supersedes #642, which became dirty after main advanced.
- `Bytes.__slots__` is intentionally unchanged because Python does not support non-empty `__slots__` on `bytes` subclasses.

## Test plan
- `uv pip install --reinstall --verbose . && .venv/bin/pytest -vvs tests/python/test_string.py`
- `PYTHONPATH=/raid/user_data/yixind/miniforge3/lib/python3.12/site-packages pre-commit run --files python/tvm_ffi/cython/string.pxi tests/python/test_string.py`