### PR TITLE
build(python)!: require CMake 3.26 for ABI-aware builds

### DIFF
--- a/.agents/skills/devtools/SKILL.md
+++ b/.agents/skills/devtools/SKILL.md
@@ -12,7 +12,7 @@ Condensed reference from `docs/dev/`. Use this when working on the TVM-FFI codeb
 
 - **Python**: 3.9+ (managed via `uv`; default virtualenv at `.venv`)
 - **Compiler**: C++17-capable toolchain (GCC/Clang on Linux, Apple Clang on macOS, MSVC on Windows)
-- **Build tools**: CMake 3.18+, Ninja
+- **Build tools**: CMake 3.26+, Ninja
 - **Source**: Always clone with `--recursive`, or run `git submodule update --init --recursive`
 
 All Python-related commands below use [`uv`](https://docs.astral.sh/uv/). The default virtual environment is `.venv` in the repo root.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ cmake --build build_cpp --parallel --config RelWithDebInfo --target tvm_ffi_shar
 
 ### Prerequisites
 
-- Python 3.9+, C++17 compiler, CMake 3.18+, Ninja
+- Python 3.9+, C++17 compiler, CMake 3.26+, Ninja
 - Submodules: `git submodule update --init --recursive`
 
 ## Testing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.26)
 
 project(tvm_ffi LANGUAGES CXX C)
 
@@ -239,9 +239,35 @@ if (TVM_FFI_BUILD_PYTHON_MODULE)
 
   find_package(
     Python
-    COMPONENTS Interpreter Development.Module Development.SABIModule
+    COMPONENTS Interpreter
     REQUIRED
   )
+
+  # Run a Python script to check for free-threaded build
+  execute_process(
+    COMMAND ${Python_EXECUTABLE} -c
+            "import sysconfig; print(sysconfig.get_config_var('Py_GIL_DISABLED') == 1)"
+    OUTPUT_VARIABLE PYTHON_IS_FREE_THREADED
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if (PYTHON_IS_FREE_THREADED)
+    message(STATUS "Free-threaded Python detected.")
+  endif ()
+
+  set(_tvm_ffi_python_version ${Python_VERSION})
+  if (Python_VERSION VERSION_GREATER_EQUAL "3.12" AND NOT PYTHON_IS_FREE_THREADED)
+    find_package(
+      Python ${_tvm_ffi_python_version} EXACT
+      COMPONENTS Interpreter Development.Module Development.SABIModule
+      REQUIRED
+    )
+  else ()
+    find_package(
+      Python ${_tvm_ffi_python_version} EXACT
+      COMPONENTS Interpreter Development.Module
+      REQUIRED
+    )
+  endif ()
   set(_core_cpp ${CMAKE_CURRENT_BINARY_DIR}/core.cpp)
   set(_core_pyx ${CMAKE_CURRENT_SOURCE_DIR}/python/tvm_ffi/cython/core.pyx)
   set(_cython_sources
@@ -258,17 +284,6 @@ if (TVM_FFI_BUILD_PYTHON_MODULE)
       ${CMAKE_CURRENT_SOURCE_DIR}/python/tvm_ffi/cython/object.pxi
       ${CMAKE_CURRENT_SOURCE_DIR}/python/tvm_ffi/cython/string.pxi
   )
-  # Run a Python script to check for free-threaded build
-  execute_process(
-    COMMAND ${Python_EXECUTABLE} -c
-            "import sysconfig; print(sysconfig.get_config_var('Py_GIL_DISABLED') == 1)"
-    OUTPUT_VARIABLE PYTHON_IS_FREE_THREADED
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-  if (PYTHON_IS_FREE_THREADED)
-    message(STATUS "Free-threaded Python detected.")
-  endif ()
-
   add_custom_command(
     OUTPUT ${_core_cpp}
     COMMAND ${Python_EXECUTABLE} -m cython --cplus ${_core_pyx} -o ${_core_cpp} --module-name

--- a/docs/dev/source_build.rst
+++ b/docs/dev/source_build.rst
@@ -34,7 +34,7 @@ This guide covers two common workflows:
      - macOS: Apple Clang (via Xcode Command Line Tools)
      - Windows: MSVC (Visual Studio 2019 or 2022, x64)
 
-   - Build tools: CMake 3.18+; Ninja
+   - Build tools: CMake 3.26+; Ninja
 
 Build the Python Package
 ------------------------


### PR DESCRIPTION
Architecture:
- Split Python interpreter discovery from development-component discovery so the extension ABI is known before CMake resolves link targets.
- Detect Py_GIL_DISABLED with the selected interpreter, pin its exact version, and request only the development components used by that ABI branch.
- Set CMake 3.26 as the project minimum, matching the first release that provides Development.SABIModule and python_add_library(USE_SABI).

Public Interfaces:
- Standard CPython 3.12 and newer requires Development.Module and Development.SABIModule and produces an abi3 extension.
- Free-threaded CPython and CPython older than 3.12 require only Development.Module and produce a version-specific extension with SOABI.
- Building the root project now requires CMake 3.26 or newer. Runtime APIs and the stable TVM FFI C ABI are unchanged.

UI/UX:
- none

Behavioral Changes:
- Stop requiring stable-ABI development artifacts for configurations that cannot use the Limited API, including free-threaded CPython.
- Preserve the existing abi3 path for standard CPython 3.12 and newer while allowing declared cp314t builds to configure against their native ABI.
- Fail early with an explicit CMake version requirement instead of reaching unsupported FindPython components or USE_SABI options on older CMake.

Docs:
- Raise the CMake prerequisite to 3.26 in the source-build guide, AGENTS.md, and the tracked developer-tool reference.

Tests:
- Executed: staged pre-commit hooks, isolated CMake configuration for the C++ project, and isolated CMake configuration with the Python module enabled.
- Result: all executed checks passed.

Untested Edge Cases:
- Free-threaded CPython, Windows, and Python versions older than 3.12 were not available locally; their component selection remains covered by the explicit CMake branches and should be exercised in CI.
- Compilation, wheel creation, and the full unit-test suites were not rerun because this commit changes configuration and dependency selection only.

BREAKING CHANGE: Building TVM FFI now requires CMake 3.26 or newer. Upgrade CMake before configuring either the standalone C++ project or Python package.