### PR TITLE
ci: drop manylinux2014 wheel builds

### DIFF
--- a/.github/workflows/ci_mainline_only.yml
+++ b/.github/workflows/ci_mainline_only.yml
@@ -69,9 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {os: ubuntu-latest, arch: x86_64, linux_image: manylinux2014, build_sdist: "true"}
-          - {os: ubuntu-latest, arch: x86_64, linux_image: manylinux_2_28, build_sdist: "false"}
-          - {os: ubuntu-24.04-arm, arch: aarch64, linux_image: manylinux2014, build_sdist: "false"}
+          - {os: ubuntu-latest, arch: x86_64, linux_image: manylinux_2_28, build_sdist: "true"}
           - {os: ubuntu-24.04-arm, arch: aarch64, linux_image: manylinux_2_28, build_sdist: "false"}
           - {os: windows-latest, arch: AMD64, linux_image: "", build_sdist: "false"}
           - {os: macos-14, arch: arm64, linux_image: "", build_sdist: "false"}

--- a/.github/workflows/publish_wheel.yml
+++ b/.github/workflows/publish_wheel.yml
@@ -31,9 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {os: ubuntu-latest, arch: x86_64, linux_image: manylinux2014, build_sdist: "true"}
-          - {os: ubuntu-latest, arch: x86_64, linux_image: manylinux_2_28, build_sdist: "false"}
-          - {os: ubuntu-24.04-arm, arch: aarch64, linux_image: manylinux2014, build_sdist: "false"}
+          - {os: ubuntu-latest, arch: x86_64, linux_image: manylinux_2_28, build_sdist: "true"}
           - {os: ubuntu-24.04-arm, arch: aarch64, linux_image: manylinux_2_28, build_sdist: "false"}
           - {os: windows-latest, arch: AMD64, linux_image: "", build_sdist: "false"}
           - {os: macos-14, arch: arm64, linux_image: "", build_sdist: "false"}

--- a/docs/packaging/cpp_tooling.rst
+++ b/docs/packaging/cpp_tooling.rst
@@ -206,7 +206,7 @@ approach: **build on old glibc, run on new**.
 
 .. code-block:: bash
 
-   docker pull quay.io/pypa/manylinux2014_x86_64
+   docker pull quay.io/pypa/manylinux_2_28_x86_64
 
 Build host and device code inside the container. For CUDA:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,9 +252,8 @@ build-verbosity = 1
 # Per-Python-version wheels (no abi3 / limited API).
 build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314t-*"]
 skip = ["*musllinux*"]
-# cp39-cp311 are covered by the cp312 test run. cp313 aarch64 is skipped because torch
-# ships no cp313 aarch64 wheel for the manylinux2014 image, so its test-phase install fails.
-test-skip = ["cp39-*", "cp310-*", "cp311-*", "cp313-*aarch64"]
+# cp39-cp311 are covered by the cp312 test run.
+test-skip = ["cp39-*", "cp310-*", "cp311-*"]
 build-frontend = "build[uv]"
 test-command = "pytest {package}/tests/python -vvs"
 test-groups = ["test"]


### PR DESCRIPTION
numpy 2.5.1 ships no glibc-2.17 wheel, so the 2014 test phase compiled it from sdist and failed on GCC 10.2.1.

Standardize Linux wheels on manylinux_2_28 (drops the 2014 matrix rows in publish/mainline workflows; moves sdist onto the surviving x86_64 row; removes the now-obsolete cp313-aarch64 test-skip).