### PR TITLE
[FIX] Build dlpack exchange test in a per-test tmp dir to avoid JIT lock hang

### DIFF
--- a/tests/python/test_dlpack_exchange_api.py
+++ b/tests/python/test_dlpack_exchange_api.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import ctypes
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -41,7 +42,7 @@ _has_gpu = torch is not None and torch.cuda.is_available()
 
 
 @pytest.mark.skipif(not _has_dlpack_api, reason="PyTorch DLPack Exchange API not available")
-def test_dlpack_exchange_api() -> None:
+def test_dlpack_exchange_api(tmp_path: Path) -> None:
     # xfail the test on windows platform, it seems to be a bug in torch extension building on windows
     if sys.platform.startswith("win"):
         pytest.xfail("DLPack Exchange API test is known to fail on Windows platform")
@@ -210,6 +211,7 @@ def test_dlpack_exchange_api() -> None:
         cpp_sources=[source],
         functions=["test_dlpack_api"],
         extra_include_paths=include_paths,
+        build_directory=str(tmp_path),
     )
 
     # Run the comprehensive test


### PR DESCRIPTION
Fixes https://github.com/apache/tvm-ffi/issues/641

### root cause
The test JIT-compiles a C++ snippet with torch's `cpp_extension.load_inline`, which by default builds into the shared `~/.cache/torch_extensions` cache, serialized by torch's `FileBaton`:
- `try_acquire()` creates an ordinary lock **file** (`os.open` `O_CREAT|O_EXCL`).
- `wait()` spins on `os.path.exists(lock)` with **no timeout** and no staleness check.
- `release()` (which deletes the file) only runs on the normal path.

If a build is killed mid-compile — e.g. a CI time limit sends SIGTERM — the lock file is left behind. On CI where that cache sits on a persistent shared filesystem, every subsequent run then waits on the orphaned lock **forever**.

### Fix
Pass `build_directory=tmp_path` to `load_inline` so each run builds in a fresh, unique directory. The baton lock is always fresh, so a killed prior run can no longer poison later runs, and the test no longer uses (or can be poisoned by) any shared cache — independent of the filesystem.