### PR TITLE
[CORE] Mark type-info lookup as pure

### DIFF
--- a/include/tvm/ffi/c_api.h
+++ b/include/tvm/ffi/c_api.h
@@ -56,6 +56,14 @@
 #define TVM_FFI_DLL_EXPORT __attribute__((visibility("default")))
 #endif
 
+// Marks a function that has no observable effects and whose return value depends
+// only on its arguments and non-volatile memory.
+#if defined(__GNUC__) || defined(__clang__)
+#define TVM_FFI_ATTRIBUTE_PURE __attribute__((__pure__))
+#else
+#define TVM_FFI_ATTRIBUTE_PURE
+#endif
+
 // NOLINTBEGIN(modernize-macro-to-enum)
 /*! \brief TVM FFI major version. */
 #define TVM_FFI_VERSION_MAJOR 0
@@ -1484,9 +1492,10 @@ TVM_FFI_DLL int32_t TVMFFITypeGetOrAllocIndex(const TVMFFIByteArray* type_key,
 
 /*!
  * \brief Get dynamic type info by type index.
+ * \pre type_index identifies a registered type.
  * \return The type info.
  */
-TVM_FFI_DLL const TVMFFITypeInfo* TVMFFIGetTypeInfo(int32_t type_index);
+TVM_FFI_DLL TVM_FFI_ATTRIBUTE_PURE const TVMFFITypeInfo* TVMFFIGetTypeInfo(int32_t type_index);
 
 // ----------------------------------------------------------------------------
 // Static handle initialization and deinitialization API


### PR DESCRIPTION
## Rationale

`TVMFFIGetTypeInfo` returns the stable entry for a registered type index without modifying observable state. Exposing this contract lets supporting compilers coalesce repeated lookups.

## Change

- Add a portable `TVM_FFI_ATTRIBUTE_PURE` macro for GCC and Clang, with a safe no-op fallback.
- State the registered-index precondition and annotate `TVMFFIGetTypeInfo`.

## Validation

The C and C++ header checks, C++ test suite, formatting, and a focused optimized compiler benchmark pass.