### PR TITLE
fix: create wheel for GIL build of Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,7 +250,7 @@ docstring-code-line-length = 80
 build-verbosity = 1
 
 # Per-Python-version wheels (no abi3 / limited API).
-build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314t-*"]
+build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*", "cp314t-*"]
 skip = ["*musllinux*"]
 # cp39-cp311 are covered by the cp312 test run.
 test-skip = ["cp39-*", "cp310-*", "cp311-*"]


### PR DESCRIPTION
Hi, please could we get the non-free-threading Python 3.14 built for this library as well?