### PR TITLE
fix(packaging): tag core wheels per-version instead of abi3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,9 @@ build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
-wheel.py-api = "cp312"
+# Per-Python-version wheels (no abi3 / limited API): the core extension builds
+# against the full per-version Python C API (WITH_SOABI in CMakeLists.txt), so the
+# wheel must be tagged per-version (cp312-cp312, ...) rather than cp312-abi3.
 minimum-version = "build-system.requires"
 ninja.version = ">=1.11"
 ninja.make-fallback = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,8 +252,9 @@ build-verbosity = 1
 # Per-Python-version wheels (no abi3 / limited API).
 build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314t-*"]
 skip = ["*musllinux*"]
-# we only need to test on cp312
-test-skip = ["cp39-*", "cp310-*", "cp311-*"]
+# cp39-cp311 are covered by the cp312 test run. cp313 aarch64 is skipped because torch
+# ships no cp313 aarch64 wheel for the manylinux2014 image, so its test-phase install fails.
+test-skip = ["cp39-*", "cp310-*", "cp311-*", "cp313-*aarch64"]
 build-frontend = "build[uv]"
 test-command = "pytest {package}/tests/python -vvs"
 test-groups = ["test"]


### PR DESCRIPTION
Fixes the `mainline-only` CI, failing on every push to `main` since #593. Two one-line changes in `pyproject.toml`:

**1. Wheel tag** — #593 moved `core` off abi3 to the per-version C API (`WITH_SOABI`) but left `wheel.py-api = "cp312"`, so wheels were still tagged `cp312-abi3`. `abi3audit --strict` rejected them (27 non-limited-API symbols). Dropped the stale setting so wheels tag per-version.

**2. cp313 aarch64 test** — with the audit fixed, the test phase ran and hit a second issue: torch ships no cp313 aarch64 wheel for `manylinux2014` (`manylinux_2_17`), so its test install is unsatisfiable. Added `cp313-*aarch64` to `test-skip` (cp313 x86_64 and cp313 aarch64 on `manylinux_2_28` still tested).

Verified green across the full `mainline-only` wheel matrix (all 6 build jobs + clang-tidy) via a temporary PR trigger, now removed.
