### PR TITLE
[FEAT][RUST] Complete structural walk/map/visit/mutate dispatch APIs

### DIFF
--- a/docs/guides/rust_lang_guide.md
+++ b/docs/guides/rust_lang_guide.md
@@ -207,7 +207,7 @@ fn may_fail(value: i32) -> Result<()> {
 ### Structural Walk and Visit
 
 Rust provides equivalents of the C++ `StructuralWalk`/`StructuralVisitor`
-APIs. Put `#[dispatch(visit)]` on an impl to turn its `visit_*` methods into
+APIs. Put `#[dispatch(walk)]` on an impl to turn its `walk_*` methods into
 typed handlers, then pass it to `structural_walk`; each handler returns a
 `WalkResult` (`Advance`, `Skip`, or `Interrupt`) to steer the traversal.
 Handlers dispatch on their argument type and may take an optional trailing
@@ -222,14 +222,14 @@ struct Probe {
     floats: usize,
 }
 
-#[dispatch(visit)]
+#[dispatch(walk)]
 impl Probe {
-    fn visit_integer(&mut self, value: i64) -> WalkResult {
+    fn walk_integer(&mut self, value: i64) -> WalkResult {
         self.total += value;
         WalkResult::Advance
     }
 
-    fn visit_float(&mut self, _value: f64, _kind: DefRegionKind) -> WalkResult {
+    fn walk_float(&mut self, _value: f64, _kind: DefRegionKind) -> WalkResult {
         self.floats += 1;
         WalkResult::Advance
     }
@@ -341,15 +341,18 @@ can recursively re-enter the same callback. Use `Cell`/`RefCell` for captured
 state. Since an interrupt is `Ok(Some(interrupt))`, return it explicitly from
 the outer callback; `?` propagates `Err`, not `Some`.
 
-For a named stateful implementation, implement `StructuralVisitor` and pass
-`&mut` it to the same entry point. `visit` runs for each value and descends
-through `default_visit_children`, or through `visit_child`, which visits one
-selected child and can override the def-region state for it (e.g.
-`DefRegionKind::Recursive` when descending into a binder's parameters):
+For a named stateful implementation, put `#[dispatch(visit)]` on its
+`visit_*` methods and pass `&mut` it to the same entry point. Unlike walk,
+each matching handler owns recursion: it descends through
+`default_visit_children`, or through `visit_child`, which visits one selected
+child and can override the def-region state for it (e.g.
+`DefRegionKind::Recursive` when descending into a binder's parameters).
+Unmatched values use default child traversal:
 
 ```rust
 use tvm_ffi::{
-    structural_visit, Array, DefRegionKind, Result, StructuralVisitor, VisitInterrupt, VisitValue,
+    dispatch, structural_visit, Array, DefRegionKind, Result, StructuralVisitor, VisitInterrupt,
+    VisitValue,
 };
 
 #[derive(Default)]
@@ -358,8 +361,9 @@ struct Depth {
     current: usize,
 }
 
-impl StructuralVisitor for Depth {
-    fn visit(
+#[dispatch(visit)]
+impl Depth {
+    fn visit_any(
         &mut self,
         value: &VisitValue,
         def_region_kind: DefRegionKind,
@@ -377,6 +381,11 @@ let mut depth = Depth::default();
 structural_visit(&values, &mut depth)?;
 assert_eq!(depth.max, 2);
 ```
+
+Implement `StructuralVisitor` directly when overriding the low-level `visit`
+method is more convenient. Both forms use the same `&mut self` reborrow chain,
+so ordinary mutable fields remain available during recursive `visit_child`
+calls.
 
 Two safety notes: mutable `List`/`Dict` contents are snapshotted before
 callbacks run, so mutation during traversal cannot invalidate the walk; and
@@ -488,6 +497,37 @@ current value, but deliberately uses the copy path because the callback still
 holds a shared borrow of that value. Mutation callbacks are `Fn` for the same
 recursive-reentry reason as visit callbacks.
 
+For ordinary mutable state, `#[dispatch(mutate)]` generates a
+`StructuralMutator` from `mutate_*` methods. A matching handler returns the
+current value's final result and may recursively call `self.mutate_child()`;
+an unmatched value follows default mutation with its current in-place permit:
+
+```rust
+use tvm_ffi::{dispatch, structural_mutate, Any, Array, DefRegionKind};
+
+#[derive(Default)]
+struct Increment {
+    integers: usize,
+}
+
+#[dispatch(mutate)]
+impl Increment {
+    fn mutate_integer(&mut self, value: i64, _kind: DefRegionKind) -> Any {
+        self.integers += 1;
+        Any::from(value + 1)
+    }
+}
+
+let mut increment = Increment::default();
+let mapped = structural_mutate(
+    Array::new(vec![1_i64, 2]),
+    &mut increment,
+)?;
+let mapped = Array::<i64>::try_from(mapped)?;
+assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![2, 3]);
+assert_eq!(increment.integers, 2);
+```
+
 For a named custom recursion policy, implement `StructuralMutator` and pass
 `&mut` it to `structural_mutate`. `InplaceValue` is an engine-issued
 capability: callers cannot construct it from a read-only `MapValue`. Override
@@ -499,13 +539,11 @@ children can be re-entered with `mutate_child`, while owned children can use
 ```rust
 use tvm_ffi::{
     structural_mutate, Any, Array, DefRegionKind, InplaceValue, MapValue, Result,
-    StructuralMutator, StructuralVarRemap,
+    StructuralMutator,
 };
 
 #[derive(Default)]
-struct Increment {
-    remap: StructuralVarRemap,
-}
+struct Increment;
 
 impl StructuralMutator for Increment {
     fn mutate(&mut self, value: &MapValue, kind: DefRegionKind) -> Result<Any> {
@@ -522,14 +560,6 @@ impl StructuralMutator for Increment {
     ) -> Result<Any> {
         self.default_maybe_inplace_mutate(value, kind)
     }
-
-    fn var_remap_get(&mut self, var: &MapValue) -> Result<Option<Any>> {
-        self.remap.get(var)
-    }
-
-    fn var_remap_set(&mut self, var: &MapValue, mapped: &Any) -> Result<()> {
-        self.remap.set(var, mapped)
-    }
 }
 
 let mapped = structural_mutate(
@@ -540,11 +570,10 @@ let mapped = Array::<i64>::try_from(mapped)?;
 assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![2, 3]);
 ```
 
-`StructuralMutator` requires `var_remap_get` and `var_remap_set` so its default
-recursion can preserve completed `FreeVar` and `DAGNode` substitutions.
-`StructuralVarRemap` is the canonical owning implementation, as shown above; a
-custom mutator is responsible for any additional identity policy it
-introduces.
+The default `var_remap_get` and `var_remap_set` methods use state local to one
+`structural_mutate` invocation, preserving completed `FreeVar` and `DAGNode`
+substitutions without adding a field to the mutator. Override them and use
+`StructuralVarRemap` when a custom identity policy is required.
 
 ## Examples
 

--- a/docs/guides/rust_lang_guide.md
+++ b/docs/guides/rust_lang_guide.md
@@ -314,16 +314,9 @@ let found = structural_walk(
 assert_eq!(found.map(|i| i64::try_from(i.value).unwrap()), Some(2));
 ```
 
-To drive recursion yourself without defining a visitor type, pass a typed
-callback or callback tuple to `structural_visit`. Each callback receives a
-mutable `VisitContext`. Tuple links are tried in order; a matched callback owns
-traversal of that value, while an unmatched value uses default child traversal.
-A catch-all callback must therefore call `visit_children()` explicitly.
-
-`VisitCallbacks` stores ordinary mutable state shared by the complete callback
-chain. Recursive operations borrow the complete context mutably, so Rust
-rejects a state borrow that remains live across `visit`, `visit_with`, or
-`visit_children`:
+`structural_visit` accepts typed callbacks in addition to a `StructuralVisitor`.
+Callbacks receive `VisitContext`, use first-match dispatch, and own traversal
+of matched values. `VisitCallbacks` adds state shared by the callback chain:
 
 ```rust
 use tvm_ffi::{structural_visit, Array, VisitCallbacks, VisitContext, VisitValue};
@@ -349,19 +342,13 @@ structural_visit(&values, &mut visitor)?;
 assert_eq!(visitor.state().total, 3);
 ```
 
-Callbacks are `Fn`, not `FnMut`: mutable data belongs in the context state,
-while callback code may recursively re-enter itself. A direct callback without
-state uses `&mut VisitContext<'_, ()>`. Since an interrupt is
-`Ok(Some(interrupt))`, return it explicitly from the outer callback; `?`
-propagates `Err`, not `Some`.
+Callbacks are `Fn`; mutable data belongs in the visitor state. A catch-all
+callback must call `visit_children()` explicitly, and interrupt values must be
+returned explicitly because `?` only propagates errors.
 
-For a named stateful implementation, put `#[dispatch(visit)]` on its
-`visit_*` methods and pass `&mut` it to the same entry point. Unlike walk,
-each matching handler owns recursion: it descends through
-`default_visit_children`, or through `visit_child`, which visits one selected
-child and can override the def-region state for it (e.g.
-`DefRegionKind::Recursive` when descending into a binder's parameters).
-Unmatched values use default child traversal:
+For a named implementation, `#[dispatch(visit)]` generates
+`StructuralVisitor` from `visit_*` methods. Matching handlers own recursion;
+unmatched values use default child traversal:
 
 ```rust
 use tvm_ffi::{
@@ -396,10 +383,8 @@ structural_visit(&values, &mut depth)?;
 assert_eq!(depth.max, 2);
 ```
 
-Implement `StructuralVisitor` directly when overriding the low-level `visit`
-method is more convenient. Both forms use the same `&mut self` reborrow chain,
-so ordinary mutable fields remain available during recursive `visit_child`
-calls.
+Implement `StructuralVisitor` directly to override its low-level `visit`
+method.
 
 Two safety notes: mutable `List`/`Dict` contents are snapshotted before
 callbacks run, so mutation during traversal cannot invalidate the walk; and
@@ -488,15 +473,9 @@ Callbacks may return `Result<Any>` to report failures. Errors propagate with
 object or reflected-field context. In-place changes completed before a later
 error are not rolled back, and the consumed root is not returned on error.
 
-`structural_mutate` likewise accepts a typed callback or ordered callback
-tuple. Each callback receives a mutable `MutateContext`. The first match
-supplies the current value's final result; an unmatched value follows default
-mutation with its current in-place permit.
-
-`MutateCallbacks` stores ordinary mutable state shared by the complete callback
-chain. As with `VisitCallbacks`, recursive operations borrow the complete
-context mutably, so a state borrow cannot remain live across `mutate`,
-`maybe_inplace_mutate`, or `default_mutate`:
+`structural_mutate` accepts typed callbacks in addition to a
+`StructuralMutator`. Callbacks receive `MutateContext`; `MutateCallbacks` adds
+state shared by the callback chain:
 
 ```rust
 use tvm_ffi::{
@@ -511,29 +490,24 @@ struct Stats {
 let mut mutator = MutateCallbacks::new(
     Stats::default(),
     (
-        |value: i64, context: &mut MutateContext<'_, Stats>| {
-            context.state_mut().integers += 1;
+        |value: i64, mutator: &mut MutateContext<'_, Stats>| {
+            mutator.state_mut().integers += 1;
             Any::from(value + 1)
         },
-        |_value: &MapValue, context: &mut MutateContext<'_, Stats>| {
-            context.default_mutate()
+        |_value: &MapValue, mutator: &mut MutateContext<'_, Stats>| {
+            mutator.default_mutate()
         },
     ),
 );
-let mapped = structural_mutate(Array::new(vec![1_i64, 2]), &mut mutator)?;
-let mapped = Array::<i64>::try_from(mapped)?;
-assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![2, 3]);
+let mutated = structural_mutate(Array::new(vec![1_i64, 2]), &mut mutator)?;
+let mutated = Array::<i64>::try_from(mutated)?;
+assert_eq!(mutated.iter().collect::<Vec<_>>(), vec![2, 3]);
 assert_eq!(mutator.state().integers, 2);
 ```
 
-`MutateContext::mutate` re-enters with a borrowed child on the copy path;
-`maybe_inplace_mutate` consumes an owned child and preserves its in-place
-opportunity. `default_mutate()` applies default mutation to the callback's
-current value, but deliberately uses the copy path because the callback still
-holds a shared borrow of that value. Mutation callbacks are `Fn`, not `FnMut`:
-mutable data belongs in the context state, while callback code may recursively
-re-enter itself. A direct callback without state uses
-`&mut MutateContext<'_, ()>` and is wrapped in a temporary `MutateCallbacks`.
+`MutateContext::mutate` uses the copy path for a borrowed child, while
+`maybe_inplace_mutate` preserves the reuse opportunity of an owned child.
+Callbacks are `Fn`; mutable data belongs in the mutator state.
 
 For ordinary mutable state, `#[dispatch(mutate)]` generates a
 `StructuralMutator` from `mutate_*` methods. A matching handler returns the
@@ -557,12 +531,12 @@ impl Increment {
 }
 
 let mut increment = Increment::default();
-let mapped = structural_mutate(
+let mutated = structural_mutate(
     Array::new(vec![1_i64, 2]),
     &mut increment,
 )?;
-let mapped = Array::<i64>::try_from(mapped)?;
-assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![2, 3]);
+let mutated = Array::<i64>::try_from(mutated)?;
+assert_eq!(mutated.iter().collect::<Vec<_>>(), vec![2, 3]);
 assert_eq!(increment.integers, 2);
 ```
 
@@ -600,12 +574,12 @@ impl StructuralMutator for Increment {
     }
 }
 
-let mapped = structural_mutate(
+let mutated = structural_mutate(
     Array::new(vec![1_i64, 2]),
     &mut Increment::default(),
 )?;
-let mapped = Array::<i64>::try_from(mapped)?;
-assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![2, 3]);
+let mutated = Array::<i64>::try_from(mutated)?;
+assert_eq!(mutated.iter().collect::<Vec<_>>(), vec![2, 3]);
 ```
 
 The default `var_remap_get` and `var_remap_set` methods use state local to one

--- a/docs/guides/rust_lang_guide.md
+++ b/docs/guides/rust_lang_guide.md
@@ -245,9 +245,11 @@ For `Map` and `Dict`, structural walk treats keys as structural anchors: it
 visits container values but does not pass keys to handlers. The map or dict
 object itself is still visited normally.
 
-Lambdas also work — pass a single typed lambda, or a tuple of them (up to 8)
-tried in order with the first matching argument type winning, like the
-variadic C++ `StructuralWalk(root, callbacks...)` chain. Unmatched values
+Lambdas also work — pass a single typed lambda, or a tuple of them tried in
+order with the first matching argument type winning, like the variadic C++
+`StructuralWalk(root, callbacks...)` chain. A flat tuple holds up to 12
+lambdas; a tuple is itself a link, so nest `(a, b, (c, d, ...))` to chain
+more — order stays the flattened left-to-right order. Unmatched values
 simply advance; a `&VisitValue` lambda acts as a catch-all and must come
 last, since links after an always-matching one never run. Each lambda may
 take a trailing `DefRegionKind` argument:
@@ -397,8 +399,9 @@ let mapped = Array::<i64>::try_from(mapped)?;
 assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![2, 3]);
 ```
 
-A single typed closure and an ordered tuple of up to eight closures are also
-accepted. Tuple dispatch is first-match, not broadcast: later closures do not
+A single typed closure and an ordered tuple of up to twelve closures are also
+accepted; a tuple is itself a link, so `(a, b, (c, d, ...))` nests beyond that
+without changing the flattened order. Tuple dispatch is first-match, not broadcast: later closures do not
 run after an earlier argument type matches. As with generated dispatch, a
 `&MapValue` catch-all belongs last. Numeric handlers claim the complete FFI
 `Int` or `Float` tag and then use Rust `as` conversion semantics; prefer `i64`

--- a/docs/guides/rust_lang_guide.md
+++ b/docs/guides/rust_lang_guide.md
@@ -314,9 +314,36 @@ let found = structural_walk(
 assert_eq!(found.map(|i| i64::try_from(i.value).unwrap()), Some(2));
 ```
 
-To drive recursion yourself, implement `StructuralVisitor` and call
-`structural_visit`; `visit` runs for each value and descends through
-`default_visit_children`, or through `visit_child`, which visits one
+To drive recursion yourself without defining a visitor type, pass a typed
+callback or callback tuple to `structural_visit`. Each callback receives a
+`VisitorRef`. Tuple links are tried in order; a matched callback owns traversal
+of that value, while an unmatched value uses default child traversal. A
+catch-all callback must therefore call `visit_children()` explicitly:
+
+```rust
+use std::cell::Cell;
+use tvm_ffi::{structural_visit, Array, VisitValue, VisitorRef};
+
+let values = Array::new(vec![1_i64, 2]);
+let total = Cell::new(0_i64);
+structural_visit(
+    &values,
+    (
+        |value: i64, _visitor: &VisitorRef<'_>| total.set(total.get() + value),
+        |_value: &VisitValue, visitor: &VisitorRef<'_>| visitor.visit_children(),
+    ),
+)?;
+assert_eq!(total.get(), 3);
+```
+
+Callbacks are `Fn`, not `FnMut`: `visit`, `visit_with`, and `visit_children`
+can recursively re-enter the same callback. Use `Cell`/`RefCell` for captured
+state. Since an interrupt is `Ok(Some(interrupt))`, return it explicitly from
+the outer callback; `?` propagates `Err`, not `Some`.
+
+For a named stateful implementation, implement `StructuralVisitor` and pass
+`&mut` it to the same entry point. `visit` runs for each value and descends
+through `default_visit_children`, or through `visit_child`, which visits one
 selected child and can override the def-region state for it (e.g.
 `DefRegionKind::Recursive` when descending into a binder's parameters):
 
@@ -438,9 +465,32 @@ Callbacks may return `Result<Any>` to report failures. Errors propagate with
 object or reflected-field context. In-place changes completed before a later
 error are not rolled back, and the consumed root is not returned on error.
 
-For custom recursion policy, implement `StructuralMutator` and call
-`structural_mutate`. `InplaceValue` is an engine-issued capability: callers
-cannot construct it from a read-only `MapValue`. Override
+`structural_mutate` likewise accepts a typed `Fn(value, &MutatorRef)` callback
+or an ordered callback tuple. The first match supplies the current value's
+final result; an unmatched value follows default mutation. This makes a typed
+leaf rewrite compact while preserving the root container's in-place permit:
+
+```rust
+use tvm_ffi::{structural_mutate, Any, Array, MutatorRef};
+
+let mapped = structural_mutate(
+    Array::new(vec![1_i64, 2]),
+    |value: i64, _mutator: &MutatorRef<'_>| Any::from(value + 1),
+)?;
+let mapped = Array::<i64>::try_from(mapped)?;
+assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![2, 3]);
+```
+
+`MutatorRef::mutate` re-enters with a borrowed child on the copy path;
+`maybe_inplace_mutate` consumes an owned child and preserves its in-place
+opportunity. `default_mutate()` applies default mutation to the callback's
+current value, but deliberately uses the copy path because the callback still
+holds a shared borrow of that value. Mutation callbacks are `Fn` for the same
+recursive-reentry reason as visit callbacks.
+
+For a named custom recursion policy, implement `StructuralMutator` and pass
+`&mut` it to `structural_mutate`. `InplaceValue` is an engine-issued
+capability: callers cannot construct it from a read-only `MapValue`. Override
 `maybe_inplace_mutate` to opt into default container reuse;
 `default_maybe_inplace_mutate` rechecks uniqueness before writing. Borrowed
 children can be re-entered with `mutate_child`, while owned children can use

--- a/docs/guides/rust_lang_guide.md
+++ b/docs/guides/rust_lang_guide.md
@@ -316,30 +316,44 @@ assert_eq!(found.map(|i| i64::try_from(i.value).unwrap()), Some(2));
 
 To drive recursion yourself without defining a visitor type, pass a typed
 callback or callback tuple to `structural_visit`. Each callback receives a
-`VisitorRef`. Tuple links are tried in order; a matched callback owns traversal
-of that value, while an unmatched value uses default child traversal. A
-catch-all callback must therefore call `visit_children()` explicitly:
+mutable `VisitContext`. Tuple links are tried in order; a matched callback owns
+traversal of that value, while an unmatched value uses default child traversal.
+A catch-all callback must therefore call `visit_children()` explicitly.
+
+`VisitCallbacks` stores ordinary mutable state shared by the complete callback
+chain. Recursive operations borrow the complete context mutably, so Rust
+rejects a state borrow that remains live across `visit`, `visit_with`, or
+`visit_children`:
 
 ```rust
-use std::cell::Cell;
-use tvm_ffi::{structural_visit, Array, VisitValue, VisitorRef};
+use tvm_ffi::{structural_visit, Array, VisitCallbacks, VisitContext, VisitValue};
+
+#[derive(Default)]
+struct Stats {
+    total: i64,
+}
 
 let values = Array::new(vec![1_i64, 2]);
-let total = Cell::new(0_i64);
-structural_visit(
-    &values,
+let mut visitor = VisitCallbacks::new(
+    Stats::default(),
     (
-        |value: i64, _visitor: &VisitorRef<'_>| total.set(total.get() + value),
-        |_value: &VisitValue, visitor: &VisitorRef<'_>| visitor.visit_children(),
+        |value: i64, visitor: &mut VisitContext<'_, Stats>| {
+            visitor.state_mut().total += value;
+        },
+        |_value: &VisitValue, visitor: &mut VisitContext<'_, Stats>| {
+            visitor.visit_children()
+        },
     ),
-)?;
-assert_eq!(total.get(), 3);
+);
+structural_visit(&values, &mut visitor)?;
+assert_eq!(visitor.state().total, 3);
 ```
 
-Callbacks are `Fn`, not `FnMut`: `visit`, `visit_with`, and `visit_children`
-can recursively re-enter the same callback. Use `Cell`/`RefCell` for captured
-state. Since an interrupt is `Ok(Some(interrupt))`, return it explicitly from
-the outer callback; `?` propagates `Err`, not `Some`.
+Callbacks are `Fn`, not `FnMut`: mutable data belongs in the context state,
+while callback code may recursively re-enter itself. A direct callback without
+state uses `&mut VisitContext<'_, ()>`. Since an interrupt is
+`Ok(Some(interrupt))`, return it explicitly from the outer callback; `?`
+propagates `Err`, not `Some`.
 
 For a named stateful implementation, put `#[dispatch(visit)]` on its
 `visit_*` methods and pass `&mut` it to the same entry point. Unlike walk,
@@ -474,28 +488,52 @@ Callbacks may return `Result<Any>` to report failures. Errors propagate with
 object or reflected-field context. In-place changes completed before a later
 error are not rolled back, and the consumed root is not returned on error.
 
-`structural_mutate` likewise accepts a typed `Fn(value, &MutatorRef)` callback
-or an ordered callback tuple. The first match supplies the current value's
-final result; an unmatched value follows default mutation. This makes a typed
-leaf rewrite compact while preserving the root container's in-place permit:
+`structural_mutate` likewise accepts a typed callback or ordered callback
+tuple. Each callback receives a mutable `MutateContext`. The first match
+supplies the current value's final result; an unmatched value follows default
+mutation with its current in-place permit.
+
+`MutateCallbacks` stores ordinary mutable state shared by the complete callback
+chain. As with `VisitCallbacks`, recursive operations borrow the complete
+context mutably, so a state borrow cannot remain live across `mutate`,
+`maybe_inplace_mutate`, or `default_mutate`:
 
 ```rust
-use tvm_ffi::{structural_mutate, Any, Array, MutatorRef};
+use tvm_ffi::{
+    structural_mutate, Any, Array, MapValue, MutateCallbacks, MutateContext,
+};
 
-let mapped = structural_mutate(
-    Array::new(vec![1_i64, 2]),
-    |value: i64, _mutator: &MutatorRef<'_>| Any::from(value + 1),
-)?;
+#[derive(Default)]
+struct Stats {
+    integers: usize,
+}
+
+let mut mutator = MutateCallbacks::new(
+    Stats::default(),
+    (
+        |value: i64, context: &mut MutateContext<'_, Stats>| {
+            context.state_mut().integers += 1;
+            Any::from(value + 1)
+        },
+        |_value: &MapValue, context: &mut MutateContext<'_, Stats>| {
+            context.default_mutate()
+        },
+    ),
+);
+let mapped = structural_mutate(Array::new(vec![1_i64, 2]), &mut mutator)?;
 let mapped = Array::<i64>::try_from(mapped)?;
 assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![2, 3]);
+assert_eq!(mutator.state().integers, 2);
 ```
 
-`MutatorRef::mutate` re-enters with a borrowed child on the copy path;
+`MutateContext::mutate` re-enters with a borrowed child on the copy path;
 `maybe_inplace_mutate` consumes an owned child and preserves its in-place
 opportunity. `default_mutate()` applies default mutation to the callback's
 current value, but deliberately uses the copy path because the callback still
-holds a shared borrow of that value. Mutation callbacks are `Fn` for the same
-recursive-reentry reason as visit callbacks.
+holds a shared borrow of that value. Mutation callbacks are `Fn`, not `FnMut`:
+mutable data belongs in the context state, while callback code may recursively
+re-enter itself. A direct callback without state uses
+`&mut MutateContext<'_, ()>` and is wrapped in a temporary `MutateCallbacks`.
 
 For ordinary mutable state, `#[dispatch(mutate)]` generates a
 `StructuralMutator` from `mutate_*` methods. A matching handler returns the

--- a/rust/tvm-ffi-macros/src/dispatch.rs
+++ b/rust/tvm-ffi-macros/src/dispatch.rs
@@ -205,6 +205,7 @@ fn expand(item_impl: &ItemImpl, mode: DispatchMode) -> syn::Result<TokenStream2>
             impl #impl_generics #tvm_ffi::extra::structural_visit::StructuralVisitor
                 for #self_type #where_clause
             {
+                #[inline]
                 #[allow(unreachable_code, unused_variables)]
                 fn visit(
                     &mut self,
@@ -241,6 +242,7 @@ fn expand(item_impl: &ItemImpl, mode: DispatchMode) -> syn::Result<TokenStream2>
                 impl #impl_generics #tvm_ffi::extra::structural_mutate::StructuralMutator
                     for #self_type #where_clause
                 {
+                    #[inline]
                     #[allow(unreachable_code, unused_variables)]
                     fn mutate(
                         &mut self,
@@ -252,6 +254,7 @@ fn expand(item_impl: &ItemImpl, mode: DispatchMode) -> syn::Result<TokenStream2>
                             default_mutate(self, value, def_region_kind)
                     }
 
+                    #[inline]
                     #[allow(unreachable_code, unused_variables)]
                     fn maybe_inplace_mutate(
                         &mut self,

--- a/rust/tvm-ffi-macros/src/dispatch.rs
+++ b/rust/tvm-ffi-macros/src/dispatch.rs
@@ -147,16 +147,16 @@ fn expand(item_impl: &ItemImpl, mode: DispatchMode) -> syn::Result<TokenStream2>
     let tvm_ffi = get_tvm_ffi_crate();
     let into_result = match mode {
         DispatchMode::Walk => quote! {
-            #tvm_ffi::extra::structural_visit::IntoVisitResult::into_visit_result
+            #tvm_ffi::extra::structural_visit::IntoWalkResult::into_walk_result
         },
         DispatchMode::Visit => quote! {
-            #tvm_ffi::extra::structural_visit::IntoVisitOutcome::into_visit_outcome
+            #tvm_ffi::extra::structural_visit::IntoVisitResult::into_visit_result
         },
         DispatchMode::Map => quote! {
             #tvm_ffi::extra::structural_mutate::IntoMapResult::into_map_result
         },
         DispatchMode::Mutate => quote! {
-            #tvm_ffi::extra::structural_mutate::IntoMapResult::into_map_result
+            #tvm_ffi::extra::structural_mutate::IntoMutateResult::into_mutate_result
         },
     };
     let links = expand_links(&handlers, mode, &into_result, quote!(value));
@@ -195,7 +195,7 @@ fn expand(item_impl: &ItemImpl, mode: DispatchMode) -> syn::Result<TokenStream2>
                     &mut self,
                     value: &#tvm_ffi::extra::structural_visit::VisitValue,
                     def_region_kind: #tvm_ffi::extra::structural_visit::DefRegionKind,
-                ) -> Option<#tvm_ffi::extra::structural_visit::VisitResult> {
+                ) -> Option<#tvm_ffi::extra::structural_visit::WalkCallbackResult> {
                     #(#links)*
                     None
                 }
@@ -286,9 +286,6 @@ fn expand_links(
         .map(|handler| {
             let method = &handler.method;
             let attrs = &handler.cfg_attrs;
-            // A handler opts into the definition-region state by declaring a
-            // trailing argument; the generated dispatch forwards by arity,
-            // like the corresponding C++ structural callback overloads.
             let kind_arg = if handler.wants_def_region {
                 quote!(, def_region_kind)
             } else {
@@ -322,10 +319,10 @@ fn expand_links(
                 }
                 HandlerArgument::Owned(value_type) => {
                     let result = wrap_result(quote! {
-                        #into_result(self.#method(node #kind_arg))
+                        #into_result(self.#method(typed #kind_arg))
                     });
                     quote! {
-                        if let Some(node) = #value.cast::<#value_type>() {
+                        if let Some(typed) = #value.cast::<#value_type>() {
                             return #result;
                         }
                     }
@@ -344,7 +341,6 @@ fn expand_links(
 struct Handler {
     method: syn::Ident,
     argument: HandlerArgument,
-    /// The handler declared a trailing `DefRegionKind` argument.
     wants_def_region: bool,
     cfg_attrs: Vec<Meta>,
 }

--- a/rust/tvm-ffi-macros/src/dispatch.rs
+++ b/rust/tvm-ffi-macros/src/dispatch.rs
@@ -43,29 +43,42 @@ struct DispatchArgs {
 
 #[derive(Clone, Copy)]
 enum DispatchMode {
+    Walk,
     Visit,
     Map,
+    Mutate,
 }
 
 impl DispatchMode {
     fn name(self) -> &'static str {
         match self {
+            Self::Walk => "walk",
             Self::Visit => "visit",
             Self::Map => "map",
+            Self::Mutate => "mutate",
         }
     }
 
     fn handler_prefix(self) -> &'static str {
         match self {
+            Self::Walk => "walk_",
             Self::Visit => "visit_",
             Self::Map => "map_",
+            Self::Mutate => "mutate_",
         }
     }
 
     fn value_type(self) -> &'static str {
         match self {
-            Self::Visit => "VisitValue",
-            Self::Map => "MapValue",
+            Self::Walk | Self::Visit => "VisitValue",
+            Self::Map | Self::Mutate => "MapValue",
+        }
+    }
+
+    fn result_is_optional(self) -> bool {
+        match self {
+            Self::Walk | Self::Map => true,
+            Self::Visit | Self::Mutate => false,
         }
     }
 }
@@ -73,14 +86,19 @@ impl DispatchMode {
 impl syn::parse::Parse for DispatchArgs {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let mode: syn::Ident = input.parse()?;
-        let mode = if mode == "visit" {
+        let mode = if mode == "walk" {
+            DispatchMode::Walk
+        } else if mode == "visit" {
             DispatchMode::Visit
         } else if mode == "map" {
             DispatchMode::Map
+        } else if mode == "mutate" {
+            DispatchMode::Mutate
         } else {
             return Err(syn::Error::new(
                 mode.span(),
-                "expected `dispatch(visit)` or `dispatch(map)`",
+                "expected `dispatch(walk)`, `dispatch(map)`, `dispatch(visit)`, or \
+                 `dispatch(mutate)`",
             ));
         };
         if !input.is_empty() {
@@ -128,53 +146,20 @@ fn expand(item_impl: &ItemImpl, mode: DispatchMode) -> syn::Result<TokenStream2>
     }
     let tvm_ffi = get_tvm_ffi_crate();
     let into_result = match mode {
-        DispatchMode::Visit => quote! {
+        DispatchMode::Walk => quote! {
             #tvm_ffi::extra::structural_visit::IntoVisitResult::into_visit_result
+        },
+        DispatchMode::Visit => quote! {
+            #tvm_ffi::extra::structural_visit::IntoVisitOutcome::into_visit_outcome
         },
         DispatchMode::Map => quote! {
             #tvm_ffi::extra::structural_mutate::IntoMapResult::into_map_result
         },
+        DispatchMode::Mutate => quote! {
+            #tvm_ffi::extra::structural_mutate::IntoMapResult::into_map_result
+        },
     };
-
-    let links = handlers.iter().map(|handler| {
-        let method = &handler.method;
-        let attrs = &handler.cfg_attrs;
-        // A handler opts into the definition-region state by declaring a
-        // trailing argument; the generated dispatch forwards by arity, like
-        // the corresponding C++ structural callback overloads.
-        let kind_arg = if handler.wants_def_region {
-            quote!(, def_region_kind)
-        } else {
-            quote!()
-        };
-        let invoke = match &handler.argument {
-            HandlerArgument::Value => quote! {
-                return Some(
-                    #into_result(self.#method(value #kind_arg))
-                );
-            },
-            HandlerArgument::BorrowedNode(node_type) => quote! {
-                if let Some(node) = value.as_node::<#node_type>() {
-                    return Some(
-                        #into_result(self.#method(node #kind_arg))
-                    );
-                }
-            },
-            HandlerArgument::Owned(value_type) => quote! {
-                if let Some(node) = value.cast::<#value_type>() {
-                    return Some(
-                        #into_result(self.#method(node #kind_arg))
-                    );
-                }
-            },
-        };
-        quote! {
-            #(#[#attrs])*
-            {
-                #invoke
-            }
-        }
-    });
+    let links = expand_links(&handlers, mode, &into_result, quote!(value));
     let self_type = &item_impl.self_ty;
     let (impl_generics, _, where_clause) = item_impl.generics.split_for_impl();
     let impl_cfg_attrs = presence_attrs(&item_impl.attrs)?;
@@ -201,18 +186,36 @@ fn expand(item_impl: &ItemImpl, mode: DispatchMode) -> syn::Result<TokenStream2>
         });
 
     let dispatch_impl = match mode {
-        DispatchMode::Visit => quote! {
-            impl #impl_generics #tvm_ffi::extra::structural_visit::VisitDispatch
+        DispatchMode::Walk => quote! {
+            impl #impl_generics #tvm_ffi::extra::structural_visit::WalkDispatch
                 for #self_type #where_clause
             {
                 #[allow(unreachable_code, unused_variables)]
-                fn dispatch_visit(
+                fn dispatch_walk(
                     &mut self,
                     value: &#tvm_ffi::extra::structural_visit::VisitValue,
                     def_region_kind: #tvm_ffi::extra::structural_visit::DefRegionKind,
                 ) -> Option<#tvm_ffi::extra::structural_visit::VisitResult> {
                     #(#links)*
                     None
+                }
+            }
+        },
+        DispatchMode::Visit => quote! {
+            impl #impl_generics #tvm_ffi::extra::structural_visit::StructuralVisitor
+                for #self_type #where_clause
+            {
+                #[allow(unreachable_code, unused_variables)]
+                fn visit(
+                    &mut self,
+                    value: &#tvm_ffi::extra::structural_visit::VisitValue,
+                    def_region_kind: #tvm_ffi::extra::structural_visit::DefRegionKind,
+                ) -> #tvm_ffi::Result<
+                    Option<#tvm_ffi::extra::structural_visit::VisitInterrupt>
+                > {
+                    #(#links)*
+                    <Self as #tvm_ffi::extra::structural_visit::StructuralVisitor>::
+                        default_visit_children(self, value, def_region_kind)
                 }
             }
         },
@@ -231,6 +234,37 @@ fn expand(item_impl: &ItemImpl, mode: DispatchMode) -> syn::Result<TokenStream2>
                 }
             }
         },
+        DispatchMode::Mutate => {
+            let inplace_links =
+                expand_links(&handlers, mode, &into_result, quote!(value.as_value()));
+            quote! {
+                impl #impl_generics #tvm_ffi::extra::structural_mutate::StructuralMutator
+                    for #self_type #where_clause
+                {
+                    #[allow(unreachable_code, unused_variables)]
+                    fn mutate(
+                        &mut self,
+                        value: &#tvm_ffi::extra::structural_mutate::MapValue,
+                        def_region_kind: #tvm_ffi::extra::structural_visit::DefRegionKind,
+                    ) -> #tvm_ffi::Result<#tvm_ffi::Any> {
+                        #(#links)*
+                        <Self as #tvm_ffi::extra::structural_mutate::StructuralMutator>::
+                            default_mutate(self, value, def_region_kind)
+                    }
+
+                    #[allow(unreachable_code, unused_variables)]
+                    fn maybe_inplace_mutate(
+                        &mut self,
+                        value: #tvm_ffi::extra::structural_mutate::InplaceValue<'_>,
+                        def_region_kind: #tvm_ffi::extra::structural_visit::DefRegionKind,
+                    ) -> #tvm_ffi::Result<#tvm_ffi::Any> {
+                        #(#inplace_links)*
+                        <Self as #tvm_ffi::extra::structural_mutate::StructuralMutator>::
+                            default_maybe_inplace_mutate(self, value, def_region_kind)
+                    }
+                }
+            }
+        }
     };
 
     Ok(quote! {
@@ -239,6 +273,72 @@ fn expand(item_impl: &ItemImpl, mode: DispatchMode) -> syn::Result<TokenStream2>
         #(#[#impl_cfg_attrs])*
         #dispatch_impl
     })
+}
+
+fn expand_links(
+    handlers: &[Handler],
+    mode: DispatchMode,
+    into_result: &TokenStream2,
+    value: TokenStream2,
+) -> Vec<TokenStream2> {
+    handlers
+        .iter()
+        .map(|handler| {
+            let method = &handler.method;
+            let attrs = &handler.cfg_attrs;
+            // A handler opts into the definition-region state by declaring a
+            // trailing argument; the generated dispatch forwards by arity,
+            // like the corresponding C++ structural callback overloads.
+            let kind_arg = if handler.wants_def_region {
+                quote!(, def_region_kind)
+            } else {
+                quote!()
+            };
+            let wrap_result = |result: TokenStream2| {
+                if mode.result_is_optional() {
+                    quote!(Some(#result))
+                } else {
+                    result
+                }
+            };
+            let invoke = match &handler.argument {
+                HandlerArgument::Value => {
+                    let result = wrap_result(quote! {
+                        #into_result(self.#method(#value #kind_arg))
+                    });
+                    quote! {
+                        return #result;
+                    }
+                }
+                HandlerArgument::BorrowedNode(node_type) => {
+                    let result = wrap_result(quote! {
+                        #into_result(self.#method(node #kind_arg))
+                    });
+                    quote! {
+                        if let Some(node) = #value.as_node::<#node_type>() {
+                            return #result;
+                        }
+                    }
+                }
+                HandlerArgument::Owned(value_type) => {
+                    let result = wrap_result(quote! {
+                        #into_result(self.#method(node #kind_arg))
+                    });
+                    quote! {
+                        if let Some(node) = #value.cast::<#value_type>() {
+                            return #result;
+                        }
+                    }
+                }
+            };
+            quote! {
+                #(#[#attrs])*
+                {
+                    #invoke
+                }
+            }
+        })
+        .collect()
 }
 
 struct Handler {

--- a/rust/tvm-ffi-macros/src/lib.rs
+++ b/rust/tvm-ffi-macros/src/lib.rs
@@ -25,14 +25,7 @@ mod match_any;
 mod object_macros;
 mod utils;
 
-/// Generate typed structural dispatch from an inherent implementation.
-///
-/// The supported modes are `walk`, `map`, `visit`, and `mutate`:
-/// `dispatch(walk)` turns `walk_*` methods into engine-driven walk callbacks,
-/// `dispatch(map)` uses `map_*` replacement callbacks, and
-/// `dispatch(visit)`/`dispatch(mutate)` generate user-driven visitors or
-/// mutators whose `&mut self` handlers may recurse through the corresponding
-/// trait helpers.
+/// Generate `walk`, `map`, `visit`, or `mutate` dispatch from an inherent impl.
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn dispatch(attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/rust/tvm-ffi-macros/src/lib.rs
+++ b/rust/tvm-ffi-macros/src/lib.rs
@@ -25,8 +25,14 @@ mod match_any;
 mod object_macros;
 mod utils;
 
-/// Generate typed structural visit or map dispatch from the `visit_*` or
-/// `map_*` methods in an inherent implementation.
+/// Generate typed structural dispatch from an inherent implementation.
+///
+/// The supported modes are `walk`, `map`, `visit`, and `mutate`:
+/// `dispatch(walk)` turns `walk_*` methods into engine-driven walk callbacks,
+/// `dispatch(map)` uses `map_*` replacement callbacks, and
+/// `dispatch(visit)`/`dispatch(mutate)` generate user-driven visitors or
+/// mutators whose `&mut self` handlers may recurse through the corresponding
+/// trait helpers.
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn dispatch(attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/rust/tvm-ffi/src/extra/dispatch.rs
+++ b/rust/tvm-ffi/src/extra/dispatch.rs
@@ -17,45 +17,24 @@
  * under the License.
  */
 
-//! Typed callback dispatch for [`super::structural_visit::structural_walk`]:
-//! the [`WalkDispatch`] trait targeted by `#[dispatch(walk)]`, and the
-//! walker adapter that runs such a dispatch at the phase selected by the walk
-//! order. The traversal engine, closure walkers, and tuple chains live in
-//! [`super::structural_visit`], which re-exports these items to keep its
-//! public paths stable.
+//! Typed callback dispatch for [`super::structural_visit::structural_walk`].
 
 use crate::error::Result;
 
 use super::structural_visit::{
-    DefRegionKind, IntoWalker, NativeVisit, VisitResult, VisitValue, WalkResult,
+    DefRegionKind, IntoWalker, NativeVisit, VisitValue, WalkCallbackResult, WalkResult,
 };
 
-/// Typed dispatch implemented by a walk-layer observer.
+/// Dispatch for typed `structural_walk` observer callbacks.
 ///
-/// [`crate::dispatch`] tests the implementation's `walk_*` methods in source
-/// order. Borrowed node arguments use refcount-free subtype checks, owned
-/// FFI-compatible arguments use exact value casts, and `&VisitValue` is a
-/// catch-all. `None` reports that no handler matched: a standalone walk then
-/// advances normally, while a tuple chain hands the value to the next link —
-/// so a spliced visitor that "handled" a value must not return `None`.
-///
-/// This is the observer layer, mirroring C++ `StructuralWalk` callbacks: the
-/// walker owns recursion, and a handler steers it only through the returned
-/// [`WalkResult`]. A traversal that must visit children itself — selected
-/// children, custom orders, explicit definition-region overrides — belongs in
-/// a [`super::structural_visit::StructuralVisitor`] instead.
-///
-/// The definition-region state active at the dispatched value arrives as the
-/// `def_region_kind` argument. A `#[dispatch(walk)]` handler opts into it by
-/// declaring a trailing `DefRegionKind` parameter — the analog of a C++
-/// `StructuralWalk` callback accepting `(value, def_region_kind)` instead of
-/// `(value)`.
+/// `None` means that no handler matched. `#[dispatch(walk)]` generates this
+/// trait from source-ordered `walk_*` methods.
 pub trait WalkDispatch: Sized {
     fn dispatch_walk(
         &mut self,
         value: &VisitValue,
         def_region_kind: DefRegionKind,
-    ) -> Option<VisitResult>;
+    ) -> Option<WalkCallbackResult>;
 }
 
 impl<V: WalkDispatch> WalkDispatch for &mut V {
@@ -64,7 +43,7 @@ impl<V: WalkDispatch> WalkDispatch for &mut V {
         &mut self,
         value: &VisitValue,
         def_region_kind: DefRegionKind,
-    ) -> Option<VisitResult> {
+    ) -> Option<WalkCallbackResult> {
         (**self).dispatch_walk(value, def_region_kind)
     }
 }
@@ -75,21 +54,19 @@ pub enum ByWalkDispatch {}
 impl<'a, V: WalkDispatch> IntoWalker<ByWalkDispatch> for &'a mut V {
     type Walker = DispatchWalker<&'a mut V>;
     fn into_walker(self) -> Self::Walker {
-        DispatchWalker { visitor: self }
+        DispatchWalker { walker: self }
     }
 }
 
-/// Owns its walker so a closure's state stays inline and a `&mut` walker
-/// keeps a single level of indirection. Public only as an
-/// [`IntoWalker::Walker`] projection.
+/// Adapter from [`WalkDispatch`] to the traversal's native callback.
 #[doc(hidden)]
 pub struct DispatchWalker<V> {
-    visitor: V,
+    walker: V,
 }
 
 impl<V: WalkDispatch> NativeVisit for DispatchWalker<V> {
     fn visit(&mut self, value: &VisitValue, def_region_kind: DefRegionKind) -> Result<WalkResult> {
-        self.visitor
+        self.walker
             .dispatch_walk(value, def_region_kind)
             .unwrap_or(Ok(WalkResult::Advance))
     }

--- a/rust/tvm-ffi/src/extra/dispatch.rs
+++ b/rust/tvm-ffi/src/extra/dispatch.rs
@@ -17,9 +17,9 @@
  * under the License.
  */
 
-//! Typed visitor dispatch for [`super::structural_visit::structural_walk`]:
-//! the [`VisitDispatch`] trait targeted by `#[dispatch(visit)]`, and the
-//! walker adapter that runs such a visitor at the phase selected by the walk
+//! Typed callback dispatch for [`super::structural_visit::structural_walk`]:
+//! the [`WalkDispatch`] trait targeted by `#[dispatch(walk)]`, and the
+//! walker adapter that runs such a dispatch at the phase selected by the walk
 //! order. The traversal engine, closure walkers, and tuple chains live in
 //! [`super::structural_visit`], which re-exports these items to keep its
 //! public paths stable.
@@ -32,7 +32,7 @@ use super::structural_visit::{
 
 /// Typed dispatch implemented by a walk-layer observer.
 ///
-/// [`crate::dispatch`] tests the implementation's `visit_*` methods in source
+/// [`crate::dispatch`] tests the implementation's `walk_*` methods in source
 /// order. Borrowed node arguments use refcount-free subtype checks, owned
 /// FFI-compatible arguments use exact value casts, and `&VisitValue` is a
 /// catch-all. `None` reports that no handler matched: a standalone walk then
@@ -46,51 +46,51 @@ use super::structural_visit::{
 /// a [`super::structural_visit::StructuralVisitor`] instead.
 ///
 /// The definition-region state active at the dispatched value arrives as the
-/// `def_region_kind` argument. A `#[dispatch(visit)]` handler opts into it by
+/// `def_region_kind` argument. A `#[dispatch(walk)]` handler opts into it by
 /// declaring a trailing `DefRegionKind` parameter — the analog of a C++
 /// `StructuralWalk` callback accepting `(value, def_region_kind)` instead of
 /// `(value)`.
-pub trait VisitDispatch: Sized {
-    fn dispatch_visit(
+pub trait WalkDispatch: Sized {
+    fn dispatch_walk(
         &mut self,
         value: &VisitValue,
         def_region_kind: DefRegionKind,
     ) -> Option<VisitResult>;
 }
 
-impl<V: VisitDispatch> VisitDispatch for &mut V {
+impl<V: WalkDispatch> WalkDispatch for &mut V {
     #[inline]
-    fn dispatch_visit(
+    fn dispatch_walk(
         &mut self,
         value: &VisitValue,
         def_region_kind: DefRegionKind,
     ) -> Option<VisitResult> {
-        (**self).dispatch_visit(value, def_region_kind)
+        (**self).dispatch_walk(value, def_region_kind)
     }
 }
 
 #[doc(hidden)]
-pub enum ByDispatch {}
+pub enum ByWalkDispatch {}
 
-impl<'a, V: VisitDispatch> IntoWalker<ByDispatch> for &'a mut V {
-    type Walker = DispatchVisitor<&'a mut V>;
+impl<'a, V: WalkDispatch> IntoWalker<ByWalkDispatch> for &'a mut V {
+    type Walker = DispatchWalker<&'a mut V>;
     fn into_walker(self) -> Self::Walker {
-        DispatchVisitor { visitor: self }
+        DispatchWalker { visitor: self }
     }
 }
 
-/// Owns its walker so a closure's state stays inline and a `&mut` visitor
+/// Owns its walker so a closure's state stays inline and a `&mut` walker
 /// keeps a single level of indirection. Public only as an
 /// [`IntoWalker::Walker`] projection.
 #[doc(hidden)]
-pub struct DispatchVisitor<V> {
+pub struct DispatchWalker<V> {
     visitor: V,
 }
 
-impl<V: VisitDispatch> NativeVisit for DispatchVisitor<V> {
+impl<V: WalkDispatch> NativeVisit for DispatchWalker<V> {
     fn visit(&mut self, value: &VisitValue, def_region_kind: DefRegionKind) -> Result<WalkResult> {
         self.visitor
-            .dispatch_visit(value, def_region_kind)
+            .dispatch_walk(value, def_region_kind)
             .unwrap_or(Ok(WalkResult::Advance))
     }
 }

--- a/rust/tvm-ffi/src/extra/structural_common.rs
+++ b/rust/tvm-ffi/src/extra/structural_common.rs
@@ -27,12 +27,7 @@ pub(crate) fn with_structural_error_context(error: Error, operation: &str, frame
     Error::with_appended_backtrace(error, &format!("[native structural {operation}] {frame}\n"))
 }
 
-// Rust treats callback tuples of different lengths as different types, so
-// each flat tuple arity needs its own impl. Generate arities 1 through 12
-// here — the same width the standard library implements its tuple traits
-// for — so structural visit and map accept the same flat tuple widths. This
-// is a per-level width, not a cap on chain length: a tuple is itself a
-// link, so nesting `(a, b, (c, d, ...))` chains any number of callbacks.
+// Generate the tuple arities supported by the standard library (1 through 12).
 macro_rules! impl_callback_chain_tuple_arities {
     ($impl_chain:ident) => {
         impl_callback_chain_tuple_arities!(

--- a/rust/tvm-ffi/src/extra/structural_common.rs
+++ b/rust/tvm-ffi/src/extra/structural_common.rs
@@ -27,9 +27,12 @@ pub(crate) fn with_structural_error_context(error: Error, operation: &str, frame
     Error::with_appended_backtrace(error, &format!("[native structural {operation}] {frame}\n"))
 }
 
-// Rust treats callback tuples of different lengths as different types.
-// Generate support for tuples containing 1 through 8 callbacks here so
-// structural visit and map use the same maximum length.
+// Rust treats callback tuples of different lengths as different types, so
+// each flat tuple arity needs its own impl. Generate arities 1 through 12
+// here — the same width the standard library implements its tuple traits
+// for — so structural visit and map accept the same flat tuple widths. This
+// is a per-level width, not a cap on chain length: a tuple is itself a
+// link, so nesting `(a, b, (c, d, ...))` chains any number of callbacks.
 macro_rules! impl_callback_chain_tuple_arities {
     ($impl_chain:ident) => {
         impl_callback_chain_tuple_arities!(
@@ -42,7 +45,11 @@ macro_rules! impl_callback_chain_tuple_arities {
             (F4, M4, 4),
             (F5, M5, 5),
             (F6, M6, 6),
-            (F7, M7, 7)
+            (F7, M7, 7),
+            (F8, M8, 8),
+            (F9, M9, 9),
+            (F10, M10, 10),
+            (F11, M11, 11)
         );
     };
     (@prefixes $impl_chain:ident; [$($prefix:tt)*];) => {};

--- a/rust/tvm-ffi/src/extra/structural_mutate.rs
+++ b/rust/tvm-ffi/src/extra/structural_mutate.rs
@@ -17,14 +17,19 @@
  * under the License.
  */
 
-//! Native Rust structural mapping.
+//! Native Rust structural mutation and mapping.
 //!
-//! [`structural_map`] mirrors the callback-controlled C++ `StructuralMap`,
-//! but keeps recursion, typed dispatch, definition-region propagation, and
-//! identity remapping in Rust.  The root is consumed so Rust ownership and
-//! the runtime strong count jointly define the boundary for optional
-//! in-place container mutation.  Passing a clone naturally selects
-//! copy-on-write behavior.
+//! Two public layers share the same runtime mutation protocol:
+//!
+//! * [`StructuralMutator`] + [`structural_mutate`] let the mutator drive
+//!   recursion. `structural_mutate` also accepts a typed callback or callback
+//!   tuple; matched callbacks receive a [`MutatorRef`] for explicit recursion.
+//! * [`MapDispatch`] + [`structural_map`] provide ordered pre/post-order
+//!   replacement callbacks while the engine owns recursion.
+//!
+//! The root is consumed so Rust ownership and the runtime strong count jointly
+//! define the boundary for optional in-place container mutation. Passing a
+//! clone naturally selects copy-on-write behavior.
 //!
 //! Rust owns callback dispatch, memoization, and identity remapping. Default
 //! recursion follows the shared structural-mutation ABI: each runtime type's
@@ -33,7 +38,7 @@
 //! values. This keeps container storage and type-specific behavior in the
 //! implementation that registered the hook.
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::ffi::c_void;
 use std::marker::PhantomData;
@@ -98,6 +103,270 @@ impl IntoMapResult for Result<Any> {
     #[inline]
     fn into_map_result(self) -> MapResult {
         self
+    }
+}
+
+/// A non-owning mutation handle supplied to `structural_mutate` callbacks.
+///
+/// A matched callback owns mutation of its value. Borrowed children use the
+/// copy path through [`Self::mutate`]; an owned child may opt into an in-place
+/// attempt through [`Self::maybe_inplace_mutate`]. [`Self::default_mutate`]
+/// applies default mutation to the callback's current value and always uses
+/// the copy path, because the callback still holds a shared borrow of that
+/// value. The handle is valid only for its callback invocation and cannot be
+/// sent or shared across threads.
+pub struct MutatorRef<'a> {
+    mutator: StructuralMutatorHandle,
+    context: *mut c_void,
+    current: TVMFFIAny,
+    def_region_kind: DefRegionKind,
+    _lifetime: PhantomData<(&'a (), std::rc::Rc<()>)>,
+}
+
+impl MutatorRef<'_> {
+    /// Definition-region state active at the callback's current value.
+    pub fn def_region_kind(&self) -> DefRegionKind {
+        self.def_region_kind
+    }
+
+    /// Mutate a borrowed child through the same callback chain. The child and
+    /// its descendants begin on the non-in-place path.
+    pub fn mutate<T>(&self, child: &T) -> Result<Any>
+    where
+        for<'x> AnyView<'x>: From<&'x T>,
+    {
+        self.mutate_with(child, self.def_region_kind)
+    }
+
+    /// Mutate a borrowed child under an explicit definition-region state.
+    pub fn mutate_with<T>(&self, child: &T, def_region_kind: DefRegionKind) -> Result<Any>
+    where
+        for<'x> AnyView<'x>: From<&'x T>,
+    {
+        let view = AnyView::from(child);
+        self.driver()
+            .dispatch_raw(*view.as_raw_ffi_any(), def_region_kind, Permit::Copy)
+    }
+
+    /// Mutate an owned child, allowing an in-place attempt when it remains
+    /// uniquely owned and no matched callback borrows it.
+    pub fn maybe_inplace_mutate<T: Into<Any>>(&self, child: T) -> Result<Any> {
+        self.maybe_inplace_mutate_with(child, self.def_region_kind)
+    }
+
+    /// Mutate an owned child under an explicit definition-region state.
+    pub fn maybe_inplace_mutate_with<T: Into<Any>>(
+        &self,
+        child: T,
+        def_region_kind: DefRegionKind,
+    ) -> Result<Any> {
+        let child = child.into();
+        self.driver().dispatch_raw(
+            *child.as_raw_ffi_any(),
+            def_region_kind,
+            Permit::MaybeInPlace,
+        )
+    }
+
+    /// Apply default mutation to the callback's current value.
+    ///
+    /// This operation always uses the copy path and may be called repeatedly.
+    pub fn default_mutate(&self) -> Result<Any> {
+        default_mutate_driver(
+            &mut self.driver(),
+            self.current,
+            self.def_region_kind,
+            Permit::Copy,
+        )
+    }
+
+    /// Look up an invocation-local identity substitution.
+    pub fn var_remap_get(&self, var: &MapValue) -> Result<Option<Any>> {
+        self.driver().var_remap_get_raw(var.raw())
+    }
+
+    /// Store an invocation-local identity substitution.
+    pub fn var_remap_set(&self, var: &MapValue, mapped_value: &Any) -> Result<()> {
+        self.driver().var_remap_set_raw(var.raw(), mapped_value)
+    }
+
+    fn driver(&self) -> SharedMutationDriver {
+        SharedMutationDriver {
+            active: self.mutator,
+            context: self.context,
+        }
+    }
+}
+
+/// Conversion into the mutator argument accepted by [`structural_mutate`].
+///
+/// Supported inputs are `&mut U` for a hand-written [`StructuralMutator`], a
+/// typed `Fn(value, &MutatorRef)` callback, or a tuple of such callbacks. A
+/// callback chain uses first-match dispatch; unmatched values use default
+/// mutation. Callbacks must implement `Fn` because invoking a handle method
+/// may recursively re-enter the same callback. Use `Cell` or `RefCell` for
+/// callback-local state, or pass `&mut StructuralMutator` when ordinary
+/// mutable state is more convenient.
+///
+/// A closure that mutates captured state directly is therefore rejected:
+///
+/// ```compile_fail
+/// use tvm_ffi::{structural_mutate, Any, MutatorRef};
+///
+/// let mut calls = 0_usize;
+/// structural_mutate(1_i64, |value: i64, _mutator: &MutatorRef<'_>| {
+///     calls += 1;
+///     Any::from(value)
+/// })
+/// .unwrap();
+/// ```
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` is not a supported `structural_mutate` mutator",
+    note = "accepted mutators: `&mut U` where `U: StructuralMutator`; an `Fn` callback over an FFI value type `T`, `&N` of an object node type, or `&MapValue`, followed by `&MutatorRef`; or a tuple of up to 12 such callbacks (tuples may nest)",
+    note = "callback arguments need explicit type annotations; callbacks must implement `Fn`, not `FnMut`, because recursive mutation may re-enter the same callback"
+)]
+pub trait IntoMutator<Marker> {
+    #[doc(hidden)]
+    fn mutate_root(self, root: Any) -> Result<Any>;
+}
+
+impl<U: StructuralMutator> IntoMutator<U> for &mut U {
+    fn mutate_root(self, root: Any) -> Result<Any> {
+        run_structural_mutator(root, self)
+    }
+}
+
+/// One typed callback in a callback-driven structural mutator.
+pub trait MutateChainLink<Marker>: mutate_sealed::SealedLink<Marker> {
+    #[doc(hidden)]
+    fn try_mutate(&self, value: &MapValue, mutator: &MutatorRef<'_>) -> Option<MapResult>;
+}
+
+mod mutate_sealed {
+    use super::{IntoMapResult, MapValue, MutatorRef, ObjectCore};
+
+    pub trait SealedLink<Marker> {}
+
+    impl<F, T, O> SealedLink<super::ByMutateOwned<T>> for F
+    where
+        F: for<'a> Fn(T, &'a MutatorRef<'a>) -> O,
+        O: IntoMapResult,
+    {
+    }
+
+    impl<F, N: ObjectCore, O> SealedLink<super::ByMutateNode<N>> for F
+    where
+        F: for<'a> Fn(&'a N, &'a MutatorRef<'a>) -> O,
+        O: IntoMapResult,
+    {
+    }
+
+    impl<F, O> SealedLink<super::ByMutateCatchAll> for F
+    where
+        F: for<'a> Fn(&'a MapValue, &'a MutatorRef<'a>) -> O,
+        O: IntoMapResult,
+    {
+    }
+}
+
+#[doc(hidden)]
+pub struct ByMutateOwned<T>(PhantomData<T>);
+
+impl<F, T, O> MutateChainLink<ByMutateOwned<T>> for F
+where
+    F: for<'a> Fn(T, &'a MutatorRef<'a>) -> O,
+    T: crate::type_traits::AnyCompatible,
+    O: IntoMapResult,
+{
+    fn try_mutate(&self, value: &MapValue, mutator: &MutatorRef<'_>) -> Option<MapResult> {
+        value
+            .cast::<T>()
+            .map(|typed| self(typed, mutator).into_map_result())
+    }
+}
+
+#[doc(hidden)]
+pub struct ByMutateNode<N>(PhantomData<N>);
+
+impl<F, N, O> MutateChainLink<ByMutateNode<N>> for F
+where
+    F: for<'a> Fn(&'a N, &'a MutatorRef<'a>) -> O,
+    N: ObjectCore,
+    O: IntoMapResult,
+{
+    fn try_mutate(&self, value: &MapValue, mutator: &MutatorRef<'_>) -> Option<MapResult> {
+        value
+            .as_node::<N>()
+            .map(|node| self(node, mutator).into_map_result())
+    }
+}
+
+#[doc(hidden)]
+pub enum ByMutateCatchAll {}
+
+impl<F, O> MutateChainLink<ByMutateCatchAll> for F
+where
+    F: for<'a> Fn(&'a MapValue, &'a MutatorRef<'a>) -> O,
+    O: IntoMapResult,
+{
+    fn try_mutate(&self, value: &MapValue, mutator: &MutatorRef<'_>) -> Option<MapResult> {
+        Some(self(value, mutator).into_map_result())
+    }
+}
+
+#[doc(hidden)]
+pub struct ByMutateChainLink<Markers>(PhantomData<fn(Markers)>);
+
+macro_rules! impl_mutate_chain_link {
+    ($(($F:ident, $M:ident, $idx:tt)),+) => {
+        impl<$($F, $M,)+> mutate_sealed::SealedLink<ByMutateChainLink<($($M,)+)>> for ($($F,)+)
+        where
+            $($F: MutateChainLink<$M>,)+
+        {
+        }
+
+        impl<$($F, $M,)+> MutateChainLink<ByMutateChainLink<($($M,)+)>> for ($($F,)+)
+        where
+            $($F: MutateChainLink<$M>,)+
+        {
+            fn try_mutate(
+                &self,
+                value: &MapValue,
+                mutator: &MutatorRef<'_>,
+            ) -> Option<MapResult> {
+                $(
+                    if let Some(result) = self.$idx.try_mutate(value, mutator) {
+                        return Some(result);
+                    }
+                )+
+                None
+            }
+        }
+    };
+}
+
+impl_callback_chain_tuple_arities!(impl_mutate_chain_link);
+
+struct CallbackMutator<Link, Marker> {
+    link: Link,
+    remap: RefCell<StructuralVarRemap>,
+    _marker: PhantomData<fn(Marker)>,
+}
+
+#[doc(hidden)]
+pub struct ByMutateCallbacks<Marker>(PhantomData<fn(Marker)>);
+
+impl<Link, Marker> IntoMutator<ByMutateCallbacks<Marker>> for Link
+where
+    Link: MutateChainLink<Marker>,
+{
+    fn mutate_root(self, root: Any) -> Result<Any> {
+        let mutator: CallbackMutator<Link, Marker> = CallbackMutator {
+            link: self,
+            remap: RefCell::new(StructuralVarRemap::default()),
+            _marker: PhantomData,
+        };
+        run_shared_structural_mutator(root, &mutator, callback_runtime_callbacks::<Link, Marker>())
     }
 }
 
@@ -1037,13 +1306,14 @@ impl Drop for RuntimeContextGuard {
     }
 }
 
-/// Temporarily take the callback context out of the runtime object.
+/// Temporarily take the erased callback context out of the runtime object.
 ///
 /// # Safety
 ///
 /// `mutator` must be null or point to a live [`RuntimeStructuralMutatorObj`].
-/// A non-null context must have been installed from the current mutable
-/// reborrow of the driver and its callback table must use that driver's type.
+/// A non-null context must have been installed by the current run. Its callback
+/// table must reconstruct it according to that run's mutable-driver or
+/// shared-callback contract.
 unsafe fn take_runtime_context(mutator: StructuralMutatorHandle) -> Result<RuntimeContextGuard> {
     if !is_active_mutator(mutator) {
         return Err(inactive_mutator_error(mutator, "callback"));
@@ -1057,8 +1327,8 @@ unsafe fn take_runtime_context(mutator: StructuralMutatorHandle) -> Result<Runti
         };
         return Err(runtime_error(message));
     }
-    // No raw driver pointer remains callable while Rust holds the mutable
-    // reborrow produced from `context`.
+    // No raw context pointer remains callable while Rust executes the selected
+    // mutable-driver or shared-callback entry.
     (*mutator).context = std::ptr::null_mut();
     Ok(RuntimeContextGuard { mutator, context })
 }
@@ -1234,10 +1504,21 @@ fn with_current_driver_context<D, T>(
     driver: &mut D,
     callback: impl FnOnce() -> Result<T>,
 ) -> Result<T> {
+    let context = std::ptr::from_mut(driver).cast::<c_void>();
+    with_current_mutator_context(mutator, context, callback)
+}
+
+/// Expose an already validated mutable or shared callback context for one
+/// registered hook/vtable call. Callers determine whether the pointer may be
+/// reconstructed as `&mut D` or only `&D`; this helper never dereferences it.
+fn with_current_mutator_context<T>(
+    mutator: StructuralMutatorHandle,
+    context: *mut c_void,
+    callback: impl FnOnce() -> Result<T>,
+) -> Result<T> {
     if !is_active_mutator(mutator) {
         return Err(inactive_mutator_error(mutator, "helper"));
     }
-    let context = std::ptr::from_mut(driver).cast::<c_void>();
     unsafe {
         if (*mutator).context_identity != context {
             return Err(runtime_error(
@@ -1322,6 +1603,118 @@ impl<U: StructuralMutator> MutationDriver for U {
     }
 }
 
+/// Thin driver used by callback-backed mutation. It owns no callback state;
+/// every recursive entry exposes the original shared context and the runtime
+/// callback table reconstructs only `&CallbackMutator` from that pointer.
+struct SharedMutationDriver {
+    active: StructuralMutatorHandle,
+    context: *mut c_void,
+}
+
+impl MutationDriver for SharedMutationDriver {
+    fn dispatch_raw(
+        &mut self,
+        raw: TVMFFIAny,
+        def_region_kind: DefRegionKind,
+        permit: Permit,
+    ) -> Result<Any> {
+        with_current_mutator_context(self.active, self.context, || {
+            call_mutator(self.active, raw, def_region_kind, permit)
+        })
+    }
+
+    fn var_remap_get_raw(&mut self, raw: TVMFFIAny) -> Result<Option<Any>> {
+        let callback = unsafe { (*self.active).callbacks.var_remap_get };
+        unsafe { callback(self.context, raw) }
+    }
+
+    fn var_remap_set_raw(&mut self, raw: TVMFFIAny, mapped_value: &Any) -> Result<()> {
+        let callback = unsafe { (*self.active).callbacks.var_remap_set };
+        unsafe { callback(self.context, raw, mapped_value) }
+    }
+
+    fn call_registered_hook(
+        &mut self,
+        raw: TVMFFIAny,
+        def_region_kind: DefRegionKind,
+        permit: Permit,
+    ) -> Result<Option<Any>> {
+        with_current_mutator_context(self.active, self.context, || {
+            call_registered_structural_mutate(self.active, raw, def_region_kind, permit)
+        })
+    }
+}
+
+fn callback_runtime_callbacks<Link, Marker>() -> RuntimeMutatorCallbacks
+where
+    Link: MutateChainLink<Marker>,
+{
+    RuntimeMutatorCallbacks {
+        mutate: runtime_callback_mutate::<Link, Marker>,
+        var_remap_get: runtime_callback_var_remap_get::<Link, Marker>,
+        var_remap_set: runtime_callback_var_remap_set::<Link, Marker>,
+    }
+}
+
+unsafe fn runtime_callback_mutate<Link, Marker>(
+    context: *mut c_void,
+    raw: TVMFFIAny,
+    def_region_kind: DefRegionKind,
+    permit: Permit,
+) -> Result<Any>
+where
+    Link: MutateChainLink<Marker>,
+{
+    // SAFETY: callback-backed runs install a pointer derived from a shared
+    // `CallbackMutator`. All recursive entries reconstruct only a shared
+    // reference, so an `Fn` callback may soundly re-enter itself.
+    let callback = &*context.cast::<CallbackMutator<Link, Marker>>();
+    let active = active_mutator()?;
+    let mutator = MutatorRef {
+        mutator: active,
+        context,
+        current: raw,
+        def_region_kind,
+        _lifetime: PhantomData,
+    };
+    let result = match callback.link.try_mutate(&MapValue::from_raw(raw), &mutator) {
+        Some(result) => result,
+        None => default_mutate_driver(
+            &mut SharedMutationDriver { active, context },
+            raw,
+            def_region_kind,
+            permit,
+        ),
+    };
+    result.map_err(|error| with_value_context(error, raw))
+}
+
+unsafe fn runtime_callback_var_remap_get<Link, Marker>(
+    context: *mut c_void,
+    raw: TVMFFIAny,
+) -> Result<Option<Any>>
+where
+    Link: MutateChainLink<Marker>,
+{
+    let callback = &*context.cast::<CallbackMutator<Link, Marker>>();
+    callback.remap.borrow().get(&MapValue::from_raw(raw))
+}
+
+unsafe fn runtime_callback_var_remap_set<Link, Marker>(
+    context: *mut c_void,
+    raw: TVMFFIAny,
+    mapped_value: &Any,
+) -> Result<()>
+where
+    Link: MutateChainLink<Marker>,
+{
+    let callback = &*context.cast::<CallbackMutator<Link, Marker>>();
+    callback
+        .remap
+        .borrow_mut()
+        .set(&MapValue::from_raw(raw), mapped_value)
+}
+
 /// Invoke the concrete Rust driver selected when the runtime mutator was built.
 ///
 /// # Safety
@@ -1370,6 +1763,25 @@ fn run_structural_mutator<D: MutationDriver>(root: Any, driver: &mut D) -> Resul
         var_remap_get: runtime_var_remap_get::<D>,
         var_remap_set: runtime_var_remap_set::<D>,
     };
+    run_structural_mutator_with_context(root, context, callbacks)
+}
+
+fn run_shared_structural_mutator<D>(
+    root: Any,
+    driver: &D,
+    callbacks: RuntimeMutatorCallbacks,
+) -> Result<Any> {
+    // The ABI field is mutable for the hand-written mutator path, but the
+    // callback table supplied here must reconstruct only shared references.
+    let context = std::ptr::from_ref(driver).cast_mut().cast::<c_void>();
+    run_structural_mutator_with_context(root, context, callbacks)
+}
+
+fn run_structural_mutator_with_context(
+    root: Any,
+    context: *mut c_void,
+    callbacks: RuntimeMutatorCallbacks,
+) -> Result<Any> {
     let mut active = ObjectArc::new(RuntimeStructuralMutatorObj {
         base: Object::new(),
         vtable: &RUST_STRUCTURAL_MUTATOR_VTABLE,
@@ -1574,12 +1986,19 @@ fn user_default_mutate<U: StructuralMutator>(
     def_region_kind: DefRegionKind,
     permit: Permit,
 ) -> Result<Any> {
+    default_mutate_driver(mutator, raw, def_region_kind, permit)
+}
+
+fn default_mutate_driver<D: MutationDriver>(
+    driver: &mut D,
+    raw: TVMFFIAny,
+    def_region_kind: DefRegionKind,
+    permit: Permit,
+) -> Result<Any> {
     // Match C++ DefaultMutateExpected: a registered type hook owns any
     // identity-remap policy for that type. Automatic remapping applies only
     // to the reflected fallback below.
-    if let Some(mapped) =
-        MutationDriver::call_registered_hook(mutator, raw, def_region_kind, permit)?
-    {
+    if let Some(mapped) = driver.call_registered_hook(raw, def_region_kind, permit)? {
         return Ok(mapped);
     }
     if raw.type_index < TVMFFITypeIndex::kTVMFFIStaticObjectBegin as i32 {
@@ -1588,32 +2007,32 @@ fn user_default_mutate<U: StructuralMutator>(
 
     let remappable = identity_key(raw)?.is_some();
     if remappable {
-        let var = MapValue::from_raw(raw);
-        if let Some(mapped) = mutator.var_remap_get(&var)? {
+        if let Some(mapped) = driver.var_remap_get_raw(raw)? {
             return Ok(mapped);
         }
     }
 
-    let result = MutationDriver::map_reflected(mutator, raw, def_region_kind)?;
+    let result = driver.map_reflected(raw, def_region_kind)?;
     if remappable {
-        let var = MapValue::from_raw(raw);
-        mutator.var_remap_set(&var, &result)?;
+        driver.var_remap_set_raw(raw, &result)?;
     }
     Ok(result)
 }
 
-/// Mutate a structured value with a user-driven [`StructuralMutator`].
+/// Mutate a structured value with a user-driven mutator or callback chain.
 ///
 /// The root is consumed to establish the ownership boundary for optional
 /// in-place mutation. Completed in-place changes are not rolled back on an
-/// error, and an error does not return the consumed root.
-pub fn structural_mutate<R, U>(root: R, mutator: &mut U) -> Result<Any>
+/// error, and an error does not return the consumed root. Passing `&mut U` for
+/// `U: StructuralMutator` preserves the low-level API. A typed `Fn(value,
+/// &MutatorRef)` callback or callback tuple builds a temporary mutator. The
+/// first matching callback supplies the final value; unmatched values use
+/// default mutation with the current in-place permit.
+pub fn structural_mutate<R, M>(root: R, mutator: impl IntoMutator<M>) -> Result<Any>
 where
     R: Into<Any>,
-    U: StructuralMutator,
 {
-    let root = root.into();
-    run_structural_mutator(root, mutator)
+    mutator.mutate_root(root.into())
 }
 
 /// Transform a structured value graph with ordered replacement callbacks.

--- a/rust/tvm-ffi/src/extra/structural_mutate.rs
+++ b/rust/tvm-ffi/src/extra/structural_mutate.rs
@@ -153,6 +153,10 @@ impl<'a, V: MapDispatch> IntoMapper<ByMapDispatch> for &'a mut V {
 /// Links are tried in tuple order and the first matching link supplies the
 /// replacement.  Supported shapes are owned FFI values, borrowed object
 /// nodes, and `&MapValue`, each optionally followed by [`DefRegionKind`].
+/// A tuple of links is itself a link, so tuples nest: a flat tuple holds up
+/// to 12 links, and nesting — `(a, b, (c, d, ...), e)` — lifts that cap
+/// without changing order, which stays the flattened depth-first,
+/// left-to-right order.
 /// Numeric links match the complete FFI `Int` or `Float` type tag and then use
 /// Rust `as` conversion semantics, so prefer `i64` and `f64` unless narrowing
 /// is intentional.
@@ -306,6 +310,9 @@ where
 }
 
 #[doc(hidden)]
+pub struct ByMapChainLink<Markers>(PhantomData<fn(Markers)>);
+
+#[doc(hidden)]
 pub enum ByMapDispatchLink {}
 
 impl<V: MapDispatch> MapChainLink<ByMapDispatchLink> for &mut V {
@@ -315,28 +322,63 @@ impl<V: MapDispatch> MapChainLink<ByMapDispatchLink> for &mut V {
     }
 }
 
-/// Statically dispatched tuple mapper, public only as an [`IntoMapper`]
-/// projection.
+/// Statically dispatched mapper over one [`MapChainLink`] — a bare closure
+/// or a tuple of links — public only as an [`IntoMapper`] projection.
 #[doc(hidden)]
-pub struct MapChain<Links, Markers> {
-    links: Links,
-    markers: PhantomData<fn(Markers)>,
+pub struct MapChain<Link, Marker> {
+    link: Link,
+    marker: PhantomData<fn(Marker)>,
 }
 
-macro_rules! impl_map_chain {
+impl<Link, Marker> MapChain<Link, Marker> {
+    #[inline]
+    fn new(link: Link) -> Self {
+        MapChain {
+            link,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<Link, Marker> MapDispatch for MapChain<Link, Marker>
+where
+    Link: MapChainLink<Marker>,
+{
+    #[inline]
+    fn dispatch_map(
+        &mut self,
+        value: &MapValue,
+        def_region_kind: DefRegionKind,
+    ) -> Option<MapResult> {
+        self.link.try_map(value, def_region_kind)
+    }
+}
+
+// A tuple of links is itself a link, tried in order with the first match
+// winning. Tuples therefore nest: the 12-wide flat arity cap becomes a
+// per-level cap and the total chain length is unbounded. Nesting does not
+// change order: links run in depth-first, left-to-right order, i.e. the
+// flattened order.
+macro_rules! impl_map_chain_link {
     ($(($F:ident, $M:ident, $idx:tt)),+) => {
-        impl<$($F, $M,)+> MapDispatch for MapChain<($($F,)+), ($($M,)+)>
+        impl<$($F, $M,)+> sealed_map::SealedMapLink<ByMapChainLink<($($M,)+)>> for ($($F,)+)
+        where
+            $($F: MapChainLink<$M>,)+
+        {
+        }
+
+        impl<$($F, $M,)+> MapChainLink<ByMapChainLink<($($M,)+)>> for ($($F,)+)
         where
             $($F: MapChainLink<$M>,)+
         {
             #[inline]
-            fn dispatch_map(
+            fn try_map(
                 &mut self,
                 value: &MapValue,
                 def_region_kind: DefRegionKind,
             ) -> Option<MapResult> {
                 $(
-                    if let Some(result) = self.links.$idx.try_map(value, def_region_kind) {
+                    if let Some(result) = self.$idx.try_map(value, def_region_kind) {
                         return Some(result);
                     }
                 )+
@@ -348,20 +390,17 @@ macro_rules! impl_map_chain {
         where
             $($F: MapChainLink<$M>,)+
         {
-            type Mapper = MapChain<($($F,)+), ($($M,)+)>;
+            type Mapper = MapChain<($($F,)+), ByMapChainLink<($($M,)+)>>;
 
             #[inline]
             fn into_mapper(self) -> Self::Mapper {
-                MapChain {
-                    links: self,
-                    markers: PhantomData,
-                }
+                MapChain::new(self)
             }
         }
     };
 }
 
-impl_callback_chain_tuple_arities!(impl_map_chain);
+impl_callback_chain_tuple_arities!(impl_map_chain_link);
 
 macro_rules! impl_bare_map_link {
     ($(($marker:ident, $($fn_args:ty),+)),+ $(,)?) => {
@@ -372,14 +411,11 @@ macro_rules! impl_bare_map_link {
                 Self: MapChainLink<$marker<T>>,
                 O: IntoMapResult,
             {
-                type Mapper = MapChain<(F,), ($marker<T>,)>;
+                type Mapper = MapChain<F, $marker<T>>;
 
                 #[inline]
                 fn into_mapper(self) -> Self::Mapper {
-                    MapChain {
-                        links: (self,),
-                        markers: PhantomData,
-                    }
+                    MapChain::new(self)
                 }
             }
         )+
@@ -398,14 +434,11 @@ where
     F: for<'a> FnMut(&'a MapValue) -> O,
     O: IntoMapResult,
 {
-    type Mapper = MapChain<(F,), (ByMapCatchAll,)>;
+    type Mapper = MapChain<F, ByMapCatchAll>;
 
     #[inline]
     fn into_mapper(self) -> Self::Mapper {
-        MapChain {
-            links: (self,),
-            markers: PhantomData,
-        }
+        MapChain::new(self)
     }
 }
 
@@ -414,14 +447,11 @@ where
     F: for<'a> FnMut(&'a MapValue, DefRegionKind) -> O,
     O: IntoMapResult,
 {
-    type Mapper = MapChain<(F,), (ByMapCatchAllKind,)>;
+    type Mapper = MapChain<F, ByMapCatchAllKind>;
 
     #[inline]
     fn into_mapper(self) -> Self::Mapper {
-        MapChain {
-            links: (self,),
-            markers: PhantomData,
-        }
+        MapChain::new(self)
     }
 }
 

--- a/rust/tvm-ffi/src/extra/structural_mutate.rs
+++ b/rust/tvm-ffi/src/extra/structural_mutate.rs
@@ -24,8 +24,8 @@
 //! * [`StructuralMutator`] + [`structural_mutate`] let the mutator drive
 //!   recursion. `#[dispatch(mutate)]` generates this trait from typed
 //!   `mutate_*` methods. `structural_mutate` also accepts a typed callback or
-//!   callback tuple; matched callbacks receive a [`MutatorRef`] for explicit
-//!   recursion.
+//!   callback tuple; matched callbacks receive a [`MutateContext`] for state
+//!   and explicit recursion.
 //! * [`MapDispatch`] + [`structural_map`] provide ordered pre/post-order
 //!   replacement callbacks while the engine owns recursion. `#[dispatch(map)]`
 //!   generates this layer from typed `map_*` methods.
@@ -48,6 +48,7 @@ use std::marker::PhantomData;
 use std::ops::{ControlFlow, Deref};
 use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
 use std::ptr::NonNull;
+use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::LazyLock;
 
@@ -109,24 +110,85 @@ impl IntoMapResult for Result<Any> {
     }
 }
 
-/// A non-owning mutation handle supplied to `structural_mutate` callbacks.
+/// Mutable callback context for a stateful structural mutator.
 ///
-/// A matched callback owns mutation of its value. Borrowed children use the
-/// copy path through [`Self::mutate`]; an owned child may opt into an in-place
-/// attempt through [`Self::maybe_inplace_mutate`]. [`Self::default_mutate`]
-/// applies default mutation to the callback's current value and always uses
-/// the copy path, because the callback still holds a shared borrow of that
-/// value. The handle is valid only for its callback invocation and cannot be
+/// A matched callback owns mutation of its value. Use [`Self::mutate`] for a
+/// borrowed child, [`Self::maybe_inplace_mutate`] for an owned child, or
+/// [`Self::default_mutate`] to apply the current value's default mutation.
+/// Mutable user state lives in [`MutateCallbacks`] and is available through
+/// [`Self::state`] and [`Self::state_mut`].
+///
+/// Recursive operations take `&mut self`. This makes each recursive entry a
+/// checked reborrow of the complete mutation context: Rust rejects a state
+/// borrow that remains live across a recursive mutation. The context is valid
+/// only for the callback invocation in which it was received and cannot be
 /// sent or shared across threads.
-pub struct MutatorRef<'a> {
-    mutator: StructuralMutatorHandle,
-    context: *mut c_void,
-    current: TVMFFIAny,
+pub struct MutateContext<'a, State> {
+    driver: &'a mut dyn MutateContextDriver<State>,
+    current: MapValue,
     def_region_kind: DefRegionKind,
-    _lifetime: PhantomData<(&'a (), std::rc::Rc<()>)>,
+    _not_send_sync: PhantomData<Rc<()>>,
 }
 
-impl MutatorRef<'_> {
+/// Object-safe bridge that lets `MutateContext<State>` reborrow a concrete
+/// `MutateCallbacks<State, ..>` without exposing its callback types.
+trait MutateContextDriver<State> {
+    fn state(&self) -> &State;
+    fn state_mut(&mut self) -> &mut State;
+    fn mutate_raw(
+        &mut self,
+        raw: TVMFFIAny,
+        def_region_kind: DefRegionKind,
+        permit: Permit,
+    ) -> Result<Any>;
+    fn default_mutate_raw(&mut self, raw: TVMFFIAny, def_region_kind: DefRegionKind)
+        -> Result<Any>;
+    fn var_remap_get_raw(&mut self, raw: TVMFFIAny) -> Result<Option<Any>>;
+    fn var_remap_set_raw(&mut self, raw: TVMFFIAny, mapped_value: &Any) -> Result<()>;
+}
+
+impl<State> MutateContext<'_, State> {
+    /// User state shared by every callback in this mutation.
+    pub fn state(&self) -> &State {
+        self.driver.state()
+    }
+
+    /// Mutably borrow the user state.
+    ///
+    /// The returned borrow must end before a recursive context method is
+    /// called. The borrow checker enforces this when the borrow is used after
+    /// that call.
+    ///
+    /// ```compile_fail
+    /// use tvm_ffi::{Any, MapValue, MutateCallbacks, MutateContext, Result};
+    ///
+    /// #[derive(Default)]
+    /// struct Stats {
+    ///     calls: usize,
+    /// }
+    ///
+    /// fn mutate_any(
+    ///     _value: &MapValue,
+    ///     context: &mut MutateContext<'_, Stats>,
+    /// ) -> Result<Any> {
+    ///     let calls = &mut context.state_mut().calls;
+    ///     *calls += 1;
+    ///     let result = context.default_mutate();
+    ///     *calls += 1; // `calls` cannot stay borrowed across recursion.
+    ///     result
+    /// }
+    ///
+    /// let _mutator = MutateCallbacks::new(Stats::default(), mutate_any);
+    /// ```
+    pub fn state_mut(&mut self) -> &mut State {
+        self.driver.state_mut()
+    }
+
+    /// Complete borrowed value active at this callback.
+    pub fn current(&self) -> &MapValue {
+        &self.current
+    }
+
     /// Definition-region state active at the callback's current value.
     pub fn def_region_kind(&self) -> DefRegionKind {
         self.def_region_kind
@@ -134,7 +196,7 @@ impl MutatorRef<'_> {
 
     /// Mutate a borrowed child through the same callback chain. The child and
     /// its descendants begin on the non-in-place path.
-    pub fn mutate<T>(&self, child: &T) -> Result<Any>
+    pub fn mutate<T>(&mut self, child: &T) -> Result<Any>
     where
         for<'x> AnyView<'x>: From<&'x T>,
     {
@@ -142,29 +204,29 @@ impl MutatorRef<'_> {
     }
 
     /// Mutate a borrowed child under an explicit definition-region state.
-    pub fn mutate_with<T>(&self, child: &T, def_region_kind: DefRegionKind) -> Result<Any>
+    pub fn mutate_with<T>(&mut self, child: &T, def_region_kind: DefRegionKind) -> Result<Any>
     where
         for<'x> AnyView<'x>: From<&'x T>,
     {
         let view = AnyView::from(child);
-        self.driver()
-            .dispatch_raw(*view.as_raw_ffi_any(), def_region_kind, Permit::Copy)
+        self.driver
+            .mutate_raw(*view.as_raw_ffi_any(), def_region_kind, Permit::Copy)
     }
 
     /// Mutate an owned child, allowing an in-place attempt when it remains
     /// uniquely owned and no matched callback borrows it.
-    pub fn maybe_inplace_mutate<T: Into<Any>>(&self, child: T) -> Result<Any> {
+    pub fn maybe_inplace_mutate<T: Into<Any>>(&mut self, child: T) -> Result<Any> {
         self.maybe_inplace_mutate_with(child, self.def_region_kind)
     }
 
     /// Mutate an owned child under an explicit definition-region state.
     pub fn maybe_inplace_mutate_with<T: Into<Any>>(
-        &self,
+        &mut self,
         child: T,
         def_region_kind: DefRegionKind,
     ) -> Result<Any> {
         let child = child.into();
-        self.driver().dispatch_raw(
+        self.driver.mutate_raw(
             *child.as_raw_ffi_any(),
             def_region_kind,
             Permit::MaybeInPlace,
@@ -173,51 +235,43 @@ impl MutatorRef<'_> {
 
     /// Apply default mutation to the callback's current value.
     ///
-    /// This operation always uses the copy path and may be called repeatedly.
-    pub fn default_mutate(&self) -> Result<Any> {
-        default_mutate_driver(
-            &mut self.driver(),
-            self.current,
-            self.def_region_kind,
-            Permit::Copy,
-        )
+    /// This operation always uses the copy path because a callback may still
+    /// hold a shared borrow of the current value. It may be called repeatedly.
+    pub fn default_mutate(&mut self) -> Result<Any> {
+        self.driver
+            .default_mutate_raw(self.current.raw(), self.def_region_kind)
     }
 
     /// Look up an invocation-local identity substitution.
-    pub fn var_remap_get(&self, var: &MapValue) -> Result<Option<Any>> {
-        self.driver().var_remap_get_raw(var.raw())
+    pub fn var_remap_get(&mut self, var: &MapValue) -> Result<Option<Any>> {
+        self.driver.var_remap_get_raw(var.raw())
     }
 
     /// Store an invocation-local identity substitution.
-    pub fn var_remap_set(&self, var: &MapValue, mapped_value: &Any) -> Result<()> {
-        self.driver().var_remap_set_raw(var.raw(), mapped_value)
-    }
-
-    fn driver(&self) -> SharedMutationDriver {
-        SharedMutationDriver {
-            active: self.mutator,
-            context: self.context,
-        }
+    pub fn var_remap_set(&mut self, var: &MapValue, mapped_value: &Any) -> Result<()> {
+        self.driver.var_remap_set_raw(var.raw(), mapped_value)
     }
 }
 
 /// Conversion into the mutator argument accepted by [`structural_mutate`].
 ///
 /// Supported inputs are `&mut U` for a hand-written [`StructuralMutator`], a
-/// typed `Fn(value, &MutatorRef)` callback, or a tuple of such callbacks. A
-/// callback chain uses first-match dispatch; unmatched values use default
-/// mutation. Callbacks must implement `Fn` because invoking a handle method
-/// may recursively re-enter the same callback. Use `Cell` or `RefCell` for
-/// callback-local state, or pass `&mut StructuralMutator` when ordinary
-/// mutable state is more convenient.
+/// typed `Fn(value, &mut MutateContext<'_, ()>)` callback, or a tuple of such
+/// callbacks. A callback chain uses first-match dispatch; unmatched values use
+/// default mutation. Use [`MutateCallbacks`] to give a callback chain ordinary
+/// mutable state.
+///
+/// Callback code still implements `Fn`, because recursive context methods may
+/// re-enter the same callback. All mutation instead goes through the single
+/// `&mut MutateContext`, so recursive calls are ordinary checked reborrows.
 ///
 /// A closure that mutates captured state directly is therefore rejected:
 ///
 /// ```compile_fail
-/// use tvm_ffi::{structural_mutate, Any, MutatorRef};
+/// use tvm_ffi::{structural_mutate, Any, MutateContext};
 ///
 /// let mut calls = 0_usize;
-/// structural_mutate(1_i64, |value: i64, _mutator: &MutatorRef<'_>| {
+/// structural_mutate(1_i64, |value: i64, _context: &mut MutateContext<'_, ()>| {
 ///     calls += 1;
 ///     Any::from(value)
 /// })
@@ -225,8 +279,8 @@ impl MutatorRef<'_> {
 /// ```
 #[diagnostic::on_unimplemented(
     message = "`{Self}` is not a supported `structural_mutate` mutator",
-    note = "accepted mutators: `&mut U` where `U: StructuralMutator`; an `Fn` callback over an FFI value type `T`, `&N` of an object node type, or `&MapValue`, followed by `&MutatorRef`; or a tuple of up to 12 such callbacks (tuples may nest)",
-    note = "callback arguments need explicit type annotations; callbacks must implement `Fn`, not `FnMut`, because recursive mutation may re-enter the same callback"
+    note = "accepted mutators: `&mut U` where `U: StructuralMutator`; an `Fn` callback over an FFI value type `T`, `&N` of an object node type, or `&MapValue`, followed by `&mut MutateContext<'_, ()>`; or a tuple of up to 12 such callbacks (tuples may nest)",
+    note = "callback arguments need explicit type annotations; use `MutateCallbacks::new(state, callbacks)` for ordinary mutable callback state"
 )]
 pub trait IntoMutator<Marker> {
     #[doc(hidden)]
@@ -240,33 +294,43 @@ impl<U: StructuralMutator> IntoMutator<U> for &mut U {
 }
 
 /// One typed callback in a callback-driven structural mutator.
-pub trait MutateChainLink<Marker>: mutate_sealed::SealedLink<Marker> {
+pub trait MutateChainLink<State, Marker>: mutate_sealed::SealedLink<State, Marker> {
     #[doc(hidden)]
-    fn try_mutate(&self, value: &MapValue, mutator: &MutatorRef<'_>) -> Option<MapResult>;
+    fn try_mutate(
+        &self,
+        value: &MapValue,
+        context: &mut MutateContext<'_, State>,
+    ) -> Option<MapResult>;
 }
 
 mod mutate_sealed {
-    use super::{IntoMapResult, MapValue, MutatorRef, ObjectCore};
+    use super::{IntoMapResult, MapValue, MutateContext, ObjectCore};
 
-    pub trait SealedLink<Marker> {}
+    pub trait SealedLink<State, Marker> {}
 
-    impl<F, T, O> SealedLink<super::ByMutateOwned<T>> for F
+    impl<F, State, T, O> SealedLink<State, super::ByMutateOwned<T>> for F
     where
-        F: for<'a> Fn(T, &'a MutatorRef<'a>) -> O,
+        F: for<'context, 'driver> Fn(T, &'context mut MutateContext<'driver, State>) -> O,
         O: IntoMapResult,
     {
     }
 
-    impl<F, N: ObjectCore, O> SealedLink<super::ByMutateNode<N>> for F
+    impl<F, State, N: ObjectCore, O> SealedLink<State, super::ByMutateNode<N>> for F
     where
-        F: for<'a> Fn(&'a N, &'a MutatorRef<'a>) -> O,
+        F: for<'value, 'context, 'driver> Fn(
+            &'value N,
+            &'context mut MutateContext<'driver, State>,
+        ) -> O,
         O: IntoMapResult,
     {
     }
 
-    impl<F, O> SealedLink<super::ByMutateCatchAll> for F
+    impl<F, State, O> SealedLink<State, super::ByMutateCatchAll> for F
     where
-        F: for<'a> Fn(&'a MapValue, &'a MutatorRef<'a>) -> O,
+        F: for<'value, 'context, 'driver> Fn(
+            &'value MapValue,
+            &'context mut MutateContext<'driver, State>,
+        ) -> O,
         O: IntoMapResult,
     {
     }
@@ -275,45 +339,63 @@ mod mutate_sealed {
 #[doc(hidden)]
 pub struct ByMutateOwned<T>(PhantomData<T>);
 
-impl<F, T, O> MutateChainLink<ByMutateOwned<T>> for F
+impl<F, State, T, O> MutateChainLink<State, ByMutateOwned<T>> for F
 where
-    F: for<'a> Fn(T, &'a MutatorRef<'a>) -> O,
+    F: for<'context, 'driver> Fn(T, &'context mut MutateContext<'driver, State>) -> O,
     T: crate::type_traits::AnyCompatible,
     O: IntoMapResult,
 {
-    fn try_mutate(&self, value: &MapValue, mutator: &MutatorRef<'_>) -> Option<MapResult> {
+    fn try_mutate(
+        &self,
+        value: &MapValue,
+        context: &mut MutateContext<'_, State>,
+    ) -> Option<MapResult> {
         value
             .cast::<T>()
-            .map(|typed| self(typed, mutator).into_map_result())
+            .map(|typed| self(typed, context).into_map_result())
     }
 }
 
 #[doc(hidden)]
 pub struct ByMutateNode<N>(PhantomData<N>);
 
-impl<F, N, O> MutateChainLink<ByMutateNode<N>> for F
+impl<F, State, N, O> MutateChainLink<State, ByMutateNode<N>> for F
 where
-    F: for<'a> Fn(&'a N, &'a MutatorRef<'a>) -> O,
+    F: for<'value, 'context, 'driver> Fn(
+        &'value N,
+        &'context mut MutateContext<'driver, State>,
+    ) -> O,
     N: ObjectCore,
     O: IntoMapResult,
 {
-    fn try_mutate(&self, value: &MapValue, mutator: &MutatorRef<'_>) -> Option<MapResult> {
+    fn try_mutate(
+        &self,
+        value: &MapValue,
+        context: &mut MutateContext<'_, State>,
+    ) -> Option<MapResult> {
         value
             .as_node::<N>()
-            .map(|node| self(node, mutator).into_map_result())
+            .map(|node| self(node, context).into_map_result())
     }
 }
 
 #[doc(hidden)]
 pub enum ByMutateCatchAll {}
 
-impl<F, O> MutateChainLink<ByMutateCatchAll> for F
+impl<F, State, O> MutateChainLink<State, ByMutateCatchAll> for F
 where
-    F: for<'a> Fn(&'a MapValue, &'a MutatorRef<'a>) -> O,
+    F: for<'value, 'context, 'driver> Fn(
+        &'value MapValue,
+        &'context mut MutateContext<'driver, State>,
+    ) -> O,
     O: IntoMapResult,
 {
-    fn try_mutate(&self, value: &MapValue, mutator: &MutatorRef<'_>) -> Option<MapResult> {
-        Some(self(value, mutator).into_map_result())
+    fn try_mutate(
+        &self,
+        value: &MapValue,
+        context: &mut MutateContext<'_, State>,
+    ) -> Option<MapResult> {
+        Some(self(value, context).into_map_result())
     }
 }
 
@@ -322,23 +404,25 @@ pub struct ByMutateChainLink<Markers>(PhantomData<fn(Markers)>);
 
 macro_rules! impl_mutate_chain_link {
     ($(($F:ident, $M:ident, $idx:tt)),+) => {
-        impl<$($F, $M,)+> mutate_sealed::SealedLink<ByMutateChainLink<($($M,)+)>> for ($($F,)+)
+        impl<State, $($F, $M,)+>
+            mutate_sealed::SealedLink<State, ByMutateChainLink<($($M,)+)>> for ($($F,)+)
         where
-            $($F: MutateChainLink<$M>,)+
+            $($F: MutateChainLink<State, $M>,)+
         {
         }
 
-        impl<$($F, $M,)+> MutateChainLink<ByMutateChainLink<($($M,)+)>> for ($($F,)+)
+        impl<State, $($F, $M,)+> MutateChainLink<State, ByMutateChainLink<($($M,)+)>>
+            for ($($F,)+)
         where
-            $($F: MutateChainLink<$M>,)+
+            $($F: MutateChainLink<State, $M>,)+
         {
             fn try_mutate(
                 &self,
                 value: &MapValue,
-                mutator: &MutatorRef<'_>,
+                context: &mut MutateContext<'_, State>,
             ) -> Option<MapResult> {
                 $(
-                    if let Some(result) = self.$idx.try_mutate(value, mutator) {
+                    if let Some(result) = self.$idx.try_mutate(value, context) {
                         return Some(result);
                     }
                 )+
@@ -350,10 +434,81 @@ macro_rules! impl_mutate_chain_link {
 
 impl_callback_chain_tuple_arities!(impl_mutate_chain_link);
 
-struct CallbackMutator<Link, Marker> {
-    link: Link,
-    remap: RefCell<StructuralVarRemap>,
+/// Stateful typed callback mutator.
+///
+/// `callbacks` may be one typed callback or a nested tuple. Every callback
+/// receives the same mutable [`MutateContext`], and therefore the same `State`.
+/// Callback code is stored behind `Rc` so recursive entries can borrow the
+/// mutable mutator while invoking the shared `Fn` independently.
+///
+/// Pass the resulting mutator to [`structural_mutate`] by mutable reference; it
+/// can be reused across mutations and its state remains available through
+/// [`Self::state`] or [`Self::into_state`].
+///
+/// ```
+/// use tvm_ffi::{
+///     structural_mutate, Any, Array, MapValue, MutateCallbacks, MutateContext, Result,
+/// };
+///
+/// #[derive(Default)]
+/// struct Stats {
+///     integers: usize,
+/// }
+///
+/// fn mutate_integer(value: i64, context: &mut MutateContext<'_, Stats>) -> Any {
+///     context.state_mut().integers += 1;
+///     Any::from(value + 1)
+/// }
+///
+/// fn mutate_any(
+///     _value: &MapValue,
+///     context: &mut MutateContext<'_, Stats>,
+/// ) -> Result<Any> {
+///     context.default_mutate()
+/// }
+///
+/// let root = Array::new(vec![1_i64, 2]);
+/// let mut mutator = MutateCallbacks::new(Stats::default(), (mutate_integer, mutate_any));
+/// let mapped = structural_mutate(root, &mut mutator).unwrap();
+/// let mapped = Array::<i64>::try_from(mapped).unwrap();
+/// assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![2, 3]);
+/// assert_eq!(mutator.state().integers, 2);
+/// ```
+pub struct MutateCallbacks<State, Link, Marker> {
+    state: State,
+    callbacks: Rc<Link>,
     _marker: PhantomData<fn(Marker)>,
+}
+
+impl<State, Link, Marker> MutateCallbacks<State, Link, Marker>
+where
+    Link: MutateChainLink<State, Marker>,
+{
+    /// Construct a stateful callback mutator.
+    pub fn new(state: State, callbacks: Link) -> Self {
+        Self {
+            state,
+            callbacks: Rc::new(callbacks),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<State, Link, Marker> MutateCallbacks<State, Link, Marker> {
+    /// Shared access to the callback state.
+    pub fn state(&self) -> &State {
+        &self.state
+    }
+
+    /// Mutable access to callback state outside an active recursive call.
+    pub fn state_mut(&mut self) -> &mut State {
+        &mut self.state
+    }
+
+    /// Consume the mutator and return its state.
+    pub fn into_state(self) -> State {
+        self.state
+    }
 }
 
 #[doc(hidden)]
@@ -361,15 +516,11 @@ pub struct ByMutateCallbacks<Marker>(PhantomData<fn(Marker)>);
 
 impl<Link, Marker> IntoMutator<ByMutateCallbacks<Marker>> for Link
 where
-    Link: MutateChainLink<Marker>,
+    Link: MutateChainLink<(), Marker>,
 {
     fn mutate_root(self, root: Any) -> Result<Any> {
-        let mutator: CallbackMutator<Link, Marker> = CallbackMutator {
-            link: self,
-            remap: RefCell::new(StructuralVarRemap::default()),
-            _marker: PhantomData,
-        };
-        run_shared_structural_mutator(root, &mutator, callback_runtime_callbacks::<Link, Marker>())
+        let mut mutator = MutateCallbacks::<(), Link, Marker>::new((), self);
+        run_structural_mutator(root, &mut mutator)
     }
 }
 
@@ -916,6 +1067,91 @@ pub trait StructuralMutator: Sized {
     }
 }
 
+impl<State, Link, Marker> MutateCallbacks<State, Link, Marker>
+where
+    Link: MutateChainLink<State, Marker>,
+{
+    fn try_callbacks(
+        &mut self,
+        value: &MapValue,
+        def_region_kind: DefRegionKind,
+    ) -> Option<MapResult> {
+        // Clone the pointer, not the callback state. The callback allocation
+        // is then independent from the mutable borrow placed in `context`, so
+        // recursive entries can invoke the same `Fn` through a checked reborrow
+        // of this mutator.
+        let callbacks = Rc::clone(&self.callbacks);
+        let mut context = MutateContext {
+            driver: self,
+            current: MapValue::from_raw(value.raw()),
+            def_region_kind,
+            _not_send_sync: PhantomData,
+        };
+        callbacks.try_mutate(value, &mut context)
+    }
+}
+
+impl<State, Link, Marker> StructuralMutator for MutateCallbacks<State, Link, Marker>
+where
+    Link: MutateChainLink<State, Marker>,
+{
+    fn mutate(&mut self, value: &MapValue, def_region_kind: DefRegionKind) -> Result<Any> {
+        match self.try_callbacks(value, def_region_kind) {
+            Some(result) => result,
+            None => self.default_mutate(value, def_region_kind),
+        }
+    }
+
+    fn maybe_inplace_mutate(
+        &mut self,
+        value: InplaceValue<'_>,
+        def_region_kind: DefRegionKind,
+    ) -> Result<Any> {
+        match self.try_callbacks(value.as_value(), def_region_kind) {
+            Some(result) => result,
+            None => self.default_maybe_inplace_mutate(value, def_region_kind),
+        }
+    }
+}
+
+impl<State, Link, Marker> MutateContextDriver<State> for MutateCallbacks<State, Link, Marker>
+where
+    Link: MutateChainLink<State, Marker>,
+{
+    fn state(&self) -> &State {
+        &self.state
+    }
+
+    fn state_mut(&mut self) -> &mut State {
+        &mut self.state
+    }
+
+    fn mutate_raw(
+        &mut self,
+        raw: TVMFFIAny,
+        def_region_kind: DefRegionKind,
+        permit: Permit,
+    ) -> Result<Any> {
+        dispatch_user_raw(self, raw, def_region_kind, permit)
+    }
+
+    fn default_mutate_raw(
+        &mut self,
+        raw: TVMFFIAny,
+        def_region_kind: DefRegionKind,
+    ) -> Result<Any> {
+        default_mutate_driver(self, raw, def_region_kind, Permit::Copy)
+    }
+
+    fn var_remap_get_raw(&mut self, raw: TVMFFIAny) -> Result<Option<Any>> {
+        <Self as StructuralMutator>::var_remap_get(self, &MapValue::from_raw(raw))
+    }
+
+    fn var_remap_set_raw(&mut self, raw: TVMFFIAny, mapped_value: &Any) -> Result<()> {
+        <Self as StructuralMutator>::var_remap_set(self, &MapValue::from_raw(raw), mapped_value)
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Permit {
     Copy,
@@ -1249,7 +1485,7 @@ struct RuntimeMutatorCallbacks {
 /// Active Rust mutator with the exact C++ `StructuralMutatorObj` prefix.
 ///
 /// C++ type hooks read `vtable` and `def_region_mode`; Rust keeps its erased
-/// callback state after that shared prefix.
+/// driver state after that shared prefix.
 #[repr(C)]
 struct RuntimeStructuralMutatorObj {
     base: Object,
@@ -1330,14 +1566,14 @@ impl Drop for RuntimeContextGuard {
     }
 }
 
-/// Temporarily take the erased callback context out of the runtime object.
+/// Temporarily take the erased driver context out of the runtime object.
 ///
 /// # Safety
 ///
 /// `mutator` must be null or point to a live [`RuntimeStructuralMutatorObj`].
-/// A non-null context must have been installed by the current run. Its callback
-/// table must reconstruct it according to that run's mutable-driver or
-/// shared-callback contract.
+/// A non-null context must have been installed by the current run. Its runtime
+/// callback table must reconstruct it according to that run's mutable-driver
+/// contract.
 unsafe fn take_runtime_context(mutator: StructuralMutatorHandle) -> Result<RuntimeContextGuard> {
     if !is_active_mutator(mutator) {
         return Err(inactive_mutator_error(mutator, "callback"));
@@ -1352,7 +1588,7 @@ unsafe fn take_runtime_context(mutator: StructuralMutatorHandle) -> Result<Runti
         return Err(runtime_error(message));
     }
     // No raw context pointer remains callable while Rust executes the selected
-    // mutable-driver or shared-callback entry.
+    // mutable-driver entry.
     (*mutator).context = std::ptr::null_mut();
     Ok(RuntimeContextGuard { mutator, context })
 }
@@ -1559,17 +1795,6 @@ fn with_current_driver_context<D, T>(
     callback: impl FnOnce() -> Result<T>,
 ) -> Result<T> {
     let context = std::ptr::from_mut(driver).cast::<c_void>();
-    with_current_mutator_context(mutator, context, callback)
-}
-
-/// Expose an already validated mutable or shared callback context for one
-/// registered hook/vtable call. Callers determine whether the pointer may be
-/// reconstructed as `&mut D` or only `&D`; this helper never dereferences it.
-fn with_current_mutator_context<T>(
-    mutator: StructuralMutatorHandle,
-    context: *mut c_void,
-    callback: impl FnOnce() -> Result<T>,
-) -> Result<T> {
     if !is_active_mutator(mutator) {
         return Err(inactive_mutator_error(mutator, "helper"));
     }
@@ -1657,118 +1882,6 @@ impl<U: StructuralMutator> MutationDriver for U {
     }
 }
 
-/// Thin driver used by callback-backed mutation. It owns no callback state;
-/// every recursive entry exposes the original shared context and the runtime
-/// callback table reconstructs only `&CallbackMutator` from that pointer.
-struct SharedMutationDriver {
-    active: StructuralMutatorHandle,
-    context: *mut c_void,
-}
-
-impl MutationDriver for SharedMutationDriver {
-    fn dispatch_raw(
-        &mut self,
-        raw: TVMFFIAny,
-        def_region_kind: DefRegionKind,
-        permit: Permit,
-    ) -> Result<Any> {
-        with_current_mutator_context(self.active, self.context, || {
-            call_mutator(self.active, raw, def_region_kind, permit)
-        })
-    }
-
-    fn var_remap_get_raw(&mut self, raw: TVMFFIAny) -> Result<Option<Any>> {
-        let callback = unsafe { (*self.active).callbacks.var_remap_get };
-        unsafe { callback(self.context, raw) }
-    }
-
-    fn var_remap_set_raw(&mut self, raw: TVMFFIAny, mapped_value: &Any) -> Result<()> {
-        let callback = unsafe { (*self.active).callbacks.var_remap_set };
-        unsafe { callback(self.context, raw, mapped_value) }
-    }
-
-    fn call_registered_hook(
-        &mut self,
-        raw: TVMFFIAny,
-        def_region_kind: DefRegionKind,
-        permit: Permit,
-    ) -> Result<Option<Any>> {
-        with_current_mutator_context(self.active, self.context, || {
-            call_registered_structural_mutate(self.active, raw, def_region_kind, permit)
-        })
-    }
-}
-
-fn callback_runtime_callbacks<Link, Marker>() -> RuntimeMutatorCallbacks
-where
-    Link: MutateChainLink<Marker>,
-{
-    RuntimeMutatorCallbacks {
-        mutate: runtime_callback_mutate::<Link, Marker>,
-        var_remap_get: runtime_callback_var_remap_get::<Link, Marker>,
-        var_remap_set: runtime_callback_var_remap_set::<Link, Marker>,
-    }
-}
-
-unsafe fn runtime_callback_mutate<Link, Marker>(
-    context: *mut c_void,
-    raw: TVMFFIAny,
-    def_region_kind: DefRegionKind,
-    permit: Permit,
-) -> Result<Any>
-where
-    Link: MutateChainLink<Marker>,
-{
-    // SAFETY: callback-backed runs install a pointer derived from a shared
-    // `CallbackMutator`. All recursive entries reconstruct only a shared
-    // reference, so an `Fn` callback may soundly re-enter itself.
-    let callback = &*context.cast::<CallbackMutator<Link, Marker>>();
-    let active = active_mutator()?;
-    let mutator = MutatorRef {
-        mutator: active,
-        context,
-        current: raw,
-        def_region_kind,
-        _lifetime: PhantomData,
-    };
-    let result = match callback.link.try_mutate(&MapValue::from_raw(raw), &mutator) {
-        Some(result) => result,
-        None => default_mutate_driver(
-            &mut SharedMutationDriver { active, context },
-            raw,
-            def_region_kind,
-            permit,
-        ),
-    };
-    result.map_err(|error| with_value_context(error, raw))
-}
-
-unsafe fn runtime_callback_var_remap_get<Link, Marker>(
-    context: *mut c_void,
-    raw: TVMFFIAny,
-) -> Result<Option<Any>>
-where
-    Link: MutateChainLink<Marker>,
-{
-    let callback = &*context.cast::<CallbackMutator<Link, Marker>>();
-    callback.remap.borrow().get(&MapValue::from_raw(raw))
-}
-
-unsafe fn runtime_callback_var_remap_set<Link, Marker>(
-    context: *mut c_void,
-    raw: TVMFFIAny,
-    mapped_value: &Any,
-) -> Result<()>
-where
-    Link: MutateChainLink<Marker>,
-{
-    let callback = &*context.cast::<CallbackMutator<Link, Marker>>();
-    callback
-        .remap
-        .borrow_mut()
-        .set(&MapValue::from_raw(raw), mapped_value)
-}
-
 /// Invoke the concrete Rust driver selected when the runtime mutator was built.
 ///
 /// # Safety
@@ -1817,17 +1930,6 @@ fn run_structural_mutator<D: MutationDriver>(root: Any, driver: &mut D) -> Resul
         var_remap_get: runtime_var_remap_get::<D>,
         var_remap_set: runtime_var_remap_set::<D>,
     };
-    run_structural_mutator_with_context(root, context, callbacks)
-}
-
-fn run_shared_structural_mutator<D>(
-    root: Any,
-    driver: &D,
-    callbacks: RuntimeMutatorCallbacks,
-) -> Result<Any> {
-    // The ABI field is mutable for the hand-written mutator path, but the
-    // callback table supplied here must reconstruct only shared references.
-    let context = std::ptr::from_ref(driver).cast_mut().cast::<c_void>();
     run_structural_mutator_with_context(root, context, callbacks)
 }
 
@@ -2082,9 +2184,9 @@ fn default_mutate_driver<D: MutationDriver>(
 /// in-place mutation. Completed in-place changes are not rolled back on an
 /// error, and an error does not return the consumed root. Passing `&mut U` for
 /// `U: StructuralMutator` preserves the low-level API. A typed `Fn(value,
-/// &MutatorRef)` callback or callback tuple builds a temporary mutator. The
-/// first matching callback supplies the final value; unmatched values use
-/// default mutation with the current in-place permit.
+/// &mut MutateContext<'_, ()>)` callback or callback tuple builds a temporary
+/// mutator. The first matching callback supplies the final value; unmatched
+/// values use default mutation with the current in-place permit.
 pub fn structural_mutate<R, M>(root: R, mutator: impl IntoMutator<M>) -> Result<Any>
 where
     R: Into<Any>,

--- a/rust/tvm-ffi/src/extra/structural_mutate.rs
+++ b/rust/tvm-ffi/src/extra/structural_mutate.rs
@@ -19,27 +19,8 @@
 
 //! Native Rust structural mutation and mapping.
 //!
-//! Two public layers share the same runtime mutation protocol:
-//!
-//! * [`StructuralMutator`] + [`structural_mutate`] let the mutator drive
-//!   recursion. `#[dispatch(mutate)]` generates this trait from typed
-//!   `mutate_*` methods. `structural_mutate` also accepts a typed callback or
-//!   callback tuple; matched callbacks receive a [`MutateContext`] for state
-//!   and explicit recursion.
-//! * [`MapDispatch`] + [`structural_map`] provide ordered pre/post-order
-//!   replacement callbacks while the engine owns recursion. `#[dispatch(map)]`
-//!   generates this layer from typed `map_*` methods.
-//!
-//! The root is consumed so Rust ownership and the runtime strong count jointly
-//! define the boundary for optional in-place container mutation. Passing a
-//! clone naturally selects copy-on-write behavior.
-//!
-//! Rust owns callback dispatch, memoization, and identity remapping. Default
-//! recursion follows the shared structural-mutation ABI: each runtime type's
-//! registered `__s_mutate__` or `__s_maybe_inplace_mutate__` hook receives the
-//! active Rust-backed mutator and re-enters Rust through its vtable for child
-//! values. This keeps container storage and type-specific behavior in the
-//! implementation that registered the hook.
+//! [`structural_mutate`] lets a mutator drive recursion, while
+//! [`structural_map`] applies callbacks around engine-owned recursion.
 
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
@@ -81,10 +62,7 @@ const SHALLOW_COPY_ATTR: &str = "__ffi_shallow_copy__";
 const FLAG_SEQ_HASH_IGNORE: i64 = kTVMFFIFieldFlagBitMaskSEqHashIgnore as i64;
 const FLAG_SETTER_IS_FUNCTION: i64 = kTVMFFIFieldFlagBitSetterIsFunctionObj as i64;
 
-/// Borrowed value passed to structural-map callbacks.
-///
-/// Structural visit and map callbacks share the same audited implementation
-/// for typed casts and borrowed node checks.
+/// Borrowed value passed to structural map and mutation callbacks.
 pub use super::structural_common::StructuralValue as MapValue;
 
 /// Result type produced by a structural-map callback.
@@ -110,19 +88,10 @@ impl IntoMapResult for Result<Any> {
     }
 }
 
-/// Mutable callback context for a stateful structural mutator.
+/// State and recursive operations available to a mutation callback.
 ///
-/// A matched callback owns mutation of its value. Use [`Self::mutate`] for a
-/// borrowed child, [`Self::maybe_inplace_mutate`] for an owned child, or
-/// [`Self::default_mutate`] to apply the current value's default mutation.
-/// Mutable user state lives in [`MutateCallbacks`] and is available through
-/// [`Self::state`] and [`Self::state_mut`].
-///
-/// Recursive operations take `&mut self`. This makes each recursive entry a
-/// checked reborrow of the complete mutation context: Rust rejects a state
-/// borrow that remains live across a recursive mutation. The context is valid
-/// only for the callback invocation in which it was received and cannot be
-/// sent or shared across threads.
+/// A matched callback owns mutation of its value. Recursive operations
+/// reborrow the mutator, so mutable state cannot remain borrowed across them.
 pub struct MutateContext<'a, State> {
     driver: &'a mut dyn MutateContextDriver<State>,
     current: MapValue,
@@ -130,8 +99,6 @@ pub struct MutateContext<'a, State> {
     _not_send_sync: PhantomData<Rc<()>>,
 }
 
-/// Object-safe bridge that lets `MutateContext<State>` reborrow a concrete
-/// `MutateCallbacks<State, ..>` without exposing its callback types.
 trait MutateContextDriver<State> {
     fn state(&self) -> &State;
     fn state_mut(&mut self) -> &mut State;
@@ -144,7 +111,7 @@ trait MutateContextDriver<State> {
     fn default_mutate_raw(&mut self, raw: TVMFFIAny, def_region_kind: DefRegionKind)
         -> Result<Any>;
     fn var_remap_get_raw(&mut self, raw: TVMFFIAny) -> Result<Option<Any>>;
-    fn var_remap_set_raw(&mut self, raw: TVMFFIAny, mapped_value: &Any) -> Result<()>;
+    fn var_remap_set_raw(&mut self, raw: TVMFFIAny, mutated_value: &Any) -> Result<()>;
 }
 
 impl<State> MutateContext<'_, State> {
@@ -154,32 +121,6 @@ impl<State> MutateContext<'_, State> {
     }
 
     /// Mutably borrow the user state.
-    ///
-    /// The returned borrow must end before a recursive context method is
-    /// called. The borrow checker enforces this when the borrow is used after
-    /// that call.
-    ///
-    /// ```compile_fail
-    /// use tvm_ffi::{Any, MapValue, MutateCallbacks, MutateContext, Result};
-    ///
-    /// #[derive(Default)]
-    /// struct Stats {
-    ///     calls: usize,
-    /// }
-    ///
-    /// fn mutate_any(
-    ///     _value: &MapValue,
-    ///     context: &mut MutateContext<'_, Stats>,
-    /// ) -> Result<Any> {
-    ///     let calls = &mut context.state_mut().calls;
-    ///     *calls += 1;
-    ///     let result = context.default_mutate();
-    ///     *calls += 1; // `calls` cannot stay borrowed across recursion.
-    ///     result
-    /// }
-    ///
-    /// let _mutator = MutateCallbacks::new(Stats::default(), mutate_any);
-    /// ```
     pub fn state_mut(&mut self) -> &mut State {
         self.driver.state_mut()
     }
@@ -248,35 +189,15 @@ impl<State> MutateContext<'_, State> {
     }
 
     /// Store an invocation-local identity substitution.
-    pub fn var_remap_set(&mut self, var: &MapValue, mapped_value: &Any) -> Result<()> {
-        self.driver.var_remap_set_raw(var.raw(), mapped_value)
+    pub fn var_remap_set(&mut self, var: &MapValue, mutated_value: &Any) -> Result<()> {
+        self.driver.var_remap_set_raw(var.raw(), mutated_value)
     }
 }
 
 /// Conversion into the mutator argument accepted by [`structural_mutate`].
 ///
-/// Supported inputs are `&mut U` for a hand-written [`StructuralMutator`], a
-/// typed `Fn(value, &mut MutateContext<'_, ()>)` callback, or a tuple of such
-/// callbacks. A callback chain uses first-match dispatch; unmatched values use
-/// default mutation. Use [`MutateCallbacks`] to give a callback chain ordinary
-/// mutable state.
-///
-/// Callback code still implements `Fn`, because recursive context methods may
-/// re-enter the same callback. All mutation instead goes through the single
-/// `&mut MutateContext`, so recursive calls are ordinary checked reborrows.
-///
-/// A closure that mutates captured state directly is therefore rejected:
-///
-/// ```compile_fail
-/// use tvm_ffi::{structural_mutate, Any, MutateContext};
-///
-/// let mut calls = 0_usize;
-/// structural_mutate(1_i64, |value: i64, _context: &mut MutateContext<'_, ()>| {
-///     calls += 1;
-///     Any::from(value)
-/// })
-/// .unwrap();
-/// ```
+/// Accepts a mutable [`StructuralMutator`] or a first-match callback chain.
+/// Use [`MutateCallbacks`] when the chain needs mutable state.
 #[diagnostic::on_unimplemented(
     message = "`{Self}` is not a supported `structural_mutate` mutator",
     note = "accepted mutators: `&mut U` where `U: StructuralMutator`; an `Fn` callback over an FFI value type `T`, `&N` of an object node type, or `&MapValue`, followed by `&mut MutateContext<'_, ()>`; or a tuple of up to 12 such callbacks (tuples may nest)",
@@ -293,45 +214,66 @@ impl<U: StructuralMutator> IntoMutator<U> for &mut U {
     }
 }
 
+/// Convert a mutation callback result into [`Result<Any>`].
+#[doc(hidden)]
+pub trait IntoMutateResult {
+    fn into_mutate_result(self) -> Result<Any>;
+}
+
+impl IntoMutateResult for Any {
+    fn into_mutate_result(self) -> Result<Any> {
+        Ok(self)
+    }
+}
+
+impl IntoMutateResult for Result<Any> {
+    fn into_mutate_result(self) -> Result<Any> {
+        self
+    }
+}
+
+#[doc(hidden)]
+pub type MutateResult = Result<Any>;
+
 /// One typed callback in a callback-driven structural mutator.
 pub trait MutateChainLink<State, Marker>: mutate_sealed::SealedLink<State, Marker> {
     #[doc(hidden)]
     fn try_mutate(
         &self,
         value: &MapValue,
-        context: &mut MutateContext<'_, State>,
-    ) -> Option<MapResult>;
+        mutator: &mut MutateContext<'_, State>,
+    ) -> Option<MutateResult>;
 }
 
 mod mutate_sealed {
-    use super::{IntoMapResult, MapValue, MutateContext, ObjectCore};
+    use super::{IntoMutateResult, MapValue, MutateContext, ObjectCore};
 
     pub trait SealedLink<State, Marker> {}
 
     impl<F, State, T, O> SealedLink<State, super::ByMutateOwned<T>> for F
     where
-        F: for<'context, 'driver> Fn(T, &'context mut MutateContext<'driver, State>) -> O,
-        O: IntoMapResult,
+        F: for<'mutator, 'driver> Fn(T, &'mutator mut MutateContext<'driver, State>) -> O,
+        O: IntoMutateResult,
     {
     }
 
     impl<F, State, N: ObjectCore, O> SealedLink<State, super::ByMutateNode<N>> for F
     where
-        F: for<'value, 'context, 'driver> Fn(
+        F: for<'value, 'mutator, 'driver> Fn(
             &'value N,
-            &'context mut MutateContext<'driver, State>,
+            &'mutator mut MutateContext<'driver, State>,
         ) -> O,
-        O: IntoMapResult,
+        O: IntoMutateResult,
     {
     }
 
     impl<F, State, O> SealedLink<State, super::ByMutateCatchAll> for F
     where
-        F: for<'value, 'context, 'driver> Fn(
+        F: for<'value, 'mutator, 'driver> Fn(
             &'value MapValue,
-            &'context mut MutateContext<'driver, State>,
+            &'mutator mut MutateContext<'driver, State>,
         ) -> O,
-        O: IntoMapResult,
+        O: IntoMutateResult,
     {
     }
 }
@@ -341,18 +283,18 @@ pub struct ByMutateOwned<T>(PhantomData<T>);
 
 impl<F, State, T, O> MutateChainLink<State, ByMutateOwned<T>> for F
 where
-    F: for<'context, 'driver> Fn(T, &'context mut MutateContext<'driver, State>) -> O,
+    F: for<'mutator, 'driver> Fn(T, &'mutator mut MutateContext<'driver, State>) -> O,
     T: crate::type_traits::AnyCompatible,
-    O: IntoMapResult,
+    O: IntoMutateResult,
 {
     fn try_mutate(
         &self,
         value: &MapValue,
-        context: &mut MutateContext<'_, State>,
-    ) -> Option<MapResult> {
+        mutator: &mut MutateContext<'_, State>,
+    ) -> Option<MutateResult> {
         value
             .cast::<T>()
-            .map(|typed| self(typed, context).into_map_result())
+            .map(|typed| self(typed, mutator).into_mutate_result())
     }
 }
 
@@ -361,21 +303,21 @@ pub struct ByMutateNode<N>(PhantomData<N>);
 
 impl<F, State, N, O> MutateChainLink<State, ByMutateNode<N>> for F
 where
-    F: for<'value, 'context, 'driver> Fn(
+    F: for<'value, 'mutator, 'driver> Fn(
         &'value N,
-        &'context mut MutateContext<'driver, State>,
+        &'mutator mut MutateContext<'driver, State>,
     ) -> O,
     N: ObjectCore,
-    O: IntoMapResult,
+    O: IntoMutateResult,
 {
     fn try_mutate(
         &self,
         value: &MapValue,
-        context: &mut MutateContext<'_, State>,
-    ) -> Option<MapResult> {
+        mutator: &mut MutateContext<'_, State>,
+    ) -> Option<MutateResult> {
         value
             .as_node::<N>()
-            .map(|node| self(node, context).into_map_result())
+            .map(|node| self(node, mutator).into_mutate_result())
     }
 }
 
@@ -384,18 +326,18 @@ pub enum ByMutateCatchAll {}
 
 impl<F, State, O> MutateChainLink<State, ByMutateCatchAll> for F
 where
-    F: for<'value, 'context, 'driver> Fn(
+    F: for<'value, 'mutator, 'driver> Fn(
         &'value MapValue,
-        &'context mut MutateContext<'driver, State>,
+        &'mutator mut MutateContext<'driver, State>,
     ) -> O,
-    O: IntoMapResult,
+    O: IntoMutateResult,
 {
     fn try_mutate(
         &self,
         value: &MapValue,
-        context: &mut MutateContext<'_, State>,
-    ) -> Option<MapResult> {
-        Some(self(value, context).into_map_result())
+        mutator: &mut MutateContext<'_, State>,
+    ) -> Option<MutateResult> {
+        Some(self(value, mutator).into_mutate_result())
     }
 }
 
@@ -419,10 +361,10 @@ macro_rules! impl_mutate_chain_link {
             fn try_mutate(
                 &self,
                 value: &MapValue,
-                context: &mut MutateContext<'_, State>,
-            ) -> Option<MapResult> {
+                mutator: &mut MutateContext<'_, State>,
+            ) -> Option<MutateResult> {
                 $(
-                    if let Some(result) = self.$idx.try_mutate(value, context) {
+                    if let Some(result) = self.$idx.try_mutate(value, mutator) {
                         return Some(result);
                     }
                 )+
@@ -434,46 +376,7 @@ macro_rules! impl_mutate_chain_link {
 
 impl_callback_chain_tuple_arities!(impl_mutate_chain_link);
 
-/// Stateful typed callback mutator.
-///
-/// `callbacks` may be one typed callback or a nested tuple. Every callback
-/// receives the same mutable [`MutateContext`], and therefore the same `State`.
-/// Callback code is stored behind `Rc` so recursive entries can borrow the
-/// mutable mutator while invoking the shared `Fn` independently.
-///
-/// Pass the resulting mutator to [`structural_mutate`] by mutable reference; it
-/// can be reused across mutations and its state remains available through
-/// [`Self::state`] or [`Self::into_state`].
-///
-/// ```
-/// use tvm_ffi::{
-///     structural_mutate, Any, Array, MapValue, MutateCallbacks, MutateContext, Result,
-/// };
-///
-/// #[derive(Default)]
-/// struct Stats {
-///     integers: usize,
-/// }
-///
-/// fn mutate_integer(value: i64, context: &mut MutateContext<'_, Stats>) -> Any {
-///     context.state_mut().integers += 1;
-///     Any::from(value + 1)
-/// }
-///
-/// fn mutate_any(
-///     _value: &MapValue,
-///     context: &mut MutateContext<'_, Stats>,
-/// ) -> Result<Any> {
-///     context.default_mutate()
-/// }
-///
-/// let root = Array::new(vec![1_i64, 2]);
-/// let mut mutator = MutateCallbacks::new(Stats::default(), (mutate_integer, mutate_any));
-/// let mapped = structural_mutate(root, &mut mutator).unwrap();
-/// let mapped = Array::<i64>::try_from(mapped).unwrap();
-/// assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![2, 3]);
-/// assert_eq!(mutator.state().integers, 2);
-/// ```
+/// A reusable callback mutator with shared user state.
 pub struct MutateCallbacks<State, Link, Marker> {
     state: State,
     callbacks: Rc<Link>,
@@ -573,16 +476,8 @@ impl<'a, V: MapDispatch> IntoMapper<ByMapDispatch> for &'a mut V {
 
 /// One typed callback in a structural-map tuple.
 ///
-/// Links are tried in tuple order and the first matching link supplies the
-/// replacement.  Supported shapes are owned FFI values, borrowed object
-/// nodes, and `&MapValue`, each optionally followed by [`DefRegionKind`].
-/// A tuple of links is itself a link, so tuples nest: a flat tuple holds up
-/// to 12 links, and nesting — `(a, b, (c, d, ...), e)` — lifts that cap
-/// without changing order, which stays the flattened depth-first,
-/// left-to-right order.
-/// Numeric links match the complete FFI `Int` or `Float` type tag and then use
-/// Rust `as` conversion semantics, so prefer `i64` and `f64` unless narrowing
-/// is intentional.
+/// Links use first-match order and may receive an owned FFI value, borrowed
+/// object node, or `&MapValue`, optionally followed by [`DefRegionKind`].
 pub trait MapChainLink<Marker>: sealed_map::SealedMapLink<Marker> {
     #[doc(hidden)]
     fn try_map(&mut self, value: &MapValue, def_region_kind: DefRegionKind) -> Option<MapResult>;
@@ -745,8 +640,7 @@ impl<V: MapDispatch> MapChainLink<ByMapDispatchLink> for &mut V {
     }
 }
 
-/// Statically dispatched mapper over one [`MapChainLink`] — a bare closure
-/// or a tuple of links — public only as an [`IntoMapper`] projection.
+/// Adapter from a [`MapChainLink`] to [`MapDispatch`].
 #[doc(hidden)]
 pub struct MapChain<Link, Marker> {
     link: Link,
@@ -777,11 +671,6 @@ where
     }
 }
 
-// A tuple of links is itself a link, tried in order with the first match
-// winning. Tuples therefore nest: the 12-wide flat arity cap becomes a
-// per-level cap and the total chain length is unbounded. Nesting does not
-// change order: links run in depth-first, left-to-right order, i.e. the
-// flattened order.
 macro_rules! impl_map_chain_link {
     ($(($F:ident, $M:ident, $idx:tt)),+) => {
         impl<$($F, $M,)+> sealed_map::SealedMapLink<ByMapChainLink<($($M,)+)>> for ($($F,)+)
@@ -880,12 +769,7 @@ where
 
 /// Engine-issued permission to attempt in-place mutation of one value.
 ///
-/// This capability cannot be constructed by callers. The native recursion
-/// engine issues it only when the parent path permits mutation and the object
-/// is uniquely owned at dispatch time. It is deliberately distinct from
-/// [`MapValue`], which can also be obtained from a read-only structural walk.
-/// Implementations should normally inspect it and then call
-/// [`StructuralMutator::default_maybe_inplace_mutate`].
+/// The engine issues it only when the current ownership path permits reuse.
 pub struct InplaceValue<'a> {
     value: MapValue,
     _scope: PhantomData<&'a mut TVMFFIAny>,
@@ -925,14 +809,9 @@ impl Deref for InplaceValue<'_> {
     }
 }
 
-/// Stateful identity-substitution environment for a hand-written
-/// [`StructuralMutator`] that needs a custom remapping policy.
+/// Identity substitutions for a custom [`StructuralMutator`] remapping policy.
 ///
-/// The map owns both its object keys and mapped values, preventing an object
-/// address from being recycled while a mutation is in progress. The default
-/// [`StructuralMutator`] methods use an invocation-local instance managed by
-/// [`structural_mutate`]; an implementation may delegate overridden
-/// `var_remap_get` and `var_remap_set` methods to this type instead.
+/// The map owns its keys and values so object addresses remain stable.
 #[derive(Default)]
 pub struct StructuralVarRemap {
     entries: HashMap<NonNull<TVMFFIObject>, MemoEntry>,
@@ -942,17 +821,17 @@ impl StructuralVarRemap {
     /// Look up an identity replacement previously stored for `var`.
     pub fn get(&self, var: &MapValue) -> Result<Option<Any>> {
         let key = object_identity_key(var.raw())?;
-        Ok(self.entries.get(&key).map(|entry| entry.mapped.clone()))
+        Ok(self.entries.get(&key).map(|entry| entry.result.clone()))
     }
 
-    /// Store the final mapped value for `var`.
-    pub fn set(&mut self, var: &MapValue, mapped_value: &Any) -> Result<()> {
+    /// Store the final mutated value for `var`.
+    pub fn set(&mut self, var: &MapValue, mutated_value: &Any) -> Result<()> {
         let key = object_identity_key(var.raw())?;
         self.entries.insert(
             key,
             MemoEntry {
                 _original: var.to_owned(),
-                mapped: mapped_value.clone(),
+                result: mutated_value.clone(),
             },
         );
         Ok(())
@@ -964,22 +843,10 @@ impl StructuralVarRemap {
     }
 }
 
-/// User-driven structural mutation, analogous to the low-level C++
-/// `StructuralMutatorObj` API.
+/// A mutator that controls its own recursion.
 ///
-/// [`structural_mutate`] dispatches the root to [`Self::mutate`] or, when
-/// ownership permits, [`Self::maybe_inplace_mutate`]. An implementation
-/// chooses where to recurse by calling `default_*` for the current value or a
-/// child helper for a selected value. Default recursion calls the registered
-/// structural hook for the value's runtime type and uses reflection only when
-/// that type has no hook. A registered hook owns identity remapping for its
-/// type; the reflected fallback uses [`Self::var_remap_get`] and
-/// [`Self::var_remap_set`] automatically.
-///
-/// Use `#[dispatch(mutate)]` on an inherent impl of typed `mutate_*` methods
-/// to generate this trait. A matching generated handler supplies the final
-/// value; values without a matching handler use the appropriate default copy
-/// or in-place path.
+/// Implementations descend with the child or `default_*` helpers.
+/// `#[dispatch(mutate)]` generates this trait from typed `mutate_*` methods.
 pub trait StructuralMutator: Sized {
     /// Mutate one borrowed value without modifying its source storage.
     fn mutate(&mut self, value: &MapValue, def_region_kind: DefRegionKind) -> Result<Any>;
@@ -1049,21 +916,14 @@ pub trait StructuralMutator: Sized {
         user_default_mutate(self, raw, def_region_kind, permit)
     }
 
-    /// Look up a previously completed FreeVar or DAG-node substitution.
-    ///
-    /// The default uses state local to the active [`structural_mutate`]
-    /// invocation, so a mutator does not need to carry a remap field. Override
-    /// this method only to provide a custom identity policy.
+    /// Look up a FreeVar or DAG-node substitution from the active mutation.
     fn var_remap_get(&mut self, var: &MapValue) -> Result<Option<Any>> {
         invocation_var_remap_get(self, var)
     }
 
-    /// Store the final mapped result for a FreeVar or DAG-node identity.
-    ///
-    /// The default writes to the same invocation-local state as
-    /// [`Self::var_remap_get`].
-    fn var_remap_set(&mut self, var: &MapValue, mapped_value: &Any) -> Result<()> {
-        invocation_var_remap_set(self, var, mapped_value)
+    /// Store a FreeVar or DAG-node substitution for the active mutation.
+    fn var_remap_set(&mut self, var: &MapValue, mutated_value: &Any) -> Result<()> {
+        invocation_var_remap_set(self, var, mutated_value)
     }
 }
 
@@ -1075,19 +935,16 @@ where
         &mut self,
         value: &MapValue,
         def_region_kind: DefRegionKind,
-    ) -> Option<MapResult> {
-        // Clone the pointer, not the callback state. The callback allocation
-        // is then independent from the mutable borrow placed in `context`, so
-        // recursive entries can invoke the same `Fn` through a checked reborrow
-        // of this mutator.
+    ) -> Option<MutateResult> {
+        // Clone the handle before `mutator` borrows all of `self`.
         let callbacks = Rc::clone(&self.callbacks);
-        let mut context = MutateContext {
+        let mut mutator = MutateContext {
             driver: self,
             current: MapValue::from_raw(value.raw()),
             def_region_kind,
             _not_send_sync: PhantomData,
         };
-        callbacks.try_mutate(value, &mut context)
+        callbacks.try_mutate(value, &mut mutator)
     }
 }
 
@@ -1147,8 +1004,8 @@ where
         <Self as StructuralMutator>::var_remap_get(self, &MapValue::from_raw(raw))
     }
 
-    fn var_remap_set_raw(&mut self, raw: TVMFFIAny, mapped_value: &Any) -> Result<()> {
-        <Self as StructuralMutator>::var_remap_set(self, &MapValue::from_raw(raw), mapped_value)
+    fn var_remap_set_raw(&mut self, raw: TVMFFIAny, mutated_value: &Any) -> Result<()> {
+        <Self as StructuralMutator>::var_remap_set(self, &MapValue::from_raw(raw), mutated_value)
     }
 }
 
@@ -1162,7 +1019,7 @@ struct MemoEntry {
     // Keeps the pointer-valued key alive so its address cannot be reused
     // during the same mapping invocation.
     _original: Any,
-    mapped: Any,
+    result: Any,
 }
 
 struct NativeMapper<D> {
@@ -1199,7 +1056,7 @@ impl<D: MapDispatch> NativeMapper<D> {
         let identity = identity_key(raw)?;
         if let Some(key) = identity {
             if let Some(entry) = self.memo.get(&key) {
-                return Ok(entry.mapped.clone());
+                return Ok(entry.result.clone());
             }
         }
 
@@ -1221,7 +1078,7 @@ impl<D: MapDispatch> NativeMapper<D> {
                 key,
                 MemoEntry {
                     _original: original,
-                    mapped: result.clone(),
+                    result: result.clone(),
                 },
             );
         }
@@ -1277,7 +1134,7 @@ impl<D: MapDispatch> NativeMapper<D> {
         let identity = identity_key(raw)?;
         if let Some(key) = identity {
             if let Some(entry) = self.memo.get(&key) {
-                return Ok(entry.mapped.clone());
+                return Ok(entry.result.clone());
             }
         }
         let original = identity.map(|_| owned_from_raw(raw)).transpose()?;
@@ -1294,7 +1151,7 @@ impl<D: MapDispatch> NativeMapper<D> {
                 key,
                 MemoEntry {
                     _original: original,
-                    mapped: result.clone(),
+                    result: result.clone(),
                 },
             );
         }
@@ -1314,7 +1171,7 @@ trait MutationDriver: Sized {
 
     fn var_remap_get_raw(&mut self, raw: TVMFFIAny) -> Result<Option<Any>>;
 
-    fn var_remap_set_raw(&mut self, raw: TVMFFIAny, mapped_value: &Any) -> Result<()>;
+    fn var_remap_set_raw(&mut self, raw: TVMFFIAny, replacement: &Any) -> Result<()>;
 
     fn call_registered_hook(
         &mut self,
@@ -1498,9 +1355,7 @@ struct RuntimeStructuralMutatorObj {
     context_identity: *mut c_void,
     owner_thread: std::thread::ThreadId,
     callbacks: RuntimeMutatorCallbacks,
-    // Default identity substitutions belong to one traversal, not to the
-    // user mutator value. This lets generated `#[dispatch(mutate)]` types use
-    // ordinary `&mut self` state without carrying a plumbing-only field.
+    // Identity substitutions for the active traversal.
     remap: RefCell<StructuralVarRemap>,
     panic: Option<Box<dyn std::any::Any + Send>>,
 }
@@ -1654,7 +1509,7 @@ unsafe extern "C" fn rust_vtable_var_remap_get(
     let context = context_guard.context;
     let raw = *var.as_raw_ffi_any();
     match catch_unwind(AssertUnwindSafe(|| callback(context, raw))) {
-        Ok(Ok(Some(mapped))) => Any::into_raw_ffi_any(mapped),
+        Ok(Ok(Some(replacement))) => Any::into_raw_ffi_any(replacement),
         Ok(Ok(None)) => TVMFFIAny::new(),
         Ok(Err(error)) => result_into_raw(Err(error)),
         Err(payload) => {
@@ -1667,7 +1522,7 @@ unsafe extern "C" fn rust_vtable_var_remap_get(
 unsafe extern "C" fn rust_vtable_var_remap_set(
     mutator: StructuralMutatorHandle,
     var: AnyView<'static>,
-    mapped_value: AnyView<'static>,
+    replacement: AnyView<'static>,
 ) -> TVMFFIAny {
     let context_guard = match take_runtime_context(mutator) {
         Ok(guard) => guard,
@@ -1676,10 +1531,10 @@ unsafe extern "C" fn rust_vtable_var_remap_set(
     let callback = (*mutator).callbacks.var_remap_set;
     let context = context_guard.context;
     let var_raw = *var.as_raw_ffi_any();
-    let mapped_raw = *mapped_value.as_raw_ffi_any();
+    let replacement_raw = *replacement.as_raw_ffi_any();
     match catch_unwind(AssertUnwindSafe(|| {
-        let mapped = owned_from_raw(mapped_raw)?;
-        callback(context, var_raw, &mapped)
+        let replacement = owned_from_raw(replacement_raw)?;
+        callback(context, var_raw, &replacement)
     })) {
         Ok(Ok(())) => TVMFFIAny::new(),
         Ok(Err(error)) => result_into_raw(Err(error)),
@@ -1744,7 +1599,7 @@ fn invocation_var_remap_get<U: Sized>(mutator: &mut U, var: &MapValue) -> Result
 fn invocation_var_remap_set<U: Sized>(
     mutator: &mut U,
     var: &MapValue,
-    mapped_value: &Any,
+    mutated_value: &Any,
 ) -> Result<()> {
     let active = active_mutator()?;
     let context = std::ptr::from_mut(mutator).cast::<c_void>();
@@ -1754,7 +1609,7 @@ fn invocation_var_remap_set<U: Sized>(
                 "default structural var-remap used by a non-active mutator",
             ));
         }
-        (*active).remap.borrow_mut().set(var, mapped_value)
+        (*active).remap.borrow_mut().set(var, mutated_value)
     }
 }
 
@@ -1847,16 +1702,16 @@ impl<D: MapDispatch> MutationDriver for NativeMapper<D> {
 
     fn var_remap_get_raw(&mut self, raw: TVMFFIAny) -> Result<Option<Any>> {
         let key = object_identity_key(raw)?;
-        Ok(self.memo.get(&key).map(|entry| entry.mapped.clone()))
+        Ok(self.memo.get(&key).map(|entry| entry.result.clone()))
     }
 
-    fn var_remap_set_raw(&mut self, raw: TVMFFIAny, mapped_value: &Any) -> Result<()> {
+    fn var_remap_set_raw(&mut self, raw: TVMFFIAny, replacement: &Any) -> Result<()> {
         let key = object_identity_key(raw)?;
         self.memo.insert(
             key,
             MemoEntry {
                 _original: owned_from_raw(raw)?,
-                mapped: mapped_value.clone(),
+                result: replacement.clone(),
             },
         );
         Ok(())
@@ -1877,8 +1732,8 @@ impl<U: StructuralMutator> MutationDriver for U {
         self.var_remap_get(&MapValue::from_raw(raw))
     }
 
-    fn var_remap_set_raw(&mut self, raw: TVMFFIAny, mapped_value: &Any) -> Result<()> {
-        self.var_remap_set(&MapValue::from_raw(raw), mapped_value)
+    fn var_remap_set_raw(&mut self, raw: TVMFFIAny, replacement: &Any) -> Result<()> {
+        self.var_remap_set(&MapValue::from_raw(raw), replacement)
     }
 }
 
@@ -1914,13 +1769,13 @@ unsafe fn runtime_var_remap_get<D: MutationDriver>(
 /// # Safety
 ///
 /// `context` must satisfy the same requirements as [`runtime_mutate`], and
-/// `mapped_value` must remain alive for this call.
+/// `replacement` must remain alive for this call.
 unsafe fn runtime_var_remap_set<D: MutationDriver>(
     context: *mut c_void,
     raw: TVMFFIAny,
-    mapped_value: &Any,
+    replacement: &Any,
 ) -> Result<()> {
-    (&mut *context.cast::<D>()).var_remap_set_raw(raw, mapped_value)
+    (&mut *context.cast::<D>()).var_remap_set_raw(raw, replacement)
 }
 
 fn run_structural_mutator<D: MutationDriver>(root: Any, driver: &mut D) -> Result<Any> {
@@ -2157,8 +2012,8 @@ fn default_mutate_driver<D: MutationDriver>(
     // Match C++ DefaultMutateExpected: a registered type hook owns any
     // identity-remap policy for that type. Automatic remapping applies only
     // to the reflected fallback below.
-    if let Some(mapped) = driver.call_registered_hook(raw, def_region_kind, permit)? {
-        return Ok(mapped);
+    if let Some(mutated) = driver.call_registered_hook(raw, def_region_kind, permit)? {
+        return Ok(mutated);
     }
     if raw.type_index < TVMFFITypeIndex::kTVMFFIStaticObjectBegin as i32 {
         return owned_from_raw(raw);
@@ -2166,8 +2021,8 @@ fn default_mutate_driver<D: MutationDriver>(
 
     let remappable = identity_key(raw)?.is_some();
     if remappable {
-        if let Some(mapped) = driver.var_remap_get_raw(raw)? {
-            return Ok(mapped);
+        if let Some(mutated) = driver.var_remap_get_raw(raw)? {
+            return Ok(mutated);
         }
     }
 
@@ -2178,15 +2033,11 @@ fn default_mutate_driver<D: MutationDriver>(
     Ok(result)
 }
 
-/// Mutate a structured value with a user-driven mutator or callback chain.
+/// Mutate a structured value with a mutator or typed callback chain.
 ///
 /// The root is consumed to establish the ownership boundary for optional
-/// in-place mutation. Completed in-place changes are not rolled back on an
-/// error, and an error does not return the consumed root. Passing `&mut U` for
-/// `U: StructuralMutator` preserves the low-level API. A typed `Fn(value,
-/// &mut MutateContext<'_, ()>)` callback or callback tuple builds a temporary
-/// mutator. The first matching callback supplies the final value; unmatched
-/// values use default mutation with the current in-place permit.
+/// in-place mutation. A matching callback supplies the final value; unmatched
+/// values use default mutation.
 pub fn structural_mutate<R, M>(root: R, mutator: impl IntoMutator<M>) -> Result<Any>
 where
     R: Into<Any>,

--- a/rust/tvm-ffi/src/extra/structural_mutate.rs
+++ b/rust/tvm-ffi/src/extra/structural_mutate.rs
@@ -221,12 +221,14 @@ pub trait IntoMutateResult {
 }
 
 impl IntoMutateResult for Any {
+    #[inline]
     fn into_mutate_result(self) -> Result<Any> {
         Ok(self)
     }
 }
 
 impl IntoMutateResult for Result<Any> {
+    #[inline]
     fn into_mutate_result(self) -> Result<Any> {
         self
     }
@@ -414,6 +416,37 @@ impl<State, Link, Marker> MutateCallbacks<State, Link, Marker> {
     }
 }
 
+struct DirectMutateCallbacks<'a, Link, Marker> {
+    state: (),
+    callbacks: &'a Link,
+    _marker: PhantomData<fn(Marker)>,
+}
+
+trait MutateCallbackState<State> {
+    fn callback_state(&self) -> &State;
+    fn callback_state_mut(&mut self) -> &mut State;
+}
+
+impl<State, Link, Marker> MutateCallbackState<State> for MutateCallbacks<State, Link, Marker> {
+    fn callback_state(&self) -> &State {
+        &self.state
+    }
+
+    fn callback_state_mut(&mut self) -> &mut State {
+        &mut self.state
+    }
+}
+
+impl<Link, Marker> MutateCallbackState<()> for DirectMutateCallbacks<'_, Link, Marker> {
+    fn callback_state(&self) -> &() {
+        &self.state
+    }
+
+    fn callback_state_mut(&mut self) -> &mut () {
+        &mut self.state
+    }
+}
+
 #[doc(hidden)]
 pub struct ByMutateCallbacks<Marker>(PhantomData<fn(Marker)>);
 
@@ -422,7 +455,12 @@ where
     Link: MutateChainLink<(), Marker>,
 {
     fn mutate_root(self, root: Any) -> Result<Any> {
-        let mut mutator = MutateCallbacks::<(), Link, Marker>::new((), self);
+        let callbacks = self;
+        let mut mutator = DirectMutateCallbacks::<Link, Marker> {
+            state: (),
+            callbacks: &callbacks,
+            _marker: PhantomData,
+        };
         run_structural_mutator(root, &mut mutator)
     }
 }
@@ -927,25 +965,24 @@ pub trait StructuralMutator: Sized {
     }
 }
 
-impl<State, Link, Marker> MutateCallbacks<State, Link, Marker>
+fn try_mutate_callbacks<State, Link, Marker>(
+    driver: &mut impl MutateContextDriver<State>,
+    callback_ptr: *const Link,
+    value: &MapValue,
+    def_region_kind: DefRegionKind,
+) -> Option<MutateResult>
 where
     Link: MutateChainLink<State, Marker>,
 {
-    fn try_callbacks(
-        &mut self,
-        value: &MapValue,
-        def_region_kind: DefRegionKind,
-    ) -> Option<MutateResult> {
-        // Clone the handle before `mutator` borrows all of `self`.
-        let callbacks = Rc::clone(&self.callbacks);
-        let mut mutator = MutateContext {
-            driver: self,
-            current: MapValue::from_raw(value.raw()),
-            def_region_kind,
-            _not_send_sync: PhantomData,
-        };
-        callbacks.try_mutate(value, &mut mutator)
-    }
+    let mut mutator = MutateContext {
+        driver,
+        current: MapValue::from_raw(value.raw()),
+        def_region_kind,
+        _not_send_sync: PhantomData,
+    };
+    // SAFETY: The owning `Rc` or the direct callback's stack slot remains live
+    // and is never modified through the driver during recursive reentry.
+    unsafe { (&*callback_ptr).try_mutate(value, &mut mutator) }
 }
 
 impl<State, Link, Marker> StructuralMutator for MutateCallbacks<State, Link, Marker>
@@ -953,7 +990,13 @@ where
     Link: MutateChainLink<State, Marker>,
 {
     fn mutate(&mut self, value: &MapValue, def_region_kind: DefRegionKind) -> Result<Any> {
-        match self.try_callbacks(value, def_region_kind) {
+        let callback_ptr = Rc::as_ptr(&self.callbacks);
+        match try_mutate_callbacks::<State, Link, Marker>(
+            self,
+            callback_ptr,
+            value,
+            def_region_kind,
+        ) {
             Some(result) => result,
             None => self.default_mutate(value, def_region_kind),
         }
@@ -964,23 +1007,59 @@ where
         value: InplaceValue<'_>,
         def_region_kind: DefRegionKind,
     ) -> Result<Any> {
-        match self.try_callbacks(value.as_value(), def_region_kind) {
+        let callback_ptr = Rc::as_ptr(&self.callbacks);
+        match try_mutate_callbacks::<State, Link, Marker>(
+            self,
+            callback_ptr,
+            value.as_value(),
+            def_region_kind,
+        ) {
             Some(result) => result,
             None => self.default_maybe_inplace_mutate(value, def_region_kind),
         }
     }
 }
 
-impl<State, Link, Marker> MutateContextDriver<State> for MutateCallbacks<State, Link, Marker>
+impl<Link, Marker> StructuralMutator for DirectMutateCallbacks<'_, Link, Marker>
 where
-    Link: MutateChainLink<State, Marker>,
+    Link: MutateChainLink<(), Marker>,
+{
+    fn mutate(&mut self, value: &MapValue, def_region_kind: DefRegionKind) -> Result<Any> {
+        let callback_ptr = std::ptr::from_ref(self.callbacks);
+        match try_mutate_callbacks::<(), Link, Marker>(self, callback_ptr, value, def_region_kind) {
+            Some(result) => result,
+            None => self.default_mutate(value, def_region_kind),
+        }
+    }
+
+    fn maybe_inplace_mutate(
+        &mut self,
+        value: InplaceValue<'_>,
+        def_region_kind: DefRegionKind,
+    ) -> Result<Any> {
+        let callback_ptr = std::ptr::from_ref(self.callbacks);
+        match try_mutate_callbacks::<(), Link, Marker>(
+            self,
+            callback_ptr,
+            value.as_value(),
+            def_region_kind,
+        ) {
+            Some(result) => result,
+            None => self.default_maybe_inplace_mutate(value, def_region_kind),
+        }
+    }
+}
+
+impl<State, Driver> MutateContextDriver<State> for Driver
+where
+    Driver: StructuralMutator + MutateCallbackState<State>,
 {
     fn state(&self) -> &State {
-        &self.state
+        self.callback_state()
     }
 
     fn state_mut(&mut self) -> &mut State {
-        &mut self.state
+        self.callback_state_mut()
     }
 
     fn mutate_raw(

--- a/rust/tvm-ffi/src/extra/structural_mutate.rs
+++ b/rust/tvm-ffi/src/extra/structural_mutate.rs
@@ -22,10 +22,13 @@
 //! Two public layers share the same runtime mutation protocol:
 //!
 //! * [`StructuralMutator`] + [`structural_mutate`] let the mutator drive
-//!   recursion. `structural_mutate` also accepts a typed callback or callback
-//!   tuple; matched callbacks receive a [`MutatorRef`] for explicit recursion.
+//!   recursion. `#[dispatch(mutate)]` generates this trait from typed
+//!   `mutate_*` methods. `structural_mutate` also accepts a typed callback or
+//!   callback tuple; matched callbacks receive a [`MutatorRef`] for explicit
+//!   recursion.
 //! * [`MapDispatch`] + [`structural_map`] provide ordered pre/post-order
-//!   replacement callbacks while the engine owns recursion.
+//!   replacement callbacks while the engine owns recursion. `#[dispatch(map)]`
+//!   generates this layer from typed `map_*` methods.
 //!
 //! The root is consumed so Rust ownership and the runtime strong count jointly
 //! define the boundary for optional in-place container mutation. Passing a
@@ -772,12 +775,13 @@ impl Deref for InplaceValue<'_> {
 }
 
 /// Stateful identity-substitution environment for a hand-written
-/// [`StructuralMutator`].
+/// [`StructuralMutator`] that needs a custom remapping policy.
 ///
 /// The map owns both its object keys and mapped values, preventing an object
-/// address from being recycled while a mutation is in progress. A mutator
-/// can delegate its required `var_remap_get` and `var_remap_set` methods to
-/// this type.
+/// address from being recycled while a mutation is in progress. The default
+/// [`StructuralMutator`] methods use an invocation-local instance managed by
+/// [`structural_mutate`]; an implementation may delegate overridden
+/// `var_remap_get` and `var_remap_set` methods to this type instead.
 #[derive(Default)]
 pub struct StructuralVarRemap {
     entries: HashMap<NonNull<TVMFFIObject>, MemoEntry>,
@@ -820,6 +824,11 @@ impl StructuralVarRemap {
 /// that type has no hook. A registered hook owns identity remapping for its
 /// type; the reflected fallback uses [`Self::var_remap_get`] and
 /// [`Self::var_remap_set`] automatically.
+///
+/// Use `#[dispatch(mutate)]` on an inherent impl of typed `mutate_*` methods
+/// to generate this trait. A matching generated handler supplies the final
+/// value; values without a matching handler use the appropriate default copy
+/// or in-place path.
 pub trait StructuralMutator: Sized {
     /// Mutate one borrowed value without modifying its source storage.
     fn mutate(&mut self, value: &MapValue, def_region_kind: DefRegionKind) -> Result<Any>;
@@ -890,10 +899,21 @@ pub trait StructuralMutator: Sized {
     }
 
     /// Look up a previously completed FreeVar or DAG-node substitution.
-    fn var_remap_get(&mut self, var: &MapValue) -> Result<Option<Any>>;
+    ///
+    /// The default uses state local to the active [`structural_mutate`]
+    /// invocation, so a mutator does not need to carry a remap field. Override
+    /// this method only to provide a custom identity policy.
+    fn var_remap_get(&mut self, var: &MapValue) -> Result<Option<Any>> {
+        invocation_var_remap_get(self, var)
+    }
 
     /// Store the final mapped result for a FreeVar or DAG-node identity.
-    fn var_remap_set(&mut self, var: &MapValue, mapped_value: &Any) -> Result<()>;
+    ///
+    /// The default writes to the same invocation-local state as
+    /// [`Self::var_remap_get`].
+    fn var_remap_set(&mut self, var: &MapValue, mapped_value: &Any) -> Result<()> {
+        invocation_var_remap_set(self, var, mapped_value)
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -1242,6 +1262,10 @@ struct RuntimeStructuralMutatorObj {
     context_identity: *mut c_void,
     owner_thread: std::thread::ThreadId,
     callbacks: RuntimeMutatorCallbacks,
+    // Default identity substitutions belong to one traversal, not to the
+    // user mutator value. This lets generated `#[dispatch(mutate)]` types use
+    // ordinary `&mut self` state without carrying a plumbing-only field.
+    remap: RefCell<StructuralVarRemap>,
     panic: Option<Box<dyn std::any::Any + Send>>,
 }
 
@@ -1466,6 +1490,36 @@ fn active_mutator() -> Result<StructuralMutatorHandle> {
             Ok(handle)
         }
     })
+}
+
+fn invocation_var_remap_get<U: Sized>(mutator: &mut U, var: &MapValue) -> Result<Option<Any>> {
+    let active = active_mutator()?;
+    let context = std::ptr::from_mut(mutator).cast::<c_void>();
+    unsafe {
+        if (*active).context_identity != context {
+            return Err(runtime_error(
+                "default structural var-remap used by a non-active mutator",
+            ));
+        }
+        (*active).remap.borrow().get(var)
+    }
+}
+
+fn invocation_var_remap_set<U: Sized>(
+    mutator: &mut U,
+    var: &MapValue,
+    mapped_value: &Any,
+) -> Result<()> {
+    let active = active_mutator()?;
+    let context = std::ptr::from_mut(mutator).cast::<c_void>();
+    unsafe {
+        if (*active).context_identity != context {
+            return Err(runtime_error(
+                "default structural var-remap used by a non-active mutator",
+            ));
+        }
+        (*active).remap.borrow_mut().set(var, mapped_value)
+    }
 }
 
 #[inline]
@@ -1790,6 +1844,7 @@ fn run_structural_mutator_with_context(
         context_identity: context,
         owner_thread: std::thread::current().id(),
         callbacks,
+        remap: RefCell::new(StructuralVarRemap::default()),
         panic: None,
     });
     let handle = unsafe { ObjectArc::as_raw_mut(&mut active) };
@@ -1803,8 +1858,10 @@ fn run_structural_mutator_with_context(
     });
     // A structural hook may only use the active mutator synchronously on this
     // thread. Make a retained reference fail instead of exposing a dangling
-    // Rust state pointer.
+    // Rust state pointer. Release invocation-local identity owners here as
+    // well: foreign code may retain the ABI object after the run ends.
     unsafe {
+        (*handle).remap.get_mut().clear();
         (*handle).context = std::ptr::null_mut();
         (*handle).context_identity = std::ptr::null_mut();
     }

--- a/rust/tvm-ffi/src/extra/structural_visit.rs
+++ b/rust/tvm-ffi/src/extra/structural_visit.rs
@@ -210,11 +210,12 @@ pub use super::dispatch::{ByDispatch, DispatchVisitor, VisitDispatch};
 ///   `FnMut(&VisitValue)`, typed `FnMut(T)`, node `FnMut(&N)`, each with an
 ///   optional trailing [`DefRegionKind`] argument — the analog of a single
 ///   C++ callback. Values a typed closure does not match advance normally.
-/// * A tuple of typed links `(link1, link2, ...)`, up to 8 — the analog of
-///   the C++ variadic callback chain; see [`WalkChainLink`] for the
-///   accepted link shapes. Larger handler sets belong in one
-///   `#[dispatch(visit)]` visitor, which itself splices into a tuple as a
-///   single link.
+/// * A tuple of typed links `(link1, link2, ...)` — the analog of the C++
+///   variadic callback chain; see [`WalkChainLink`] for the accepted link
+///   shapes. A flat tuple holds up to 12 links; a tuple is itself a link, so
+///   nesting `(a, b, (c, d, ...), e)` chains any number of them. Larger
+///   handler sets may also live in one `#[dispatch(visit)]` visitor, which
+///   itself splices into a tuple as a single link.
 ///
 /// Closure arguments usually need explicit type annotations
 /// (`|value: &VisitValue| ...`) for the marker to be inferred.
@@ -223,7 +224,7 @@ pub use super::dispatch::{ByDispatch, DispatchVisitor, VisitDispatch};
     note = "accepted walkers: `&mut V` where `V: VisitDispatch`; a closure over `&VisitValue`, \
             an FFI value type `T`, or `&N` of an object node type (`N: ObjectCore`, e.g. \
             `&Object`), optionally with a trailing `DefRegionKind` argument; or a tuple of \
-            up to 8 such links",
+            up to 12 such links (tuples nest, so `(a, (b, c))` chains more)",
     note = "closure arguments need explicit type annotations; ObjectRef wrappers like `String` \
             or `Array<T>` are FFI value types — take them by value, not by reference"
 )]
@@ -303,9 +304,12 @@ where
 /// One typed link of a tuple walker — a single callback of the C++ variadic
 /// `StructuralWalk(root, callbacks...)` chain.
 ///
-/// A tuple of up to 8 links passed to [`structural_walk`] is tried in order
-/// and the first link whose argument type matches the value runs, exactly
-/// like the C++ callback chain. (Python's `structural_walk` differs on one
+/// A tuple of links passed to [`structural_walk`] is tried in order and the
+/// first link whose argument type matches the value runs, exactly like the
+/// C++ callback chain. A flat tuple holds up to 12 links, and a tuple is
+/// itself a link, so `(a, b, (c, d, ...), e)` nests to any length; nesting
+/// does not change order, which stays the flattened depth-first,
+/// left-to-right order. (Python's `structural_walk` differs on one
 /// point: it keeps `callbacks` and `with_def_region_kind` as two separately
 /// ordered groups, trying every plain entry before any kind-taking entry,
 /// so a mixed Rust tuple's single interleaved order has no exact Python
@@ -515,6 +519,9 @@ where
 }
 
 #[doc(hidden)]
+pub struct ByChainLink<Markers>(PhantomData<fn(Markers)>);
+
+#[doc(hidden)]
 pub enum ByDispatchLink {}
 
 impl<V: VisitDispatch> WalkChainLink<ByDispatchLink> for &mut V {
@@ -528,48 +535,69 @@ impl<V: VisitDispatch> WalkChainLink<ByDispatchLink> for &mut V {
     }
 }
 
-/// Runs a tuple of [`WalkChainLink`]s at the phase selected by `order`,
-/// trying links in order and short-circuiting on the first whose type
-/// matches — the Rust analog of C++ `StructuralWalkCallbackChain`. Static
-/// dispatch throughout: each link's type test inlines to the same code the
-/// `#[dispatch(visit)]` macro generates for a `visit_*` chain.
+/// Runs one [`WalkChainLink`] — a bare typed closure or a tuple of links —
+/// at the phase selected by `order`; a value the link does not claim
+/// advances normally. This is the Rust analog of C++
+/// `StructuralWalkCallbackChain`. Static dispatch throughout: each link's
+/// type test inlines to the same code the `#[dispatch(visit)]` macro
+/// generates for a `visit_*` chain.
 #[doc(hidden)]
-pub struct ChainWalker<Links, Markers> {
-    links: Links,
-    markers: PhantomData<fn(Markers)>,
+pub struct ChainWalker<Link, Marker> {
+    link: Link,
+    marker: PhantomData<fn(Marker)>,
 }
 
-macro_rules! impl_chain_walker {
+impl<Link, Marker> ChainWalker<Link, Marker> {
+    #[inline]
+    fn new(link: Link) -> Self {
+        ChainWalker {
+            link,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<Link, Marker> NativeVisit for ChainWalker<Link, Marker>
+where
+    Link: WalkChainLink<Marker>,
+{
+    #[inline]
+    fn visit(&mut self, value: &VisitValue, def_region_kind: DefRegionKind) -> Result<WalkResult> {
+        self.link
+            .try_call(value, def_region_kind)
+            .unwrap_or(Ok(WalkResult::Advance))
+    }
+}
+
+// A tuple of links is itself a link, tried in order with the first match
+// winning. Tuples therefore nest: the 12-wide flat arity cap becomes a
+// per-level cap and the total chain length is unbounded. Nesting does not
+// change order: links run in depth-first, left-to-right order, i.e. the
+// flattened order.
+macro_rules! impl_chain_link {
     ($(($F:ident, $M:ident, $idx:tt)),+) => {
-        impl<$($F, $M,)+> ChainWalker<($($F,)+), ($($M,)+)>
+        impl<$($F, $M,)+> sealed::SealedLink<ByChainLink<($($M,)+)>> for ($($F,)+)
+        where
+            $($F: WalkChainLink<$M>,)+
+        {
+        }
+
+        impl<$($F, $M,)+> WalkChainLink<ByChainLink<($($M,)+)>> for ($($F,)+)
         where
             $($F: WalkChainLink<$M>,)+
         {
             #[inline]
-            fn dispatch(
+            fn try_call(
                 &mut self,
                 value: &VisitValue,
                 def_region_kind: DefRegionKind,
-            ) -> Result<WalkResult> {
+            ) -> Option<VisitResult> {
                 $(
-                    if let Some(result) = self.links.$idx.try_call(value, def_region_kind) {
-                        return result;
+                    if let Some(result) = self.$idx.try_call(value, def_region_kind) {
+                        return Some(result);
                     }
                 )+
-                Ok(WalkResult::Advance)
-            }
-        }
-
-        impl<$($F, $M,)+> NativeVisit for ChainWalker<($($F,)+), ($($M,)+)>
-        where
-            $($F: WalkChainLink<$M>,)+
-        {
-            fn visit(
-                &mut self,
-                value: &VisitValue,
-                def_region_kind: DefRegionKind,
-            ) -> Result<WalkResult> {
-                self.dispatch(value, def_region_kind)
+                None
             }
         }
 
@@ -577,21 +605,18 @@ macro_rules! impl_chain_walker {
         where
             $($F: WalkChainLink<$M>,)+
         {
-            type Walker = ChainWalker<($($F,)+), ($($M,)+)>;
+            type Walker = ChainWalker<($($F,)+), ByChainLink<($($M,)+)>>;
             fn into_walker(self) -> Self::Walker {
-                ChainWalker {
-                    links: self,
-                    markers: PhantomData,
-                }
+                ChainWalker::new(self)
             }
         }
     };
 }
 
-impl_callback_chain_tuple_arities!(impl_chain_walker);
+impl_callback_chain_tuple_arities!(impl_chain_link);
 
 // A bare typed closure — `FnMut(T)` or `FnMut(&N)`, optionally with a
-// trailing `DefRegionKind` — walks as a single-link chain, so a lone typed
+// trailing `DefRegionKind` — walks as a single link, so a lone typed
 // handler needs no tuple wrapping; values that do not match its argument
 // type advance normally. `&VisitValue` catch-all closures keep their
 // dedicated `ClosureWalker`/`ClosureKindWalker` path above.
@@ -604,12 +629,9 @@ macro_rules! impl_bare_link_walker {
                 Self: WalkChainLink<$marker<T>>,
                 O: IntoVisitResult,
             {
-                type Walker = ChainWalker<(F,), ($marker<T>,)>;
+                type Walker = ChainWalker<F, $marker<T>>;
                 fn into_walker(self) -> Self::Walker {
-                    ChainWalker {
-                        links: (self,),
-                        markers: PhantomData,
-                    }
+                    ChainWalker::new(self)
                 }
             }
         )+

--- a/rust/tvm-ffi/src/extra/structural_visit.rs
+++ b/rust/tvm-ffi/src/extra/structural_visit.rs
@@ -26,13 +26,10 @@
 //!   [`StructuralVisitor::visit`] runs once per reached value and descends
 //!   only where it calls [`StructuralVisitor::default_visit_children`] or
 //!   [`StructuralVisitor::visit_child`]. `#[dispatch(visit)]` generates this
-//!   trait from typed `visit_*` methods. `structural_visit` also accepts a
-//!   typed callback or callback tuple; matched callbacks receive a mutable
-//!   [`VisitContext`] through which they drive the same recursive protocol.
+//!   trait from typed `visit_*` methods.
 //! * [`WalkDispatch`] + [`structural_walk`] — observer callbacks, like C++
 //!   `StructuralWalk`: the walker recurses on its own and callbacks steer it
 //!   through the returned [`WalkResult`] (advance, skip, interrupt).
-//!   `#[dispatch(walk)]` generates this layer from typed `walk_*` methods.
 //!
 //! Both layers thread the definition-region state explicitly: walk handlers
 //! opt in with a trailing [`DefRegionKind`] argument, and a visitor receives
@@ -98,18 +95,18 @@ impl WalkResult {
 ///
 /// This keeps simple handlers terse while allowing a handler to return
 /// `tvm_ffi::Result<WalkResult>` and use `?`.
-pub trait IntoVisitResult {
-    fn into_visit_result(self) -> Result<WalkResult>;
+pub trait IntoWalkResult {
+    fn into_walk_result(self) -> Result<WalkResult>;
 }
 
-impl IntoVisitResult for WalkResult {
-    fn into_visit_result(self) -> Result<WalkResult> {
+impl IntoWalkResult for WalkResult {
+    fn into_walk_result(self) -> Result<WalkResult> {
         Ok(self)
     }
 }
 
-impl IntoVisitResult for Result<WalkResult> {
-    fn into_visit_result(self) -> Result<WalkResult> {
+impl IntoWalkResult for Result<WalkResult> {
+    fn into_walk_result(self) -> Result<WalkResult> {
         self
     }
 }
@@ -174,43 +171,38 @@ impl VisitInterrupt {
 }
 
 /// Convert a callback result into structural-visit completion state.
-///
-/// Callback-driven visitors may return `()`, `Result<()>`,
-/// `Option<VisitInterrupt>`, or `Result<Option<VisitInterrupt>>`. Returning
-/// without an interrupt completes the current callback; it does not
-/// implicitly visit the matched value's children.
 #[doc(hidden)]
-pub trait IntoVisitOutcome {
-    fn into_visit_outcome(self) -> Result<Option<VisitInterrupt>>;
+pub trait IntoVisitResult {
+    fn into_visit_result(self) -> Result<Option<VisitInterrupt>>;
 }
 
-impl IntoVisitOutcome for () {
-    fn into_visit_outcome(self) -> Result<Option<VisitInterrupt>> {
+impl IntoVisitResult for () {
+    fn into_visit_result(self) -> Result<Option<VisitInterrupt>> {
         Ok(None)
     }
 }
 
-impl IntoVisitOutcome for Result<()> {
-    fn into_visit_outcome(self) -> Result<Option<VisitInterrupt>> {
+impl IntoVisitResult for Result<()> {
+    fn into_visit_result(self) -> Result<Option<VisitInterrupt>> {
         self.map(|()| None)
     }
 }
 
-impl IntoVisitOutcome for Option<VisitInterrupt> {
-    fn into_visit_outcome(self) -> Result<Option<VisitInterrupt>> {
+impl IntoVisitResult for Option<VisitInterrupt> {
+    fn into_visit_result(self) -> Result<Option<VisitInterrupt>> {
         Ok(self)
     }
 }
 
-impl IntoVisitOutcome for Result<Option<VisitInterrupt>> {
-    fn into_visit_outcome(self) -> Result<Option<VisitInterrupt>> {
+impl IntoVisitResult for Result<Option<VisitInterrupt>> {
+    fn into_visit_result(self) -> Result<Option<VisitInterrupt>> {
         self
     }
 }
 
 /// Fallible result returned by generated typed dispatch.
 #[doc(hidden)]
-pub type VisitResult = Result<WalkResult>;
+pub type WalkCallbackResult = Result<WalkResult>;
 
 /// A borrowed view of a raw tvm-ffi value passed to structural-visit callbacks.
 ///
@@ -232,19 +224,10 @@ impl From<Error> for NativeHalt {
 
 type NativeResult = std::result::Result<(), NativeHalt>;
 
-/// Mutable callback context for a stateful structural visitor.
+/// State and recursive operations available to a visit callback.
 ///
-/// A matched callback owns traversal of its value. Use [`Self::visit`] to
-/// visit a selected child, [`Self::visit_with`] to override its definition
-/// region, or [`Self::visit_children`] to apply the current value's default
-/// child traversal. Mutable user state lives in [`VisitCallbacks`] and is
-/// available through [`Self::state`] and [`Self::state_mut`].
-///
-/// Recursive operations take `&mut self`. This makes each recursive entry a
-/// checked reborrow of the complete traversal context: Rust rejects a state
-/// borrow that remains live across [`Self::visit`] or [`Self::visit_children`].
-/// The context is valid only for the callback invocation in which it was
-/// received and cannot be sent or shared across threads.
+/// A matched callback owns traversal of its value. Recursive operations
+/// reborrow the visitor, so mutable state cannot remain borrowed across them.
 pub struct VisitContext<'a, State> {
     driver: &'a mut dyn VisitContextDriver<State>,
     current: VisitValue,
@@ -252,8 +235,6 @@ pub struct VisitContext<'a, State> {
     _not_send_sync: PhantomData<Rc<()>>,
 }
 
-/// Object-safe bridge that lets `VisitContext<State>` reborrow a concrete
-/// `VisitCallbacks<State, ..>` without exposing its callback types.
 trait VisitContextDriver<State> {
     fn state(&self) -> &State;
     fn state_mut(&mut self) -> &mut State;
@@ -276,37 +257,6 @@ impl<State> VisitContext<'_, State> {
     }
 
     /// Mutably borrow the user state.
-    ///
-    /// The returned borrow must end before a recursive context method is
-    /// called. The borrow checker enforces this when the borrow is used after
-    /// that call.
-    ///
-    /// ```compile_fail
-    /// use tvm_ffi::{
-    ///     structural_visit, Array, Result, VisitCallbacks, VisitContext, VisitInterrupt,
-    ///     VisitValue,
-    /// };
-    ///
-    /// #[derive(Default)]
-    /// struct Depth {
-    ///     current: usize,
-    /// }
-    ///
-    /// fn visit_any(
-    ///     _value: &VisitValue,
-    ///     context: &mut VisitContext<'_, Depth>,
-    /// ) -> Result<Option<VisitInterrupt>> {
-    ///     let current = &mut context.state_mut().current;
-    ///     *current += 1;
-    ///     context.visit_children()?;
-    ///     *current -= 1; // `current` cannot stay borrowed across recursion.
-    ///     Ok(None)
-    /// }
-    ///
-    /// let root = Array::new(vec![1_i64]);
-    /// let mut visitor = VisitCallbacks::new(Depth::default(), visit_any);
-    /// structural_visit(&root, &mut visitor).unwrap();
-    /// ```
     pub fn state_mut(&mut self) -> &mut State {
         self.driver.state_mut()
     }
@@ -322,10 +272,6 @@ impl<State> VisitContext<'_, State> {
     }
 
     /// Visit `child` using the current definition-region state.
-    ///
-    /// An interrupt is returned as `Ok(Some(..))`, so a callback that wants to
-    /// propagate it must return that value explicitly; `?` propagates errors,
-    /// not interrupts.
     pub fn visit<T>(&mut self, child: &T) -> Result<Option<VisitInterrupt>>
     where
         for<'x> AnyView<'x>: From<&'x T>,
@@ -359,28 +305,8 @@ impl<State> VisitContext<'_, State> {
 
 /// Conversion into the visitor argument accepted by [`structural_visit`].
 ///
-/// Supported inputs are `&mut V` for a hand-written [`StructuralVisitor`], a
-/// typed `Fn(value, &mut VisitContext<'_, ()>)` callback, or a tuple of such
-/// callbacks. A callback chain uses first-match dispatch; unmatched values
-/// recurse through their default children. Use [`VisitCallbacks`] to give a
-/// callback chain ordinary mutable state.
-///
-/// Callback code still implements `Fn`, because recursive context methods may
-/// re-enter the same callback. All mutation instead goes through the single
-/// `&mut VisitContext`, so recursive calls are ordinary checked reborrows.
-///
-/// A closure that mutates captured state directly is therefore rejected:
-///
-/// ```compile_fail
-/// use tvm_ffi::{structural_visit, Array, VisitContext};
-///
-/// let root = Array::new(vec![1_i64]);
-/// let mut total = 0_i64;
-/// structural_visit(&root, |value: i64, _visitor: &mut VisitContext<'_, ()>| {
-///     total += value;
-/// })
-/// .unwrap();
-/// ```
+/// Accepts a mutable [`StructuralVisitor`] or a first-match callback chain.
+/// Use [`VisitCallbacks`] when the chain needs mutable state.
 #[diagnostic::on_unimplemented(
     message = "`{Self}` is not a supported `structural_visit` visitor",
     note = "accepted visitors: `&mut V` where `V: StructuralVisitor`; an `Fn` callback over an FFI value type `T`, `&N` of an object node type, or `&VisitValue`, followed by `&mut VisitContext<'_, ()>`; or a tuple of up to 12 such callbacks (tuples may nest)",
@@ -401,11 +327,7 @@ impl<V: StructuralVisitor> IntoVisitor<V> for &mut V {
     }
 }
 
-/// One typed callback in a callback-driven structural visitor.
-///
-/// The first matching link runs. Returning `None` means this link's value
-/// type did not match; a matched callback returning normally owns traversal
-/// and does not trigger implicit child recursion.
+/// One link in a first-match visitor callback chain.
 pub trait VisitChainLink<State, Marker>: visit_sealed::SealedLink<State, Marker> {
     #[doc(hidden)]
     fn try_visit(
@@ -416,34 +338,34 @@ pub trait VisitChainLink<State, Marker>: visit_sealed::SealedLink<State, Marker>
 }
 
 mod visit_sealed {
-    use super::{IntoVisitOutcome, ObjectCore, VisitContext, VisitValue};
+    use super::{IntoVisitResult, ObjectCore, VisitContext, VisitValue};
 
     pub trait SealedLink<State, Marker> {}
 
     impl<F, State, T, O> SealedLink<State, super::ByVisitOwnedLink<T>> for F
     where
-        F: for<'context, 'driver> Fn(T, &'context mut VisitContext<'driver, State>) -> O,
-        O: IntoVisitOutcome,
+        F: for<'visitor, 'driver> Fn(T, &'visitor mut VisitContext<'driver, State>) -> O,
+        O: IntoVisitResult,
     {
     }
 
     impl<F, State, N: ObjectCore, O> SealedLink<State, super::ByVisitNodeLink<N>> for F
     where
-        F: for<'value, 'context, 'driver> Fn(
+        F: for<'value, 'visitor, 'driver> Fn(
             &'value N,
-            &'context mut VisitContext<'driver, State>,
+            &'visitor mut VisitContext<'driver, State>,
         ) -> O,
-        O: IntoVisitOutcome,
+        O: IntoVisitResult,
     {
     }
 
     impl<F, State, O> SealedLink<State, super::ByVisitCatchAllLink> for F
     where
-        F: for<'value, 'context, 'driver> Fn(
+        F: for<'value, 'visitor, 'driver> Fn(
             &'value VisitValue,
-            &'context mut VisitContext<'driver, State>,
+            &'visitor mut VisitContext<'driver, State>,
         ) -> O,
-        O: IntoVisitOutcome,
+        O: IntoVisitResult,
     {
     }
 }
@@ -453,9 +375,9 @@ pub struct ByVisitOwnedLink<T>(PhantomData<T>);
 
 impl<F, State, T, O> VisitChainLink<State, ByVisitOwnedLink<T>> for F
 where
-    F: for<'context, 'driver> Fn(T, &'context mut VisitContext<'driver, State>) -> O,
+    F: for<'visitor, 'driver> Fn(T, &'visitor mut VisitContext<'driver, State>) -> O,
     T: crate::type_traits::AnyCompatible,
-    O: IntoVisitOutcome,
+    O: IntoVisitResult,
 {
     fn try_visit(
         &self,
@@ -464,7 +386,7 @@ where
     ) -> Option<Result<Option<VisitInterrupt>>> {
         value
             .cast::<T>()
-            .map(|typed| self(typed, visitor).into_visit_outcome())
+            .map(|typed| self(typed, visitor).into_visit_result())
     }
 }
 
@@ -473,12 +395,12 @@ pub struct ByVisitNodeLink<N>(PhantomData<N>);
 
 impl<F, State, N, O> VisitChainLink<State, ByVisitNodeLink<N>> for F
 where
-    F: for<'value, 'context, 'driver> Fn(
+    F: for<'value, 'visitor, 'driver> Fn(
         &'value N,
-        &'context mut VisitContext<'driver, State>,
+        &'visitor mut VisitContext<'driver, State>,
     ) -> O,
     N: ObjectCore,
-    O: IntoVisitOutcome,
+    O: IntoVisitResult,
 {
     fn try_visit(
         &self,
@@ -487,7 +409,7 @@ where
     ) -> Option<Result<Option<VisitInterrupt>>> {
         value
             .as_node::<N>()
-            .map(|node| self(node, visitor).into_visit_outcome())
+            .map(|node| self(node, visitor).into_visit_result())
     }
 }
 
@@ -496,18 +418,18 @@ pub enum ByVisitCatchAllLink {}
 
 impl<F, State, O> VisitChainLink<State, ByVisitCatchAllLink> for F
 where
-    F: for<'value, 'context, 'driver> Fn(
+    F: for<'value, 'visitor, 'driver> Fn(
         &'value VisitValue,
-        &'context mut VisitContext<'driver, State>,
+        &'visitor mut VisitContext<'driver, State>,
     ) -> O,
-    O: IntoVisitOutcome,
+    O: IntoVisitResult,
 {
     fn try_visit(
         &self,
         value: &VisitValue,
         visitor: &mut VisitContext<'_, State>,
     ) -> Option<Result<Option<VisitInterrupt>>> {
-        Some(self(value, visitor).into_visit_outcome())
+        Some(self(value, visitor).into_visit_result())
     }
 }
 
@@ -546,43 +468,7 @@ macro_rules! impl_visit_chain_link {
 
 impl_callback_chain_tuple_arities!(impl_visit_chain_link);
 
-/// Stateful typed callback visitor.
-///
-/// `callbacks` may be one typed callback or a nested tuple. Every callback
-/// receives the same mutable [`VisitContext`], and therefore the same `State`.
-/// Callback code is stored behind `Rc` so recursive entries can borrow the
-/// mutable visitor while invoking the shared `Fn` independently.
-///
-/// Pass the resulting visitor to [`structural_visit`] by mutable reference;
-/// it can be reused across traversals and its state remains available through
-/// [`Self::state`] or [`Self::into_state`].
-///
-/// ```
-/// use tvm_ffi::{
-///     structural_visit, Array, Result, VisitCallbacks, VisitContext, VisitInterrupt, VisitValue,
-/// };
-///
-/// #[derive(Default)]
-/// struct Stats {
-///     total: i64,
-/// }
-///
-/// fn visit_integer(value: i64, context: &mut VisitContext<'_, Stats>) {
-///     context.state_mut().total += value;
-/// }
-///
-/// fn visit_any(
-///     _value: &VisitValue,
-///     context: &mut VisitContext<'_, Stats>,
-/// ) -> Result<Option<VisitInterrupt>> {
-///     context.visit_children()
-/// }
-///
-/// let root = Array::new(vec![1_i64, 2]);
-/// let mut visitor = VisitCallbacks::new(Stats::default(), (visit_integer, visit_any));
-/// structural_visit(&root, &mut visitor).unwrap();
-/// assert_eq!(visitor.state().total, 3);
-/// ```
+/// A reusable callback visitor with shared user state.
 pub struct VisitCallbacks<State, Link, Marker> {
     state: State,
     callbacks: Rc<Link>,
@@ -637,33 +523,13 @@ where
     }
 }
 
-// The typed-dispatch layer (`WalkDispatch`, its walker adapter, and the
-// `&mut V` IntoWalker form) lives in `super::dispatch`; re-exported here so
-// the module's public paths — which `#[dispatch(walk)]`-generated code
-// names — stay stable.
+// Keep the generated walk-dispatch paths stable.
 pub use super::dispatch::{ByWalkDispatch, DispatchWalker, WalkDispatch};
 
 /// Conversion into the walker argument of [`structural_walk`].
 ///
-/// The `Marker` parameter lets one entry point accept several handler
-/// shapes without overlapping implementations — the Rust equivalent of the
-/// C++ `StructuralWalk` callback overload set:
-///
-/// * `&mut V` where `V: WalkDispatch` — a stateful typed walker
-///   (`#[dispatch(walk)]` or hand-written).
-/// * A bare closure in any [`WalkChainLink`] shape — catch-all
-///   `FnMut(&VisitValue)`, typed `FnMut(T)`, node `FnMut(&N)`, each with an
-///   optional trailing [`DefRegionKind`] argument — the analog of a single
-///   C++ callback. Values a typed closure does not match advance normally.
-/// * A tuple of typed links `(link1, link2, ...)` — the analog of the C++
-///   variadic callback chain; see [`WalkChainLink`] for the accepted link
-///   shapes. A flat tuple holds up to 12 links; a tuple is itself a link, so
-///   nesting `(a, b, (c, d, ...), e)` chains any number of them. Larger
-///   handler sets may also live in one `#[dispatch(walk)]` walker, which
-///   itself splices into a tuple as a single link.
-///
-/// Closure arguments usually need explicit type annotations
-/// (`|value: &VisitValue| ...`) for the marker to be inferred.
+/// Accepts a mutable [`WalkDispatch`], a typed callback, or a nested callback
+/// tuple. `Marker` distinguishes the supported callback shapes.
 #[diagnostic::on_unimplemented(
     message = "`{Self}` is not a supported `structural_walk` walker",
     note = "accepted walkers: `&mut V` where `V: WalkDispatch`; a closure over `&VisitValue`, \
@@ -680,12 +546,7 @@ pub trait IntoWalker<Marker> {
     fn into_walker(self) -> Self::Walker;
 }
 
-/// Runs a catch-all closure at the phase selected by `order` — the closure
-/// analog of `DispatchWalker`, without the `Option<VisitResult>`
-/// no-handler-matched layer a dispatch chain needs. (Routing closures
-/// through `DispatchWalker` instead measures ~10-20% slower on the bare
-/// closure walk: the wrapped-and-unwrapped `Option<Result<..>>` does not
-/// fold away.)
+/// Adapter for a catch-all walk callback.
 #[doc(hidden)]
 pub struct ClosureWalker<F> {
     callback: F,
@@ -694,10 +555,10 @@ pub struct ClosureWalker<F> {
 impl<F, O> NativeVisit for ClosureWalker<F>
 where
     F: FnMut(&VisitValue) -> O,
-    O: IntoVisitResult,
+    O: IntoWalkResult,
 {
     fn visit(&mut self, value: &VisitValue, _def_region_kind: DefRegionKind) -> Result<WalkResult> {
-        (self.callback)(value).into_visit_result()
+        (self.callback)(value).into_walk_result()
     }
 }
 
@@ -707,7 +568,7 @@ pub enum ByValueClosure {}
 impl<F, O> IntoWalker<ByValueClosure> for F
 where
     F: FnMut(&VisitValue) -> O,
-    O: IntoVisitResult,
+    O: IntoWalkResult,
 {
     type Walker = ClosureWalker<F>;
     fn into_walker(self) -> Self::Walker {
@@ -715,8 +576,7 @@ where
     }
 }
 
-/// `ClosureWalker` variant whose callback also receives the definition-region
-/// state.
+/// Catch-all walk adapter that also supplies the definition-region state.
 #[doc(hidden)]
 pub struct ClosureKindWalker<F> {
     callback: F,
@@ -725,10 +585,10 @@ pub struct ClosureKindWalker<F> {
 impl<F, O> NativeVisit for ClosureKindWalker<F>
 where
     F: FnMut(&VisitValue, DefRegionKind) -> O,
-    O: IntoVisitResult,
+    O: IntoWalkResult,
 {
     fn visit(&mut self, value: &VisitValue, def_region_kind: DefRegionKind) -> Result<WalkResult> {
-        (self.callback)(value, def_region_kind).into_visit_result()
+        (self.callback)(value, def_region_kind).into_walk_result()
     }
 }
 
@@ -738,7 +598,7 @@ pub enum ByValueKindClosure {}
 impl<F, O> IntoWalker<ByValueKindClosure> for F
 where
     F: FnMut(&VisitValue, DefRegionKind) -> O,
-    O: IntoVisitResult,
+    O: IntoWalkResult,
 {
     type Walker = ClosureKindWalker<F>;
     fn into_walker(self) -> Self::Walker {
@@ -746,46 +606,11 @@ where
     }
 }
 
-/// One typed link of a tuple walker — a single callback of the C++ variadic
-/// `StructuralWalk(root, callbacks...)` chain.
+/// One link in a first-match [`structural_walk`] callback chain.
 ///
-/// A tuple of links passed to [`structural_walk`] is tried in order and the
-/// first link whose argument type matches the value runs, exactly like the
-/// C++ callback chain. A flat tuple holds up to 12 links, and a tuple is
-/// itself a link, so `(a, b, (c, d, ...), e)` nests to any length; nesting
-/// does not change order, which stays the flattened depth-first,
-/// left-to-right order. (Python's `structural_walk` differs on one
-/// point: it keeps `callbacks` and `with_def_region_kind` as two separately
-/// ordered groups, trying every plain entry before any kind-taking entry,
-/// so a mixed Rust tuple's single interleaved order has no exact Python
-/// equivalent.) Accepted link shapes mirror `#[dispatch(walk)]` handlers:
-///
-/// * `FnMut(T) -> impl IntoVisitResult` for an FFI-convertible `T` — value
-///   cast via [`VisitValue::cast`], which matches on the FFI type tag: a
-///   numeric link claims every `Int` (or `Float`) regardless of width and
-///   converts with `as` semantics, so prefer `i64`/`f64` links unless a
-///   deliberate narrowing is wanted.
-/// * `FnMut(&N) -> impl IntoVisitResult` for an object node `N` —
-///   refcount-free subtype check via [`VisitValue::as_node`].
-/// * `FnMut(&VisitValue) -> impl IntoVisitResult` — catch-all.
-/// * `&mut V` where `V: WalkDispatch` — splice a typed walker into the
-///   chain; it claims every value one of its handlers matches.
-///
-/// Links after one that matches every value never run: place a catch-all
-/// closure — or a spliced visitor whose own chain ends in a `&VisitValue`
-/// handler — last. Unlike the in-visitor ordering check, misordering a
-/// tuple is not a compile error.
-///
-/// Every closure shape may declare a trailing [`DefRegionKind`] argument,
-/// and a single typed closure may also be passed to [`structural_walk`]
-/// bare, without the tuple. Closure arguments need explicit type
-/// annotations for the marker to be inferred. Borrow rules apply per link,
-/// so state shared across links goes through a `Cell`/`RefCell` — or in a
-/// single `#[dispatch(walk)]` walker, which shares `&mut self` between
-/// its handlers.
-///
-/// This trait is sealed: the link shapes above are the complete set, and
-/// the dispatch method is an internal detail.
+/// Supported links are typed values, borrowed object nodes, `&VisitValue`,
+/// and mutable [`WalkDispatch`] implementations, optionally followed by
+/// [`DefRegionKind`]. Tuples hold up to 12 links and may be nested.
 pub trait WalkChainLink<Marker>: sealed::SealedLink<Marker> {
     /// Run this link if `value` matches its argument type; `None` hands the
     /// value to the next link.
@@ -794,50 +619,48 @@ pub trait WalkChainLink<Marker>: sealed::SealedLink<Marker> {
         &mut self,
         value: &VisitValue,
         def_region_kind: DefRegionKind,
-    ) -> Option<VisitResult>;
+    ) -> Option<WalkCallbackResult>;
 }
 
 mod sealed {
-    use super::{DefRegionKind, IntoVisitResult, ObjectCore, VisitValue, WalkDispatch};
+    use super::{DefRegionKind, IntoWalkResult, ObjectCore, VisitValue, WalkDispatch};
 
-    /// Seal for [`super::WalkChainLink`]: one impl per accepted link shape,
-    /// mirroring the `WalkChainLink` impl set exactly.
     pub trait SealedLink<Marker> {}
 
     impl<F, T, O> SealedLink<super::ByOwnedLink<T>> for F
     where
         F: FnMut(T) -> O,
-        O: IntoVisitResult,
+        O: IntoWalkResult,
     {
     }
     impl<F, T, O> SealedLink<super::ByOwnedKindLink<T>> for F
     where
         F: FnMut(T, DefRegionKind) -> O,
-        O: IntoVisitResult,
+        O: IntoWalkResult,
     {
     }
     impl<F, N: ObjectCore, O> SealedLink<super::ByNodeLink<N>> for F
     where
         F: for<'a> FnMut(&'a N) -> O,
-        O: IntoVisitResult,
+        O: IntoWalkResult,
     {
     }
     impl<F, N: ObjectCore, O> SealedLink<super::ByNodeKindLink<N>> for F
     where
         F: for<'a> FnMut(&'a N, DefRegionKind) -> O,
-        O: IntoVisitResult,
+        O: IntoWalkResult,
     {
     }
     impl<F, O> SealedLink<super::ByCatchAllLink> for F
     where
         F: for<'a> FnMut(&'a VisitValue) -> O,
-        O: IntoVisitResult,
+        O: IntoWalkResult,
     {
     }
     impl<F, O> SealedLink<super::ByCatchAllKindLink> for F
     where
         F: for<'a> FnMut(&'a VisitValue, DefRegionKind) -> O,
-        O: IntoVisitResult,
+        O: IntoWalkResult,
     {
     }
     impl<V: WalkDispatch> SealedLink<super::ByWalkDispatchLink> for &mut V {}
@@ -850,17 +673,17 @@ impl<F, T, O> WalkChainLink<ByOwnedLink<T>> for F
 where
     F: FnMut(T) -> O,
     T: crate::type_traits::AnyCompatible,
-    O: IntoVisitResult,
+    O: IntoWalkResult,
 {
     #[inline]
     fn try_call(
         &mut self,
         value: &VisitValue,
         _def_region_kind: DefRegionKind,
-    ) -> Option<VisitResult> {
+    ) -> Option<WalkCallbackResult> {
         value
             .cast::<T>()
-            .map(|typed| self(typed).into_visit_result())
+            .map(|typed| self(typed).into_walk_result())
     }
 }
 
@@ -871,17 +694,17 @@ impl<F, T, O> WalkChainLink<ByOwnedKindLink<T>> for F
 where
     F: FnMut(T, DefRegionKind) -> O,
     T: crate::type_traits::AnyCompatible,
-    O: IntoVisitResult,
+    O: IntoWalkResult,
 {
     #[inline]
     fn try_call(
         &mut self,
         value: &VisitValue,
         def_region_kind: DefRegionKind,
-    ) -> Option<VisitResult> {
+    ) -> Option<WalkCallbackResult> {
         value
             .cast::<T>()
-            .map(|typed| self(typed, def_region_kind).into_visit_result())
+            .map(|typed| self(typed, def_region_kind).into_walk_result())
     }
 }
 
@@ -892,17 +715,17 @@ impl<F, N, O> WalkChainLink<ByNodeLink<N>> for F
 where
     F: for<'a> FnMut(&'a N) -> O,
     N: ObjectCore,
-    O: IntoVisitResult,
+    O: IntoWalkResult,
 {
     #[inline]
     fn try_call(
         &mut self,
         value: &VisitValue,
         _def_region_kind: DefRegionKind,
-    ) -> Option<VisitResult> {
+    ) -> Option<WalkCallbackResult> {
         value
             .as_node::<N>()
-            .map(|node| self(node).into_visit_result())
+            .map(|node| self(node).into_walk_result())
     }
 }
 
@@ -913,17 +736,17 @@ impl<F, N, O> WalkChainLink<ByNodeKindLink<N>> for F
 where
     F: for<'a> FnMut(&'a N, DefRegionKind) -> O,
     N: ObjectCore,
-    O: IntoVisitResult,
+    O: IntoWalkResult,
 {
     #[inline]
     fn try_call(
         &mut self,
         value: &VisitValue,
         def_region_kind: DefRegionKind,
-    ) -> Option<VisitResult> {
+    ) -> Option<WalkCallbackResult> {
         value
             .as_node::<N>()
-            .map(|node| self(node, def_region_kind).into_visit_result())
+            .map(|node| self(node, def_region_kind).into_walk_result())
     }
 }
 
@@ -933,15 +756,15 @@ pub enum ByCatchAllLink {}
 impl<F, O> WalkChainLink<ByCatchAllLink> for F
 where
     F: for<'a> FnMut(&'a VisitValue) -> O,
-    O: IntoVisitResult,
+    O: IntoWalkResult,
 {
     #[inline]
     fn try_call(
         &mut self,
         value: &VisitValue,
         _def_region_kind: DefRegionKind,
-    ) -> Option<VisitResult> {
-        Some(self(value).into_visit_result())
+    ) -> Option<WalkCallbackResult> {
+        Some(self(value).into_walk_result())
     }
 }
 
@@ -951,15 +774,15 @@ pub enum ByCatchAllKindLink {}
 impl<F, O> WalkChainLink<ByCatchAllKindLink> for F
 where
     F: for<'a> FnMut(&'a VisitValue, DefRegionKind) -> O,
-    O: IntoVisitResult,
+    O: IntoWalkResult,
 {
     #[inline]
     fn try_call(
         &mut self,
         value: &VisitValue,
         def_region_kind: DefRegionKind,
-    ) -> Option<VisitResult> {
-        Some(self(value, def_region_kind).into_visit_result())
+    ) -> Option<WalkCallbackResult> {
+        Some(self(value, def_region_kind).into_walk_result())
     }
 }
 
@@ -975,17 +798,12 @@ impl<V: WalkDispatch> WalkChainLink<ByWalkDispatchLink> for &mut V {
         &mut self,
         value: &VisitValue,
         def_region_kind: DefRegionKind,
-    ) -> Option<VisitResult> {
+    ) -> Option<WalkCallbackResult> {
         self.dispatch_walk(value, def_region_kind)
     }
 }
 
-/// Runs one [`WalkChainLink`] — a bare typed closure or a tuple of links —
-/// at the phase selected by `order`; a value the link does not claim
-/// advances normally. This is the Rust analog of C++
-/// `StructuralWalkCallbackChain`. Static dispatch throughout: each link's
-/// type test inlines to the same code the `#[dispatch(walk)]` macro
-/// generates for a `walk_*` chain.
+/// Adapter from a [`WalkChainLink`] to the native traversal callback.
 #[doc(hidden)]
 pub struct ChainWalker<Link, Marker> {
     link: Link,
@@ -1014,11 +832,6 @@ where
     }
 }
 
-// A tuple of links is itself a link, tried in order with the first match
-// winning. Tuples therefore nest: the 12-wide flat arity cap becomes a
-// per-level cap and the total chain length is unbounded. Nesting does not
-// change order: links run in depth-first, left-to-right order, i.e. the
-// flattened order.
 macro_rules! impl_chain_link {
     ($(($F:ident, $M:ident, $idx:tt)),+) => {
         impl<$($F, $M,)+> sealed::SealedLink<ByChainLink<($($M,)+)>> for ($($F,)+)
@@ -1036,7 +849,7 @@ macro_rules! impl_chain_link {
                 &mut self,
                 value: &VisitValue,
                 def_region_kind: DefRegionKind,
-            ) -> Option<VisitResult> {
+            ) -> Option<WalkCallbackResult> {
                 $(
                     if let Some(result) = self.$idx.try_call(value, def_region_kind) {
                         return Some(result);
@@ -1060,11 +873,6 @@ macro_rules! impl_chain_link {
 
 impl_callback_chain_tuple_arities!(impl_chain_link);
 
-// A bare typed closure — `FnMut(T)` or `FnMut(&N)`, optionally with a
-// trailing `DefRegionKind` — walks as a single link, so a lone typed
-// handler needs no tuple wrapping; values that do not match its argument
-// type advance normally. `&VisitValue` catch-all closures keep their
-// dedicated `ClosureWalker`/`ClosureKindWalker` path above.
 macro_rules! impl_bare_link_walker {
     ($(($marker:ident, $($fn_args:ty),+)),+ $(,)?) => {
         $(
@@ -1072,7 +880,7 @@ macro_rules! impl_bare_link_walker {
             where
                 F: FnMut($($fn_args),+) -> O,
                 Self: WalkChainLink<$marker<T>>,
-                O: IntoVisitResult,
+                O: IntoWalkResult,
             {
                 type Walker = ChainWalker<F, $marker<T>>;
                 fn into_walker(self) -> Self::Walker {
@@ -1090,38 +898,11 @@ impl_bare_link_walker!(
     (ByNodeKindLink, &T, DefRegionKind),
 );
 
-/// A visitor that drives recursion itself, mirroring C++
-/// `StructuralVisitorObj`.
+/// A visitor that controls its own recursion.
 ///
-/// [`structural_visit`] calls [`StructuralVisitor::visit`] for the root;
-/// after that the visitor is in control, exactly like a C++ visitor whose
-/// vtable `visit` runs per value. A `visit` implementation descends only
-/// where it chooses:
-///
-/// * [`StructuralVisitor::default_visit_children`] delegates the default
-///   child recursion — the analog of C++
-///   `StructuralVisitorObj::DefaultVisitExpected`.
-/// * [`StructuralVisitor::visit_child`] visits one selected child — the
-///   analog of C++ `visitor->Visit(child)`, with the explicit
-///   `def_region_kind` argument playing the role of `WithDefRegionKind`.
-///
-/// Returning without descending skips the value's children. There is no
-/// [`WalkResult`] at this layer: control flow is what the implementation
-/// visits, and `Ok(Some(interrupt))` halts the traversal — the analog of
-/// returning a C++ `VisitInterrupt`. Nested `visit_child` and
-/// `default_visit_children` calls report a nested interrupt through their
-/// return value; propagate it (and errors, via `?`) upward instead of
-/// dropping the result.
-///
-/// The definition-region state is threaded explicitly, exactly like walk
-/// handlers that declare the trailing argument: `visit` receives the state
-/// active at the value and forwards it — or an override — when descending.
-/// Reflected-field annotations override the forwarded state automatically
-/// inside `default_visit_children`.
-///
-/// Use `#[dispatch(visit)]` on an inherent impl of typed `visit_*` methods to
-/// generate this trait. A matching generated handler owns recursion; values
-/// without a matching handler use [`Self::default_visit_children`].
+/// Implementations descend with [`Self::visit_child`] or
+/// [`Self::default_visit_children`]. `#[dispatch(visit)]` generates this trait
+/// from typed `visit_*` methods.
 pub trait StructuralVisitor: Sized {
     /// Visit one value under the definition-region state active at it.
     fn visit(
@@ -1130,9 +911,7 @@ pub trait StructuralVisitor: Sized {
         def_region_kind: DefRegionKind,
     ) -> Result<Option<VisitInterrupt>>;
 
-    /// Visit `child` now under `def_region_kind`, dispatching back into
-    /// [`StructuralVisitor::visit`]. An FFI `None` child is skipped without
-    /// a callback, matching the walk layer.
+    /// Visit `child` under `def_region_kind`.
     #[inline]
     fn visit_child<T>(
         &mut self,
@@ -1153,13 +932,7 @@ pub trait StructuralVisitor: Sized {
         }))
     }
 
-    /// Visit `value`'s children — not `value` itself — with the default
-    /// rules, dispatching each child back into [`StructuralVisitor::visit`].
-    ///
-    /// Children are container contents for `Array`/`List`/`Map`/`Dict` and
-    /// reflected structural fields otherwise. Field annotations override
-    /// `def_region_kind` for that field's recursive visit exactly like the
-    /// walk layer.
+    /// Visit `value`'s children with the default structural rules.
     #[inline]
     fn default_visit_children(
         &mut self,
@@ -1188,20 +961,17 @@ where
         value: &VisitValue,
         def_region_kind: DefRegionKind,
     ) -> Result<Option<VisitInterrupt>> {
-        // Clone the pointer, not the callback state. The callback allocation
-        // is then independent from the mutable borrow placed in `context`, so
-        // recursive entries can invoke the same `Fn` through a checked reborrow
-        // of this visitor.
+        // Clone the handle before `visitor` borrows all of `self`.
         let callbacks = Rc::clone(&self.callbacks);
-        let mut context = VisitContext {
+        let mut visitor = VisitContext {
             driver: self,
             current: VisitValue::from_raw(value.raw()),
             def_region_kind,
             _not_send_sync: PhantomData,
         };
-        match callbacks.try_visit(value, &mut context) {
+        match callbacks.try_visit(value, &mut visitor) {
             Some(outcome) => outcome,
-            None => context.visit_children(),
+            None => visitor.visit_children(),
         }
     }
 }
@@ -1246,26 +1016,17 @@ where
     }
 }
 
-/// Internal per-value protocol driven by the recursion engine. Public only
-/// as the bound of [`IntoWalker::Walker`]; not meant to be implemented
-/// outside this crate.
+/// Internal callback protocol used by [`IntoWalker`].
 #[doc(hidden)]
 pub trait NativeVisit {
     fn visit(&mut self, value: &VisitValue, def_region_kind: DefRegionKind) -> Result<WalkResult>;
 }
 
-/// Per-child action invoked by the shared child-iteration engine.
-///
-/// The engine owns *finding* the children (container contents, reflected
-/// fields) and computing each child's definition-region state; this trait
-/// decides what happens at a child. The walk layer recurses
-/// ([`WalkChildren`]); the visitor layer hands the child straight to user
-/// code ([`UserChildren`]).
+/// Action applied to each child found by the shared traversal.
 trait ChildVisit {
     fn visit_child(&mut self, child: TVMFFIAny, def_region_kind: DefRegionKind) -> NativeResult;
 }
 
-/// Walk-layer recursion: every child re-enters [`visit_raw`].
 struct WalkChildren<'a, V, const PRE_ORDER: bool> {
     visitor: &'a mut V,
 }
@@ -1276,8 +1037,6 @@ impl<V: NativeVisit, const PRE_ORDER: bool> ChildVisit for WalkChildren<'_, V, P
     }
 }
 
-/// Visitor-layer dispatch: every child goes back into the user-driven
-/// [`StructuralVisitor::visit`], which controls further descent itself.
 struct UserChildren<'a, V> {
     visitor: &'a mut V,
 }
@@ -1299,11 +1058,7 @@ impl<V: StructuralVisitor> ChildVisit for UserChildren<'_, V> {
     }
 }
 
-/// Recurse into `value`: run the handler before or after its children according
-/// to the compile-time walk order, and use the registered hook to find children.
-// This is forced inline because every registered container child re-enters
-// through `runtime_walk`; release benchmarks show that a regular inline hint
-// leaves an extra Rust call on this hot path.
+// Every registered container child re-enters this hot path.
 #[inline(always)]
 fn visit_raw<V: NativeVisit, const PRE_ORDER: bool>(
     value: TVMFFIAny,
@@ -1315,10 +1070,6 @@ fn visit_raw<V: NativeVisit, const PRE_ORDER: bool>(
     }
 
     let visit_value = VisitValue::from_raw(value);
-    // Single by-value matches: splitting the Result match from the
-    // WalkResult match leaves a partially-moved temporary whose drop glue
-    // the compiler cannot fold away (measurably so on the container fast
-    // path).
     if PRE_ORDER {
         match visitor.visit(&visit_value, def_region_kind) {
             Ok(WalkResult::Advance) => {}
@@ -1427,9 +1178,7 @@ unsafe fn visit_reflected_field<C: ChildVisit>(
         ))));
     };
     let address = object.offset(field.offset as isize) as *mut c_void;
-    // Own the result slot before entering foreign code. A getter may write an
-    // owning value and still report an error, in which case `child` must drop
-    // that partial result.
+    // Own the getter result so partial writes and recursive borrows drop safely.
     let mut child = Any::new();
     if getter(address, Any::as_data_ptr(&mut child)) != 0 {
         return Err(with_error_context(
@@ -1438,8 +1187,6 @@ unsafe fn visit_reflected_field<C: ChildVisit>(
         ));
     }
 
-    // A reflection getter returns an owned Any. Keep it alive while the
-    // recursive walk borrows its raw cell.
     let borrowed = raw_of_owned(&child);
     let child_region = field_def_region(field, inherited_region);
     visitor
@@ -1457,19 +1204,13 @@ struct StructuralVisitorVTable {
     visit: FStructuralVisit,
 }
 
-/// Active Rust visitor with the exact C++ `StructuralVisitorObj` prefix.
-///
-/// Registered type hooks read `vtable` and `def_region_mode`; the Rust-only
-/// diagnostic and panic state follows that shared prefix and is never
-/// inspected by C++.
+/// Rust visitor object with the C++ `StructuralVisitorObj` prefix.
 #[repr(C)]
 struct RuntimeStructuralVisitorObj {
     base: Object,
     vtable: *const StructuralVisitorVTable,
     def_region_mode: i32,
-    // The live Rust context stays in traversal-local TLS state. These fields
-    // are diagnostic markers only, so a retained or foreign-thread handle can
-    // fail without following a pointer into another thread's stack.
+    // The live context remains in traversal-local TLS.
     context_identity: *mut c_void,
     owner_thread: std::thread::ThreadId,
     panic: Option<Box<dyn std::any::Any + Send>>,
@@ -1540,9 +1281,7 @@ unsafe impl ObjectCore for RuntimeVisitInterruptObj {
     }
 }
 
-// Give each concrete Rust visitor a direct C ABI entry. The returned reference
-// is promoted to static storage, and the direct entry lets LLVM inline the
-// typed Rust callback instead of making another indirect call for every value.
+// Use a direct ABI entry for each concrete visitor type.
 fn walk_runtime_vtable<V: NativeVisit, const PRE_ORDER: bool>() -> &'static StructuralVisitorVTable
 {
     &StructuralVisitorVTable {
@@ -1569,9 +1308,7 @@ impl Drop for RuntimeContextGuard {
     }
 }
 
-/// Traversal-local Rust state. Registered hooks only retain the owning FFI
-/// object, never this stack address; TLS exposes it solely on the owner thread
-/// for the duration of the traversal.
+/// Traversal-local state exposed through TLS on the owner thread.
 struct ActiveStructuralVisitor {
     visitor: StructuralVisitorHandle,
     context: *mut c_void,
@@ -2002,15 +1739,10 @@ fn with_value_context(halt: NativeHalt, value: TVMFFIAny) -> NativeHalt {
     }
 }
 
-/// Visit `root` with a user-driven visitor or typed callback chain.
+/// Visit `root` with a [`StructuralVisitor`] or typed callback chain.
 ///
-/// Passing `&mut V` for `V: StructuralVisitor` preserves the low-level API:
-/// `V::visit` receives the root and controls recursion. A typed `Fn(value,
-/// &mut VisitContext<'_, ()>)` callback or callback tuple builds a temporary
-/// visitor. [`VisitCallbacks`] adds ordinary mutable state to the same callback
-/// model. The first matching callback owns traversal of that value; unmatched
-/// values use default child recursion. An FFI `None` root completes
-/// immediately.
+/// A matching callback owns recursion; unmatched values use default child
+/// traversal. Use [`VisitCallbacks`] to attach mutable state to the chain.
 pub fn structural_visit<R, M>(
     root: &R,
     visitor: impl IntoVisitor<M>,

--- a/rust/tvm-ffi/src/extra/structural_visit.rs
+++ b/rust/tvm-ffi/src/extra/structural_visit.rs
@@ -25,7 +25,9 @@
 //!   recursion itself, like a hand-written C++ `StructuralVisitorObj`:
 //!   [`StructuralVisitor::visit`] runs once per reached value and descends
 //!   only where it calls [`StructuralVisitor::default_visit_children`] or
-//!   [`StructuralVisitor::visit_child`].
+//!   [`StructuralVisitor::visit_child`]. `structural_visit` also accepts a
+//!   typed callback or callback tuple; matched callbacks receive a
+//!   [`VisitorRef`] through which they drive the same recursive protocol.
 //! * [`VisitDispatch`] + [`structural_walk`] — observer callbacks, like C++
 //!   `StructuralWalk`: the walker recurses on its own and callbacks steer it
 //!   through the returned [`WalkResult`] (advance, skip, interrupt).
@@ -168,6 +170,41 @@ impl VisitInterrupt {
     }
 }
 
+/// Convert a callback result into structural-visit completion state.
+///
+/// Callback-driven visitors may return `()`, `Result<()>`,
+/// `Option<VisitInterrupt>`, or `Result<Option<VisitInterrupt>>`. Returning
+/// without an interrupt completes the current callback; it does not
+/// implicitly visit the matched value's children.
+#[doc(hidden)]
+pub trait IntoVisitOutcome {
+    fn into_visit_outcome(self) -> Result<Option<VisitInterrupt>>;
+}
+
+impl IntoVisitOutcome for () {
+    fn into_visit_outcome(self) -> Result<Option<VisitInterrupt>> {
+        Ok(None)
+    }
+}
+
+impl IntoVisitOutcome for Result<()> {
+    fn into_visit_outcome(self) -> Result<Option<VisitInterrupt>> {
+        self.map(|()| None)
+    }
+}
+
+impl IntoVisitOutcome for Option<VisitInterrupt> {
+    fn into_visit_outcome(self) -> Result<Option<VisitInterrupt>> {
+        Ok(self)
+    }
+}
+
+impl IntoVisitOutcome for Result<Option<VisitInterrupt>> {
+    fn into_visit_outcome(self) -> Result<Option<VisitInterrupt>> {
+        self
+    }
+}
+
 /// Fallible result returned by generated typed dispatch.
 #[doc(hidden)]
 pub type VisitResult = Result<WalkResult>;
@@ -191,6 +228,274 @@ impl From<Error> for NativeHalt {
 }
 
 type NativeResult = std::result::Result<(), NativeHalt>;
+
+/// A non-owning traversal handle supplied to `structural_visit` callbacks.
+///
+/// A matched callback owns traversal of its value. Use [`Self::visit`] to
+/// visit a selected child, [`Self::visit_with`] to override its definition
+/// region, or [`Self::visit_children`] to apply the current value's default
+/// child traversal. The handle is valid only for the callback invocation in
+/// which it was received and cannot be sent or shared across threads.
+pub struct VisitorRef<'a> {
+    visitor: StructuralVisitorHandle,
+    context: *mut c_void,
+    current: TVMFFIAny,
+    def_region_kind: DefRegionKind,
+    _lifetime: PhantomData<(&'a (), std::rc::Rc<()>)>,
+}
+
+impl VisitorRef<'_> {
+    /// Definition-region state active at the callback's current value.
+    pub fn def_region_kind(&self) -> DefRegionKind {
+        self.def_region_kind
+    }
+
+    /// Visit `child` using the current definition-region state.
+    ///
+    /// An interrupt is returned as `Ok(Some(..))`, so a callback that wants to
+    /// propagate it must return that value explicitly; `?` propagates errors,
+    /// not interrupts.
+    pub fn visit<T>(&self, child: &T) -> Result<Option<VisitInterrupt>>
+    where
+        for<'x> AnyView<'x>: From<&'x T>,
+    {
+        self.visit_with(child, self.def_region_kind)
+    }
+
+    /// Visit `child` using an explicit definition-region state.
+    pub fn visit_with<T>(
+        &self,
+        child: &T,
+        def_region_kind: DefRegionKind,
+    ) -> Result<Option<VisitInterrupt>>
+    where
+        for<'x> AnyView<'x>: From<&'x T>,
+    {
+        let raw = raw_of(AnyView::from(child));
+        if raw.type_index == TVMFFITypeIndex::kTVMFFINone as i32 {
+            return Ok(None);
+        }
+        finish(with_current_visitor_context(
+            self.visitor,
+            self.context,
+            || call_visitor(self.visitor, raw, def_region_kind),
+        ))
+    }
+
+    /// Visit the current value's children using registered hooks or reflected
+    /// structural fields. The current value itself is not dispatched again.
+    pub fn visit_children(&self) -> Result<Option<VisitInterrupt>> {
+        let result = visit_children_raw(
+            self.current,
+            &mut HandleChildren {
+                visitor: self.visitor,
+                context: self.context,
+            },
+            self.context,
+            self.def_region_kind,
+        )
+        .map_err(|halt| with_value_context(halt, self.current));
+        finish(result)
+    }
+}
+
+/// Conversion into the visitor argument accepted by [`structural_visit`].
+///
+/// Supported inputs are `&mut V` for a hand-written [`StructuralVisitor`], a
+/// typed `Fn(value, &VisitorRef)` callback, or a tuple of such callbacks. A
+/// callback chain uses first-match dispatch; unmatched values recurse through
+/// their default children. Callbacks must implement `Fn` because invoking a
+/// handle method may recursively re-enter the same callback. Use `Cell` or
+/// `RefCell` for callback-local state, or pass `&mut StructuralVisitor` when
+/// ordinary mutable state is more convenient.
+///
+/// A closure that mutates captured state directly is therefore rejected:
+///
+/// ```compile_fail
+/// use tvm_ffi::{structural_visit, Array, VisitorRef};
+///
+/// let root = Array::new(vec![1_i64]);
+/// let mut total = 0_i64;
+/// structural_visit(&root, |value: i64, _visitor: &VisitorRef<'_>| {
+///     total += value;
+/// })
+/// .unwrap();
+/// ```
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` is not a supported `structural_visit` visitor",
+    note = "accepted visitors: `&mut V` where `V: StructuralVisitor`; an `Fn` callback over an FFI value type `T`, `&N` of an object node type, or `&VisitValue`, followed by `&VisitorRef`; or a tuple of up to 12 such callbacks (tuples may nest)",
+    note = "callback arguments need explicit type annotations; callbacks must implement `Fn`, not `FnMut`, because recursive visits may re-enter the same callback"
+)]
+pub trait IntoVisitor<Marker> {
+    #[doc(hidden)]
+    fn visit_root(self, root: TVMFFIAny) -> Result<Option<VisitInterrupt>>;
+}
+
+impl<V: StructuralVisitor> IntoVisitor<V> for &mut V {
+    fn visit_root(self, root: TVMFFIAny) -> Result<Option<VisitInterrupt>> {
+        finish(run_structural_visitor(
+            root,
+            self,
+            user_runtime_vtable::<V>(),
+        ))
+    }
+}
+
+/// One typed callback in a callback-driven structural visitor.
+///
+/// The first matching link runs. Returning `None` means this link's value
+/// type did not match; a matched callback returning normally owns traversal
+/// and does not trigger implicit child recursion.
+pub trait VisitChainLink<Marker>: visit_sealed::SealedLink<Marker> {
+    #[doc(hidden)]
+    fn try_visit(
+        &self,
+        value: &VisitValue,
+        visitor: &VisitorRef<'_>,
+    ) -> Option<Result<Option<VisitInterrupt>>>;
+}
+
+mod visit_sealed {
+    use super::{IntoVisitOutcome, ObjectCore, VisitValue, VisitorRef};
+
+    pub trait SealedLink<Marker> {}
+
+    impl<F, T, O> SealedLink<super::ByVisitOwnedLink<T>> for F
+    where
+        F: for<'a> Fn(T, &'a VisitorRef<'a>) -> O,
+        O: IntoVisitOutcome,
+    {
+    }
+
+    impl<F, N: ObjectCore, O> SealedLink<super::ByVisitNodeLink<N>> for F
+    where
+        F: for<'a> Fn(&'a N, &'a VisitorRef<'a>) -> O,
+        O: IntoVisitOutcome,
+    {
+    }
+
+    impl<F, O> SealedLink<super::ByVisitCatchAllLink> for F
+    where
+        F: for<'a> Fn(&'a VisitValue, &'a VisitorRef<'a>) -> O,
+        O: IntoVisitOutcome,
+    {
+    }
+}
+
+#[doc(hidden)]
+pub struct ByVisitOwnedLink<T>(PhantomData<T>);
+
+impl<F, T, O> VisitChainLink<ByVisitOwnedLink<T>> for F
+where
+    F: for<'a> Fn(T, &'a VisitorRef<'a>) -> O,
+    T: crate::type_traits::AnyCompatible,
+    O: IntoVisitOutcome,
+{
+    fn try_visit(
+        &self,
+        value: &VisitValue,
+        visitor: &VisitorRef<'_>,
+    ) -> Option<Result<Option<VisitInterrupt>>> {
+        value
+            .cast::<T>()
+            .map(|typed| self(typed, visitor).into_visit_outcome())
+    }
+}
+
+#[doc(hidden)]
+pub struct ByVisitNodeLink<N>(PhantomData<N>);
+
+impl<F, N, O> VisitChainLink<ByVisitNodeLink<N>> for F
+where
+    F: for<'a> Fn(&'a N, &'a VisitorRef<'a>) -> O,
+    N: ObjectCore,
+    O: IntoVisitOutcome,
+{
+    fn try_visit(
+        &self,
+        value: &VisitValue,
+        visitor: &VisitorRef<'_>,
+    ) -> Option<Result<Option<VisitInterrupt>>> {
+        value
+            .as_node::<N>()
+            .map(|node| self(node, visitor).into_visit_outcome())
+    }
+}
+
+#[doc(hidden)]
+pub enum ByVisitCatchAllLink {}
+
+impl<F, O> VisitChainLink<ByVisitCatchAllLink> for F
+where
+    F: for<'a> Fn(&'a VisitValue, &'a VisitorRef<'a>) -> O,
+    O: IntoVisitOutcome,
+{
+    fn try_visit(
+        &self,
+        value: &VisitValue,
+        visitor: &VisitorRef<'_>,
+    ) -> Option<Result<Option<VisitInterrupt>>> {
+        Some(self(value, visitor).into_visit_outcome())
+    }
+}
+
+#[doc(hidden)]
+pub struct ByVisitChainLink<Markers>(PhantomData<fn(Markers)>);
+
+macro_rules! impl_visit_chain_link {
+    ($(($F:ident, $M:ident, $idx:tt)),+) => {
+        impl<$($F, $M,)+> visit_sealed::SealedLink<ByVisitChainLink<($($M,)+)>> for ($($F,)+)
+        where
+            $($F: VisitChainLink<$M>,)+
+        {
+        }
+
+        impl<$($F, $M,)+> VisitChainLink<ByVisitChainLink<($($M,)+)>> for ($($F,)+)
+        where
+            $($F: VisitChainLink<$M>,)+
+        {
+            fn try_visit(
+                &self,
+                value: &VisitValue,
+                visitor: &VisitorRef<'_>,
+            ) -> Option<Result<Option<VisitInterrupt>>> {
+                $(
+                    if let Some(result) = self.$idx.try_visit(value, visitor) {
+                        return Some(result);
+                    }
+                )+
+                None
+            }
+        }
+    };
+}
+
+impl_callback_chain_tuple_arities!(impl_visit_chain_link);
+
+struct CallbackVisitor<Link, Marker> {
+    link: Link,
+    _marker: PhantomData<fn(Marker)>,
+}
+
+#[doc(hidden)]
+pub struct ByVisitCallbacks<Marker>(PhantomData<fn(Marker)>);
+
+impl<Link, Marker> IntoVisitor<ByVisitCallbacks<Marker>> for Link
+where
+    Link: VisitChainLink<Marker>,
+{
+    fn visit_root(self, root: TVMFFIAny) -> Result<Option<VisitInterrupt>> {
+        let visitor: CallbackVisitor<Link, Marker> = CallbackVisitor {
+            link: self,
+            _marker: PhantomData,
+        };
+        finish(run_shared_structural_visitor(
+            root,
+            &visitor,
+            callback_runtime_vtable::<Link, Marker>(),
+        ))
+    }
+}
 
 // The typed-dispatch layer (`VisitDispatch`, its walker adapter, and the
 // `&mut V` IntoWalker form) lives in `super::dispatch`; re-exported here so
@@ -783,6 +1088,26 @@ impl<V: StructuralVisitor> ChildVisit for UserChildren<'_, V> {
     }
 }
 
+/// Callback-layer child dispatch. Each child re-enters the active ABI visitor
+/// after temporarily exposing the same shared callback context. The context is
+/// never converted to a mutable reference on this path.
+struct HandleChildren {
+    visitor: StructuralVisitorHandle,
+    context: *mut c_void,
+}
+
+impl ChildVisit for HandleChildren {
+    #[inline]
+    fn visit_child(&mut self, child: TVMFFIAny, def_region_kind: DefRegionKind) -> NativeResult {
+        if child.type_index == TVMFFITypeIndex::kTVMFFINone as i32 {
+            return Ok(());
+        }
+        with_current_visitor_context(self.visitor, self.context, || {
+            call_visitor(self.visitor, child, def_region_kind)
+        })
+    }
+}
+
 /// Recurse into `value`: run the handler before or after its children according
 /// to the compile-time walk order, and use the registered hook to find children.
 // This is forced inline because every registered container child re-enters
@@ -1040,6 +1365,15 @@ fn user_runtime_vtable<V: StructuralVisitor>() -> &'static StructuralVisitorVTab
     }
 }
 
+fn callback_runtime_vtable<Link, Marker>() -> &'static StructuralVisitorVTable
+where
+    Link: VisitChainLink<Marker>,
+{
+    &StructuralVisitorVTable {
+        visit: rust_vtable_callback::<Link, Marker>,
+    }
+}
+
 struct RuntimeContextGuard {
     active: *mut ActiveStructuralVisitor,
     context: *mut c_void,
@@ -1096,6 +1430,18 @@ unsafe extern "C" fn rust_vtable_user<V: StructuralVisitor>(
 ) -> TVMFFIAny {
     rust_vtable_visit_impl(visitor, value, |context, raw, kind| {
         runtime_user_visit::<V>(context, raw, kind)
+    })
+}
+
+unsafe extern "C" fn rust_vtable_callback<Link, Marker>(
+    visitor: StructuralVisitorHandle,
+    value: AnyView<'static>,
+) -> TVMFFIAny
+where
+    Link: VisitChainLink<Marker>,
+{
+    rust_vtable_visit_impl(visitor, value, |context, raw, kind| {
+        runtime_callback_visit::<Link, Marker>(context, raw, kind)
     })
 }
 
@@ -1294,12 +1640,72 @@ unsafe fn runtime_user_visit<V: StructuralVisitor>(
     }
 }
 
+#[inline(always)]
+unsafe fn runtime_callback_visit<Link, Marker>(
+    context: *mut c_void,
+    raw: TVMFFIAny,
+    def_region_kind: DefRegionKind,
+) -> NativeResult
+where
+    Link: VisitChainLink<Marker>,
+{
+    if raw.type_index == TVMFFITypeIndex::kTVMFFINone as i32 {
+        return Ok(());
+    }
+
+    // SAFETY: callback-backed traversals install a pointer derived from a
+    // shared `CallbackVisitor` reference. Every recursive entry on this path
+    // reconstructs only a shared reference, so re-entering an `Fn` callback
+    // cannot create overlapping mutable borrows.
+    let callback = &*context.cast::<CallbackVisitor<Link, Marker>>();
+    let active = active_structural_visitor()?;
+    let visitor = VisitorRef {
+        visitor: active,
+        context,
+        current: raw,
+        def_region_kind,
+        _lifetime: PhantomData,
+    };
+    let outcome = match callback
+        .link
+        .try_visit(&VisitValue::from_raw(raw), &visitor)
+    {
+        Some(outcome) => outcome,
+        None => visitor.visit_children(),
+    };
+    match outcome {
+        Ok(None) => Ok(()),
+        Ok(Some(interrupt)) => Err(NativeHalt::Interrupt(interrupt.value)),
+        Err(error) => Err(NativeHalt::Error(error)),
+    }
+}
+
 fn run_structural_visitor<D>(
     root: TVMFFIAny,
     driver: &mut D,
     vtable: &'static StructuralVisitorVTable,
 ) -> NativeResult {
     let context = std::ptr::from_mut(driver).cast::<c_void>();
+    run_structural_visitor_with_context(root, context, vtable)
+}
+
+fn run_shared_structural_visitor<D>(
+    root: TVMFFIAny,
+    driver: &D,
+    vtable: &'static StructuralVisitorVTable,
+) -> NativeResult {
+    // The ABI stores an opaque mutable pointer, but callback vtables must only
+    // reconstruct `&D` from it. Keeping this wrapper separate makes that
+    // shared-only invariant explicit at the construction site.
+    let context = std::ptr::from_ref(driver).cast_mut().cast::<c_void>();
+    run_structural_visitor_with_context(root, context, vtable)
+}
+
+fn run_structural_visitor_with_context(
+    root: TVMFFIAny,
+    context: *mut c_void,
+    vtable: &'static StructuralVisitorVTable,
+) -> NativeResult {
     let mut active = ObjectArc::new(RuntimeStructuralVisitorObj {
         base: Object::new(),
         vtable,
@@ -1486,22 +1892,21 @@ fn with_value_context(halt: NativeHalt, value: TVMFFIAny) -> NativeHalt {
     }
 }
 
-/// Visit `root` with a user-driven [`StructuralVisitor`].
+/// Visit `root` with a user-driven visitor or typed callback chain.
 ///
-/// The visitor's [`StructuralVisitor::visit`] runs for the root under
-/// [`DefRegionKind::None`] and controls all further recursion itself. This is
-/// the Rust analog of constructing a C++ `StructuralVisitorObj` and calling
-/// `visitor->Visit(root)`. An FFI `None` root completes immediately.
-pub fn structural_visit<R, V>(root: &R, visitor: &mut V) -> Result<Option<VisitInterrupt>>
+/// Passing `&mut V` for `V: StructuralVisitor` preserves the low-level API:
+/// `V::visit` receives the root and controls recursion. A typed `Fn(value,
+/// &VisitorRef)` callback or callback tuple builds a temporary visitor. The
+/// first matching callback owns traversal of that value; unmatched values use
+/// default child recursion. An FFI `None` root completes immediately.
+pub fn structural_visit<R, M>(
+    root: &R,
+    visitor: impl IntoVisitor<M>,
+) -> Result<Option<VisitInterrupt>>
 where
-    V: StructuralVisitor,
     for<'x> AnyView<'x>: From<&'x R>,
 {
-    finish(run_structural_visitor(
-        raw_of(AnyView::from(root)),
-        visitor,
-        user_runtime_vtable::<V>(),
-    ))
+    visitor.visit_root(raw_of(AnyView::from(root)))
 }
 
 /// Walk `root` with an observer, the Rust analog of C++

--- a/rust/tvm-ffi/src/extra/structural_visit.rs
+++ b/rust/tvm-ffi/src/extra/structural_visit.rs
@@ -25,12 +25,14 @@
 //!   recursion itself, like a hand-written C++ `StructuralVisitorObj`:
 //!   [`StructuralVisitor::visit`] runs once per reached value and descends
 //!   only where it calls [`StructuralVisitor::default_visit_children`] or
-//!   [`StructuralVisitor::visit_child`]. `structural_visit` also accepts a
+//!   [`StructuralVisitor::visit_child`]. `#[dispatch(visit)]` generates this
+//!   trait from typed `visit_*` methods. `structural_visit` also accepts a
 //!   typed callback or callback tuple; matched callbacks receive a
 //!   [`VisitorRef`] through which they drive the same recursive protocol.
-//! * [`VisitDispatch`] + [`structural_walk`] — observer callbacks, like C++
+//! * [`WalkDispatch`] + [`structural_walk`] — observer callbacks, like C++
 //!   `StructuralWalk`: the walker recurses on its own and callbacks steer it
 //!   through the returned [`WalkResult`] (advance, skip, interrupt).
+//!   `#[dispatch(walk)]` generates this layer from typed `walk_*` methods.
 //!
 //! Both layers thread the definition-region state explicitly: walk handlers
 //! opt in with a trailing [`DefRegionKind`] argument, and a visitor receives
@@ -497,11 +499,11 @@ where
     }
 }
 
-// The typed-dispatch layer (`VisitDispatch`, its walker adapter, and the
+// The typed-dispatch layer (`WalkDispatch`, its walker adapter, and the
 // `&mut V` IntoWalker form) lives in `super::dispatch`; re-exported here so
-// the module's public paths — which `#[dispatch(visit)]`-generated code
+// the module's public paths — which `#[dispatch(walk)]`-generated code
 // names — stay stable.
-pub use super::dispatch::{ByDispatch, DispatchVisitor, VisitDispatch};
+pub use super::dispatch::{ByWalkDispatch, DispatchWalker, WalkDispatch};
 
 /// Conversion into the walker argument of [`structural_walk`].
 ///
@@ -509,8 +511,8 @@ pub use super::dispatch::{ByDispatch, DispatchVisitor, VisitDispatch};
 /// shapes without overlapping implementations — the Rust equivalent of the
 /// C++ `StructuralWalk` callback overload set:
 ///
-/// * `&mut V` where `V: VisitDispatch` — a stateful typed visitor
-///   (`#[dispatch(visit)]` or hand-written).
+/// * `&mut V` where `V: WalkDispatch` — a stateful typed walker
+///   (`#[dispatch(walk)]` or hand-written).
 /// * A bare closure in any [`WalkChainLink`] shape — catch-all
 ///   `FnMut(&VisitValue)`, typed `FnMut(T)`, node `FnMut(&N)`, each with an
 ///   optional trailing [`DefRegionKind`] argument — the analog of a single
@@ -519,14 +521,14 @@ pub use super::dispatch::{ByDispatch, DispatchVisitor, VisitDispatch};
 ///   variadic callback chain; see [`WalkChainLink`] for the accepted link
 ///   shapes. A flat tuple holds up to 12 links; a tuple is itself a link, so
 ///   nesting `(a, b, (c, d, ...), e)` chains any number of them. Larger
-///   handler sets may also live in one `#[dispatch(visit)]` visitor, which
+///   handler sets may also live in one `#[dispatch(walk)]` walker, which
 ///   itself splices into a tuple as a single link.
 ///
 /// Closure arguments usually need explicit type annotations
 /// (`|value: &VisitValue| ...`) for the marker to be inferred.
 #[diagnostic::on_unimplemented(
     message = "`{Self}` is not a supported `structural_walk` walker",
-    note = "accepted walkers: `&mut V` where `V: VisitDispatch`; a closure over `&VisitValue`, \
+    note = "accepted walkers: `&mut V` where `V: WalkDispatch`; a closure over `&VisitValue`, \
             an FFI value type `T`, or `&N` of an object node type (`N: ObjectCore`, e.g. \
             `&Object`), optionally with a trailing `DefRegionKind` argument; or a tuple of \
             up to 12 such links (tuples nest, so `(a, (b, c))` chains more)",
@@ -541,9 +543,9 @@ pub trait IntoWalker<Marker> {
 }
 
 /// Runs a catch-all closure at the phase selected by `order` — the closure
-/// analog of `DispatchVisitor`, without the `Option<VisitResult>`
+/// analog of `DispatchWalker`, without the `Option<VisitResult>`
 /// no-handler-matched layer a dispatch chain needs. (Routing closures
-/// through `DispatchVisitor` instead measures ~10-20% slower on the bare
+/// through `DispatchWalker` instead measures ~10-20% slower on the bare
 /// closure walk: the wrapped-and-unwrapped `Option<Result<..>>` does not
 /// fold away.)
 #[doc(hidden)]
@@ -618,7 +620,7 @@ where
 /// point: it keeps `callbacks` and `with_def_region_kind` as two separately
 /// ordered groups, trying every plain entry before any kind-taking entry,
 /// so a mixed Rust tuple's single interleaved order has no exact Python
-/// equivalent.) Accepted link shapes mirror `#[dispatch(visit)]` handlers:
+/// equivalent.) Accepted link shapes mirror `#[dispatch(walk)]` handlers:
 ///
 /// * `FnMut(T) -> impl IntoVisitResult` for an FFI-convertible `T` — value
 ///   cast via [`VisitValue::cast`], which matches on the FFI type tag: a
@@ -628,7 +630,7 @@ where
 /// * `FnMut(&N) -> impl IntoVisitResult` for an object node `N` —
 ///   refcount-free subtype check via [`VisitValue::as_node`].
 /// * `FnMut(&VisitValue) -> impl IntoVisitResult` — catch-all.
-/// * `&mut V` where `V: VisitDispatch` — splice a typed visitor into the
+/// * `&mut V` where `V: WalkDispatch` — splice a typed walker into the
 ///   chain; it claims every value one of its handlers matches.
 ///
 /// Links after one that matches every value never run: place a catch-all
@@ -641,7 +643,7 @@ where
 /// bare, without the tuple. Closure arguments need explicit type
 /// annotations for the marker to be inferred. Borrow rules apply per link,
 /// so state shared across links goes through a `Cell`/`RefCell` — or in a
-/// single `#[dispatch(visit)]` visitor, which shares `&mut self` between
+/// single `#[dispatch(walk)]` walker, which shares `&mut self` between
 /// its handlers.
 ///
 /// This trait is sealed: the link shapes above are the complete set, and
@@ -658,7 +660,7 @@ pub trait WalkChainLink<Marker>: sealed::SealedLink<Marker> {
 }
 
 mod sealed {
-    use super::{DefRegionKind, IntoVisitResult, ObjectCore, VisitDispatch, VisitValue};
+    use super::{DefRegionKind, IntoVisitResult, ObjectCore, VisitValue, WalkDispatch};
 
     /// Seal for [`super::WalkChainLink`]: one impl per accepted link shape,
     /// mirroring the `WalkChainLink` impl set exactly.
@@ -700,7 +702,7 @@ mod sealed {
         O: IntoVisitResult,
     {
     }
-    impl<V: VisitDispatch> SealedLink<super::ByDispatchLink> for &mut V {}
+    impl<V: WalkDispatch> SealedLink<super::ByWalkDispatchLink> for &mut V {}
 }
 
 #[doc(hidden)]
@@ -827,16 +829,16 @@ where
 pub struct ByChainLink<Markers>(PhantomData<fn(Markers)>);
 
 #[doc(hidden)]
-pub enum ByDispatchLink {}
+pub enum ByWalkDispatchLink {}
 
-impl<V: VisitDispatch> WalkChainLink<ByDispatchLink> for &mut V {
+impl<V: WalkDispatch> WalkChainLink<ByWalkDispatchLink> for &mut V {
     #[inline]
     fn try_call(
         &mut self,
         value: &VisitValue,
         def_region_kind: DefRegionKind,
     ) -> Option<VisitResult> {
-        self.dispatch_visit(value, def_region_kind)
+        self.dispatch_walk(value, def_region_kind)
     }
 }
 
@@ -844,8 +846,8 @@ impl<V: VisitDispatch> WalkChainLink<ByDispatchLink> for &mut V {
 /// at the phase selected by `order`; a value the link does not claim
 /// advances normally. This is the Rust analog of C++
 /// `StructuralWalkCallbackChain`. Static dispatch throughout: each link's
-/// type test inlines to the same code the `#[dispatch(visit)]` macro
-/// generates for a `visit_*` chain.
+/// type test inlines to the same code the `#[dispatch(walk)]` macro
+/// generates for a `walk_*` chain.
 #[doc(hidden)]
 pub struct ChainWalker<Link, Marker> {
     link: Link,
@@ -978,6 +980,10 @@ impl_bare_link_walker!(
 /// active at the value and forwards it — or an override — when descending.
 /// Reflected-field annotations override the forwarded state automatically
 /// inside `default_visit_children`.
+///
+/// Use `#[dispatch(visit)]` on an inherent impl of typed `visit_*` methods to
+/// generate this trait. A matching generated handler owns recursion; values
+/// without a matching handler use [`Self::default_visit_children`].
 pub trait StructuralVisitor: Sized {
     /// Visit one value under the definition-region state active at it.
     fn visit(
@@ -1913,7 +1919,7 @@ where
 /// `StructuralWalk<order>(root, callbacks...)`.
 ///
 /// `walker` is anything implementing [`IntoWalker`]: a `&mut` reference to a
-/// stateful [`VisitDispatch`] visitor (`#[dispatch(visit)]`), a bare closure
+/// stateful [`WalkDispatch`] walker (`#[dispatch(walk)]`), a bare closure
 /// in any [`WalkChainLink`] shape (catch-all `&VisitValue`, typed, or node,
 /// with an optional trailing [`DefRegionKind`]), or a tuple of such
 /// callbacks tried in order — the C++ callback overloads and variadic

--- a/rust/tvm-ffi/src/extra/structural_visit.rs
+++ b/rust/tvm-ffi/src/extra/structural_visit.rs
@@ -177,24 +177,28 @@ pub trait IntoVisitResult {
 }
 
 impl IntoVisitResult for () {
+    #[inline]
     fn into_visit_result(self) -> Result<Option<VisitInterrupt>> {
         Ok(None)
     }
 }
 
 impl IntoVisitResult for Result<()> {
+    #[inline]
     fn into_visit_result(self) -> Result<Option<VisitInterrupt>> {
         self.map(|()| None)
     }
 }
 
 impl IntoVisitResult for Option<VisitInterrupt> {
+    #[inline]
     fn into_visit_result(self) -> Result<Option<VisitInterrupt>> {
         Ok(self)
     }
 }
 
 impl IntoVisitResult for Result<Option<VisitInterrupt>> {
+    #[inline]
     fn into_visit_result(self) -> Result<Option<VisitInterrupt>> {
         self
     }
@@ -506,6 +510,37 @@ impl<State, Link, Marker> VisitCallbacks<State, Link, Marker> {
     }
 }
 
+struct DirectVisitCallbacks<'a, Link, Marker> {
+    state: (),
+    callbacks: &'a Link,
+    _marker: PhantomData<fn(Marker)>,
+}
+
+trait VisitCallbackState<State> {
+    fn callback_state(&self) -> &State;
+    fn callback_state_mut(&mut self) -> &mut State;
+}
+
+impl<State, Link, Marker> VisitCallbackState<State> for VisitCallbacks<State, Link, Marker> {
+    fn callback_state(&self) -> &State {
+        &self.state
+    }
+
+    fn callback_state_mut(&mut self) -> &mut State {
+        &mut self.state
+    }
+}
+
+impl<Link, Marker> VisitCallbackState<()> for DirectVisitCallbacks<'_, Link, Marker> {
+    fn callback_state(&self) -> &() {
+        &self.state
+    }
+
+    fn callback_state_mut(&mut self) -> &mut () {
+        &mut self.state
+    }
+}
+
 #[doc(hidden)]
 pub struct ByVisitCallbacks<Marker>(PhantomData<fn(Marker)>);
 
@@ -514,11 +549,16 @@ where
     Link: VisitChainLink<(), Marker>,
 {
     fn visit_root(self, root: TVMFFIAny) -> Result<Option<VisitInterrupt>> {
-        let mut visitor = VisitCallbacks::<(), Link, Marker>::new((), self);
+        let callbacks = self;
+        let mut visitor = DirectVisitCallbacks::<Link, Marker> {
+            state: (),
+            callbacks: &callbacks,
+            _marker: PhantomData,
+        };
         finish(run_structural_visitor(
             root,
             &mut visitor,
-            user_runtime_vtable::<VisitCallbacks<(), Link, Marker>>(),
+            user_runtime_vtable::<DirectVisitCallbacks<Link, Marker>>(),
         ))
     }
 }
@@ -952,6 +992,29 @@ pub trait StructuralVisitor: Sized {
     }
 }
 
+fn try_visit_callbacks<State, Link, Marker>(
+    driver: &mut impl VisitContextDriver<State>,
+    callback_ptr: *const Link,
+    value: &VisitValue,
+    def_region_kind: DefRegionKind,
+) -> Result<Option<VisitInterrupt>>
+where
+    Link: VisitChainLink<State, Marker>,
+{
+    let mut visitor = VisitContext {
+        driver,
+        current: VisitValue::from_raw(value.raw()),
+        def_region_kind,
+        _not_send_sync: PhantomData,
+    };
+    // SAFETY: The owning `Rc` or the direct callback's stack slot remains live
+    // and is never modified through the driver during recursive reentry.
+    match unsafe { (&*callback_ptr).try_visit(value, &mut visitor) } {
+        Some(outcome) => outcome,
+        None => visitor.visit_children(),
+    }
+}
+
 impl<State, Link, Marker> StructuralVisitor for VisitCallbacks<State, Link, Marker>
 where
     Link: VisitChainLink<State, Marker>,
@@ -961,31 +1024,35 @@ where
         value: &VisitValue,
         def_region_kind: DefRegionKind,
     ) -> Result<Option<VisitInterrupt>> {
-        // Clone the handle before `visitor` borrows all of `self`.
-        let callbacks = Rc::clone(&self.callbacks);
-        let mut visitor = VisitContext {
-            driver: self,
-            current: VisitValue::from_raw(value.raw()),
-            def_region_kind,
-            _not_send_sync: PhantomData,
-        };
-        match callbacks.try_visit(value, &mut visitor) {
-            Some(outcome) => outcome,
-            None => visitor.visit_children(),
-        }
+        let callback_ptr = Rc::as_ptr(&self.callbacks);
+        try_visit_callbacks::<State, Link, Marker>(self, callback_ptr, value, def_region_kind)
     }
 }
 
-impl<State, Link, Marker> VisitContextDriver<State> for VisitCallbacks<State, Link, Marker>
+impl<Link, Marker> StructuralVisitor for DirectVisitCallbacks<'_, Link, Marker>
 where
-    Link: VisitChainLink<State, Marker>,
+    Link: VisitChainLink<(), Marker>,
+{
+    fn visit(
+        &mut self,
+        value: &VisitValue,
+        def_region_kind: DefRegionKind,
+    ) -> Result<Option<VisitInterrupt>> {
+        let callback_ptr = std::ptr::from_ref(self.callbacks);
+        try_visit_callbacks::<(), Link, Marker>(self, callback_ptr, value, def_region_kind)
+    }
+}
+
+impl<State, Driver> VisitContextDriver<State> for Driver
+where
+    Driver: StructuralVisitor + VisitCallbackState<State>,
 {
     fn state(&self) -> &State {
-        &self.state
+        self.callback_state()
     }
 
     fn state_mut(&mut self) -> &mut State {
-        &mut self.state
+        self.callback_state_mut()
     }
 
     fn visit_raw(

--- a/rust/tvm-ffi/src/extra/structural_visit.rs
+++ b/rust/tvm-ffi/src/extra/structural_visit.rs
@@ -27,8 +27,8 @@
 //!   only where it calls [`StructuralVisitor::default_visit_children`] or
 //!   [`StructuralVisitor::visit_child`]. `#[dispatch(visit)]` generates this
 //!   trait from typed `visit_*` methods. `structural_visit` also accepts a
-//!   typed callback or callback tuple; matched callbacks receive a
-//!   [`VisitorRef`] through which they drive the same recursive protocol.
+//!   typed callback or callback tuple; matched callbacks receive a mutable
+//!   [`VisitContext`] through which they drive the same recursive protocol.
 //! * [`WalkDispatch`] + [`structural_walk`] — observer callbacks, like C++
 //!   `StructuralWalk`: the walker recurses on its own and callbacks steer it
 //!   through the returned [`WalkResult`] (advance, skip, interrupt).
@@ -50,6 +50,7 @@ use std::ops::ControlFlow;
 use std::os::raw::c_void;
 use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
 use std::ptr::NonNull;
+use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::LazyLock;
 
@@ -231,22 +232,90 @@ impl From<Error> for NativeHalt {
 
 type NativeResult = std::result::Result<(), NativeHalt>;
 
-/// A non-owning traversal handle supplied to `structural_visit` callbacks.
+/// Mutable callback context for a stateful structural visitor.
 ///
 /// A matched callback owns traversal of its value. Use [`Self::visit`] to
 /// visit a selected child, [`Self::visit_with`] to override its definition
 /// region, or [`Self::visit_children`] to apply the current value's default
-/// child traversal. The handle is valid only for the callback invocation in
-/// which it was received and cannot be sent or shared across threads.
-pub struct VisitorRef<'a> {
-    visitor: StructuralVisitorHandle,
-    context: *mut c_void,
-    current: TVMFFIAny,
+/// child traversal. Mutable user state lives in [`VisitCallbacks`] and is
+/// available through [`Self::state`] and [`Self::state_mut`].
+///
+/// Recursive operations take `&mut self`. This makes each recursive entry a
+/// checked reborrow of the complete traversal context: Rust rejects a state
+/// borrow that remains live across [`Self::visit`] or [`Self::visit_children`].
+/// The context is valid only for the callback invocation in which it was
+/// received and cannot be sent or shared across threads.
+pub struct VisitContext<'a, State> {
+    driver: &'a mut dyn VisitContextDriver<State>,
+    current: VisitValue,
     def_region_kind: DefRegionKind,
-    _lifetime: PhantomData<(&'a (), std::rc::Rc<()>)>,
+    _not_send_sync: PhantomData<Rc<()>>,
 }
 
-impl VisitorRef<'_> {
+/// Object-safe bridge that lets `VisitContext<State>` reborrow a concrete
+/// `VisitCallbacks<State, ..>` without exposing its callback types.
+trait VisitContextDriver<State> {
+    fn state(&self) -> &State;
+    fn state_mut(&mut self) -> &mut State;
+    fn visit_raw(
+        &mut self,
+        raw: TVMFFIAny,
+        def_region_kind: DefRegionKind,
+    ) -> Result<Option<VisitInterrupt>>;
+    fn visit_children_raw(
+        &mut self,
+        raw: TVMFFIAny,
+        def_region_kind: DefRegionKind,
+    ) -> Result<Option<VisitInterrupt>>;
+}
+
+impl<State> VisitContext<'_, State> {
+    /// User state shared by every callback in this traversal.
+    pub fn state(&self) -> &State {
+        self.driver.state()
+    }
+
+    /// Mutably borrow the user state.
+    ///
+    /// The returned borrow must end before a recursive context method is
+    /// called. The borrow checker enforces this when the borrow is used after
+    /// that call.
+    ///
+    /// ```compile_fail
+    /// use tvm_ffi::{
+    ///     structural_visit, Array, Result, VisitCallbacks, VisitContext, VisitInterrupt,
+    ///     VisitValue,
+    /// };
+    ///
+    /// #[derive(Default)]
+    /// struct Depth {
+    ///     current: usize,
+    /// }
+    ///
+    /// fn visit_any(
+    ///     _value: &VisitValue,
+    ///     context: &mut VisitContext<'_, Depth>,
+    /// ) -> Result<Option<VisitInterrupt>> {
+    ///     let current = &mut context.state_mut().current;
+    ///     *current += 1;
+    ///     context.visit_children()?;
+    ///     *current -= 1; // `current` cannot stay borrowed across recursion.
+    ///     Ok(None)
+    /// }
+    ///
+    /// let root = Array::new(vec![1_i64]);
+    /// let mut visitor = VisitCallbacks::new(Depth::default(), visit_any);
+    /// structural_visit(&root, &mut visitor).unwrap();
+    /// ```
+    pub fn state_mut(&mut self) -> &mut State {
+        self.driver.state_mut()
+    }
+
+    /// Complete borrowed value active at this callback.
+    pub fn current(&self) -> &VisitValue {
+        &self.current
+    }
+
     /// Definition-region state active at the callback's current value.
     pub fn def_region_kind(&self) -> DefRegionKind {
         self.def_region_kind
@@ -257,7 +326,7 @@ impl VisitorRef<'_> {
     /// An interrupt is returned as `Ok(Some(..))`, so a callback that wants to
     /// propagate it must return that value explicitly; `?` propagates errors,
     /// not interrupts.
-    pub fn visit<T>(&self, child: &T) -> Result<Option<VisitInterrupt>>
+    pub fn visit<T>(&mut self, child: &T) -> Result<Option<VisitInterrupt>>
     where
         for<'x> AnyView<'x>: From<&'x T>,
     {
@@ -266,7 +335,7 @@ impl VisitorRef<'_> {
 
     /// Visit `child` using an explicit definition-region state.
     pub fn visit_with<T>(
-        &self,
+        &mut self,
         child: &T,
         def_region_kind: DefRegionKind,
     ) -> Result<Option<VisitInterrupt>>
@@ -277,56 +346,45 @@ impl VisitorRef<'_> {
         if raw.type_index == TVMFFITypeIndex::kTVMFFINone as i32 {
             return Ok(None);
         }
-        finish(with_current_visitor_context(
-            self.visitor,
-            self.context,
-            || call_visitor(self.visitor, raw, def_region_kind),
-        ))
+        self.driver.visit_raw(raw, def_region_kind)
     }
 
     /// Visit the current value's children using registered hooks or reflected
     /// structural fields. The current value itself is not dispatched again.
-    pub fn visit_children(&self) -> Result<Option<VisitInterrupt>> {
-        let result = visit_children_raw(
-            self.current,
-            &mut HandleChildren {
-                visitor: self.visitor,
-                context: self.context,
-            },
-            self.context,
-            self.def_region_kind,
-        )
-        .map_err(|halt| with_value_context(halt, self.current));
-        finish(result)
+    pub fn visit_children(&mut self) -> Result<Option<VisitInterrupt>> {
+        self.driver
+            .visit_children_raw(self.current.raw(), self.def_region_kind)
     }
 }
 
 /// Conversion into the visitor argument accepted by [`structural_visit`].
 ///
 /// Supported inputs are `&mut V` for a hand-written [`StructuralVisitor`], a
-/// typed `Fn(value, &VisitorRef)` callback, or a tuple of such callbacks. A
-/// callback chain uses first-match dispatch; unmatched values recurse through
-/// their default children. Callbacks must implement `Fn` because invoking a
-/// handle method may recursively re-enter the same callback. Use `Cell` or
-/// `RefCell` for callback-local state, or pass `&mut StructuralVisitor` when
-/// ordinary mutable state is more convenient.
+/// typed `Fn(value, &mut VisitContext<'_, ()>)` callback, or a tuple of such
+/// callbacks. A callback chain uses first-match dispatch; unmatched values
+/// recurse through their default children. Use [`VisitCallbacks`] to give a
+/// callback chain ordinary mutable state.
+///
+/// Callback code still implements `Fn`, because recursive context methods may
+/// re-enter the same callback. All mutation instead goes through the single
+/// `&mut VisitContext`, so recursive calls are ordinary checked reborrows.
 ///
 /// A closure that mutates captured state directly is therefore rejected:
 ///
 /// ```compile_fail
-/// use tvm_ffi::{structural_visit, Array, VisitorRef};
+/// use tvm_ffi::{structural_visit, Array, VisitContext};
 ///
 /// let root = Array::new(vec![1_i64]);
 /// let mut total = 0_i64;
-/// structural_visit(&root, |value: i64, _visitor: &VisitorRef<'_>| {
+/// structural_visit(&root, |value: i64, _visitor: &mut VisitContext<'_, ()>| {
 ///     total += value;
 /// })
 /// .unwrap();
 /// ```
 #[diagnostic::on_unimplemented(
     message = "`{Self}` is not a supported `structural_visit` visitor",
-    note = "accepted visitors: `&mut V` where `V: StructuralVisitor`; an `Fn` callback over an FFI value type `T`, `&N` of an object node type, or `&VisitValue`, followed by `&VisitorRef`; or a tuple of up to 12 such callbacks (tuples may nest)",
-    note = "callback arguments need explicit type annotations; callbacks must implement `Fn`, not `FnMut`, because recursive visits may re-enter the same callback"
+    note = "accepted visitors: `&mut V` where `V: StructuralVisitor`; an `Fn` callback over an FFI value type `T`, `&N` of an object node type, or `&VisitValue`, followed by `&mut VisitContext<'_, ()>`; or a tuple of up to 12 such callbacks (tuples may nest)",
+    note = "callback arguments need explicit type annotations; use `VisitCallbacks::new(state, callbacks)` for ordinary mutable callback state"
 )]
 pub trait IntoVisitor<Marker> {
     #[doc(hidden)]
@@ -348,37 +406,43 @@ impl<V: StructuralVisitor> IntoVisitor<V> for &mut V {
 /// The first matching link runs. Returning `None` means this link's value
 /// type did not match; a matched callback returning normally owns traversal
 /// and does not trigger implicit child recursion.
-pub trait VisitChainLink<Marker>: visit_sealed::SealedLink<Marker> {
+pub trait VisitChainLink<State, Marker>: visit_sealed::SealedLink<State, Marker> {
     #[doc(hidden)]
     fn try_visit(
         &self,
         value: &VisitValue,
-        visitor: &VisitorRef<'_>,
+        visitor: &mut VisitContext<'_, State>,
     ) -> Option<Result<Option<VisitInterrupt>>>;
 }
 
 mod visit_sealed {
-    use super::{IntoVisitOutcome, ObjectCore, VisitValue, VisitorRef};
+    use super::{IntoVisitOutcome, ObjectCore, VisitContext, VisitValue};
 
-    pub trait SealedLink<Marker> {}
+    pub trait SealedLink<State, Marker> {}
 
-    impl<F, T, O> SealedLink<super::ByVisitOwnedLink<T>> for F
+    impl<F, State, T, O> SealedLink<State, super::ByVisitOwnedLink<T>> for F
     where
-        F: for<'a> Fn(T, &'a VisitorRef<'a>) -> O,
+        F: for<'context, 'driver> Fn(T, &'context mut VisitContext<'driver, State>) -> O,
         O: IntoVisitOutcome,
     {
     }
 
-    impl<F, N: ObjectCore, O> SealedLink<super::ByVisitNodeLink<N>> for F
+    impl<F, State, N: ObjectCore, O> SealedLink<State, super::ByVisitNodeLink<N>> for F
     where
-        F: for<'a> Fn(&'a N, &'a VisitorRef<'a>) -> O,
+        F: for<'value, 'context, 'driver> Fn(
+            &'value N,
+            &'context mut VisitContext<'driver, State>,
+        ) -> O,
         O: IntoVisitOutcome,
     {
     }
 
-    impl<F, O> SealedLink<super::ByVisitCatchAllLink> for F
+    impl<F, State, O> SealedLink<State, super::ByVisitCatchAllLink> for F
     where
-        F: for<'a> Fn(&'a VisitValue, &'a VisitorRef<'a>) -> O,
+        F: for<'value, 'context, 'driver> Fn(
+            &'value VisitValue,
+            &'context mut VisitContext<'driver, State>,
+        ) -> O,
         O: IntoVisitOutcome,
     {
     }
@@ -387,16 +451,16 @@ mod visit_sealed {
 #[doc(hidden)]
 pub struct ByVisitOwnedLink<T>(PhantomData<T>);
 
-impl<F, T, O> VisitChainLink<ByVisitOwnedLink<T>> for F
+impl<F, State, T, O> VisitChainLink<State, ByVisitOwnedLink<T>> for F
 where
-    F: for<'a> Fn(T, &'a VisitorRef<'a>) -> O,
+    F: for<'context, 'driver> Fn(T, &'context mut VisitContext<'driver, State>) -> O,
     T: crate::type_traits::AnyCompatible,
     O: IntoVisitOutcome,
 {
     fn try_visit(
         &self,
         value: &VisitValue,
-        visitor: &VisitorRef<'_>,
+        visitor: &mut VisitContext<'_, State>,
     ) -> Option<Result<Option<VisitInterrupt>>> {
         value
             .cast::<T>()
@@ -407,16 +471,19 @@ where
 #[doc(hidden)]
 pub struct ByVisitNodeLink<N>(PhantomData<N>);
 
-impl<F, N, O> VisitChainLink<ByVisitNodeLink<N>> for F
+impl<F, State, N, O> VisitChainLink<State, ByVisitNodeLink<N>> for F
 where
-    F: for<'a> Fn(&'a N, &'a VisitorRef<'a>) -> O,
+    F: for<'value, 'context, 'driver> Fn(
+        &'value N,
+        &'context mut VisitContext<'driver, State>,
+    ) -> O,
     N: ObjectCore,
     O: IntoVisitOutcome,
 {
     fn try_visit(
         &self,
         value: &VisitValue,
-        visitor: &VisitorRef<'_>,
+        visitor: &mut VisitContext<'_, State>,
     ) -> Option<Result<Option<VisitInterrupt>>> {
         value
             .as_node::<N>()
@@ -427,15 +494,18 @@ where
 #[doc(hidden)]
 pub enum ByVisitCatchAllLink {}
 
-impl<F, O> VisitChainLink<ByVisitCatchAllLink> for F
+impl<F, State, O> VisitChainLink<State, ByVisitCatchAllLink> for F
 where
-    F: for<'a> Fn(&'a VisitValue, &'a VisitorRef<'a>) -> O,
+    F: for<'value, 'context, 'driver> Fn(
+        &'value VisitValue,
+        &'context mut VisitContext<'driver, State>,
+    ) -> O,
     O: IntoVisitOutcome,
 {
     fn try_visit(
         &self,
         value: &VisitValue,
-        visitor: &VisitorRef<'_>,
+        visitor: &mut VisitContext<'_, State>,
     ) -> Option<Result<Option<VisitInterrupt>>> {
         Some(self(value, visitor).into_visit_outcome())
     }
@@ -446,20 +516,22 @@ pub struct ByVisitChainLink<Markers>(PhantomData<fn(Markers)>);
 
 macro_rules! impl_visit_chain_link {
     ($(($F:ident, $M:ident, $idx:tt)),+) => {
-        impl<$($F, $M,)+> visit_sealed::SealedLink<ByVisitChainLink<($($M,)+)>> for ($($F,)+)
+        impl<State, $($F, $M,)+>
+            visit_sealed::SealedLink<State, ByVisitChainLink<($($M,)+)>> for ($($F,)+)
         where
-            $($F: VisitChainLink<$M>,)+
+            $($F: VisitChainLink<State, $M>,)+
         {
         }
 
-        impl<$($F, $M,)+> VisitChainLink<ByVisitChainLink<($($M,)+)>> for ($($F,)+)
+        impl<State, $($F, $M,)+> VisitChainLink<State, ByVisitChainLink<($($M,)+)>>
+            for ($($F,)+)
         where
-            $($F: VisitChainLink<$M>,)+
+            $($F: VisitChainLink<State, $M>,)+
         {
             fn try_visit(
                 &self,
                 value: &VisitValue,
-                visitor: &VisitorRef<'_>,
+                visitor: &mut VisitContext<'_, State>,
             ) -> Option<Result<Option<VisitInterrupt>>> {
                 $(
                     if let Some(result) = self.$idx.try_visit(value, visitor) {
@@ -474,9 +546,78 @@ macro_rules! impl_visit_chain_link {
 
 impl_callback_chain_tuple_arities!(impl_visit_chain_link);
 
-struct CallbackVisitor<Link, Marker> {
-    link: Link,
+/// Stateful typed callback visitor.
+///
+/// `callbacks` may be one typed callback or a nested tuple. Every callback
+/// receives the same mutable [`VisitContext`], and therefore the same `State`.
+/// Callback code is stored behind `Rc` so recursive entries can borrow the
+/// mutable visitor while invoking the shared `Fn` independently.
+///
+/// Pass the resulting visitor to [`structural_visit`] by mutable reference;
+/// it can be reused across traversals and its state remains available through
+/// [`Self::state`] or [`Self::into_state`].
+///
+/// ```
+/// use tvm_ffi::{
+///     structural_visit, Array, Result, VisitCallbacks, VisitContext, VisitInterrupt, VisitValue,
+/// };
+///
+/// #[derive(Default)]
+/// struct Stats {
+///     total: i64,
+/// }
+///
+/// fn visit_integer(value: i64, context: &mut VisitContext<'_, Stats>) {
+///     context.state_mut().total += value;
+/// }
+///
+/// fn visit_any(
+///     _value: &VisitValue,
+///     context: &mut VisitContext<'_, Stats>,
+/// ) -> Result<Option<VisitInterrupt>> {
+///     context.visit_children()
+/// }
+///
+/// let root = Array::new(vec![1_i64, 2]);
+/// let mut visitor = VisitCallbacks::new(Stats::default(), (visit_integer, visit_any));
+/// structural_visit(&root, &mut visitor).unwrap();
+/// assert_eq!(visitor.state().total, 3);
+/// ```
+pub struct VisitCallbacks<State, Link, Marker> {
+    state: State,
+    callbacks: Rc<Link>,
     _marker: PhantomData<fn(Marker)>,
+}
+
+impl<State, Link, Marker> VisitCallbacks<State, Link, Marker>
+where
+    Link: VisitChainLink<State, Marker>,
+{
+    /// Construct a stateful callback visitor.
+    pub fn new(state: State, callbacks: Link) -> Self {
+        Self {
+            state,
+            callbacks: Rc::new(callbacks),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<State, Link, Marker> VisitCallbacks<State, Link, Marker> {
+    /// Shared access to the callback state.
+    pub fn state(&self) -> &State {
+        &self.state
+    }
+
+    /// Mutable access to the callback state outside an active recursive call.
+    pub fn state_mut(&mut self) -> &mut State {
+        &mut self.state
+    }
+
+    /// Consume the visitor and return its state.
+    pub fn into_state(self) -> State {
+        self.state
+    }
 }
 
 #[doc(hidden)]
@@ -484,17 +625,14 @@ pub struct ByVisitCallbacks<Marker>(PhantomData<fn(Marker)>);
 
 impl<Link, Marker> IntoVisitor<ByVisitCallbacks<Marker>> for Link
 where
-    Link: VisitChainLink<Marker>,
+    Link: VisitChainLink<(), Marker>,
 {
     fn visit_root(self, root: TVMFFIAny) -> Result<Option<VisitInterrupt>> {
-        let visitor: CallbackVisitor<Link, Marker> = CallbackVisitor {
-            link: self,
-            _marker: PhantomData,
-        };
-        finish(run_shared_structural_visitor(
+        let mut visitor = VisitCallbacks::<(), Link, Marker>::new((), self);
+        finish(run_structural_visitor(
             root,
-            &visitor,
-            callback_runtime_vtable::<Link, Marker>(),
+            &mut visitor,
+            user_runtime_vtable::<VisitCallbacks<(), Link, Marker>>(),
         ))
     }
 }
@@ -1041,6 +1179,73 @@ pub trait StructuralVisitor: Sized {
     }
 }
 
+impl<State, Link, Marker> StructuralVisitor for VisitCallbacks<State, Link, Marker>
+where
+    Link: VisitChainLink<State, Marker>,
+{
+    fn visit(
+        &mut self,
+        value: &VisitValue,
+        def_region_kind: DefRegionKind,
+    ) -> Result<Option<VisitInterrupt>> {
+        // Clone the pointer, not the callback state. The callback allocation
+        // is then independent from the mutable borrow placed in `context`, so
+        // recursive entries can invoke the same `Fn` through a checked reborrow
+        // of this visitor.
+        let callbacks = Rc::clone(&self.callbacks);
+        let mut context = VisitContext {
+            driver: self,
+            current: VisitValue::from_raw(value.raw()),
+            def_region_kind,
+            _not_send_sync: PhantomData,
+        };
+        match callbacks.try_visit(value, &mut context) {
+            Some(outcome) => outcome,
+            None => context.visit_children(),
+        }
+    }
+}
+
+impl<State, Link, Marker> VisitContextDriver<State> for VisitCallbacks<State, Link, Marker>
+where
+    Link: VisitChainLink<State, Marker>,
+{
+    fn state(&self) -> &State {
+        &self.state
+    }
+
+    fn state_mut(&mut self) -> &mut State {
+        &mut self.state
+    }
+
+    fn visit_raw(
+        &mut self,
+        raw: TVMFFIAny,
+        def_region_kind: DefRegionKind,
+    ) -> Result<Option<VisitInterrupt>> {
+        if raw.type_index == TVMFFITypeIndex::kTVMFFINone as i32 {
+            return Ok(None);
+        }
+        let active = active_structural_visitor()?;
+        let context = std::ptr::from_mut(self).cast::<c_void>();
+        finish(with_current_visitor_context(active, context, || {
+            call_visitor(active, raw, def_region_kind)
+        }))
+    }
+
+    fn visit_children_raw(
+        &mut self,
+        raw: TVMFFIAny,
+        def_region_kind: DefRegionKind,
+    ) -> Result<Option<VisitInterrupt>> {
+        <Self as StructuralVisitor>::default_visit_children(
+            self,
+            &VisitValue::from_raw(raw),
+            def_region_kind,
+        )
+    }
+}
+
 /// Internal per-value protocol driven by the recursion engine. Public only
 /// as the bound of [`IntoWalker::Walker`]; not meant to be implemented
 /// outside this crate.
@@ -1091,26 +1296,6 @@ impl<V: StructuralVisitor> ChildVisit for UserChildren<'_, V> {
             Ok(Some(interrupt)) => Err(NativeHalt::Interrupt(interrupt.value)),
             Err(error) => Err(NativeHalt::Error(error)),
         }
-    }
-}
-
-/// Callback-layer child dispatch. Each child re-enters the active ABI visitor
-/// after temporarily exposing the same shared callback context. The context is
-/// never converted to a mutable reference on this path.
-struct HandleChildren {
-    visitor: StructuralVisitorHandle,
-    context: *mut c_void,
-}
-
-impl ChildVisit for HandleChildren {
-    #[inline]
-    fn visit_child(&mut self, child: TVMFFIAny, def_region_kind: DefRegionKind) -> NativeResult {
-        if child.type_index == TVMFFITypeIndex::kTVMFFINone as i32 {
-            return Ok(());
-        }
-        with_current_visitor_context(self.visitor, self.context, || {
-            call_visitor(self.visitor, child, def_region_kind)
-        })
     }
 }
 
@@ -1371,15 +1556,6 @@ fn user_runtime_vtable<V: StructuralVisitor>() -> &'static StructuralVisitorVTab
     }
 }
 
-fn callback_runtime_vtable<Link, Marker>() -> &'static StructuralVisitorVTable
-where
-    Link: VisitChainLink<Marker>,
-{
-    &StructuralVisitorVTable {
-        visit: rust_vtable_callback::<Link, Marker>,
-    }
-}
-
 struct RuntimeContextGuard {
     active: *mut ActiveStructuralVisitor,
     context: *mut c_void,
@@ -1436,18 +1612,6 @@ unsafe extern "C" fn rust_vtable_user<V: StructuralVisitor>(
 ) -> TVMFFIAny {
     rust_vtable_visit_impl(visitor, value, |context, raw, kind| {
         runtime_user_visit::<V>(context, raw, kind)
-    })
-}
-
-unsafe extern "C" fn rust_vtable_callback<Link, Marker>(
-    visitor: StructuralVisitorHandle,
-    value: AnyView<'static>,
-) -> TVMFFIAny
-where
-    Link: VisitChainLink<Marker>,
-{
-    rust_vtable_visit_impl(visitor, value, |context, raw, kind| {
-        runtime_callback_visit::<Link, Marker>(context, raw, kind)
     })
 }
 
@@ -1646,72 +1810,12 @@ unsafe fn runtime_user_visit<V: StructuralVisitor>(
     }
 }
 
-#[inline(always)]
-unsafe fn runtime_callback_visit<Link, Marker>(
-    context: *mut c_void,
-    raw: TVMFFIAny,
-    def_region_kind: DefRegionKind,
-) -> NativeResult
-where
-    Link: VisitChainLink<Marker>,
-{
-    if raw.type_index == TVMFFITypeIndex::kTVMFFINone as i32 {
-        return Ok(());
-    }
-
-    // SAFETY: callback-backed traversals install a pointer derived from a
-    // shared `CallbackVisitor` reference. Every recursive entry on this path
-    // reconstructs only a shared reference, so re-entering an `Fn` callback
-    // cannot create overlapping mutable borrows.
-    let callback = &*context.cast::<CallbackVisitor<Link, Marker>>();
-    let active = active_structural_visitor()?;
-    let visitor = VisitorRef {
-        visitor: active,
-        context,
-        current: raw,
-        def_region_kind,
-        _lifetime: PhantomData,
-    };
-    let outcome = match callback
-        .link
-        .try_visit(&VisitValue::from_raw(raw), &visitor)
-    {
-        Some(outcome) => outcome,
-        None => visitor.visit_children(),
-    };
-    match outcome {
-        Ok(None) => Ok(()),
-        Ok(Some(interrupt)) => Err(NativeHalt::Interrupt(interrupt.value)),
-        Err(error) => Err(NativeHalt::Error(error)),
-    }
-}
-
 fn run_structural_visitor<D>(
     root: TVMFFIAny,
     driver: &mut D,
     vtable: &'static StructuralVisitorVTable,
 ) -> NativeResult {
     let context = std::ptr::from_mut(driver).cast::<c_void>();
-    run_structural_visitor_with_context(root, context, vtable)
-}
-
-fn run_shared_structural_visitor<D>(
-    root: TVMFFIAny,
-    driver: &D,
-    vtable: &'static StructuralVisitorVTable,
-) -> NativeResult {
-    // The ABI stores an opaque mutable pointer, but callback vtables must only
-    // reconstruct `&D` from it. Keeping this wrapper separate makes that
-    // shared-only invariant explicit at the construction site.
-    let context = std::ptr::from_ref(driver).cast_mut().cast::<c_void>();
-    run_structural_visitor_with_context(root, context, vtable)
-}
-
-fn run_structural_visitor_with_context(
-    root: TVMFFIAny,
-    context: *mut c_void,
-    vtable: &'static StructuralVisitorVTable,
-) -> NativeResult {
     let mut active = ObjectArc::new(RuntimeStructuralVisitorObj {
         base: Object::new(),
         vtable,
@@ -1902,9 +2006,11 @@ fn with_value_context(halt: NativeHalt, value: TVMFFIAny) -> NativeHalt {
 ///
 /// Passing `&mut V` for `V: StructuralVisitor` preserves the low-level API:
 /// `V::visit` receives the root and controls recursion. A typed `Fn(value,
-/// &VisitorRef)` callback or callback tuple builds a temporary visitor. The
-/// first matching callback owns traversal of that value; unmatched values use
-/// default child recursion. An FFI `None` root completes immediately.
+/// &mut VisitContext<'_, ()>)` callback or callback tuple builds a temporary
+/// visitor. [`VisitCallbacks`] adds ordinary mutable state to the same callback
+/// model. The first matching callback owns traversal of that value; unmatched
+/// values use default child recursion. An FFI `None` root completes
+/// immediately.
 pub fn structural_visit<R, M>(
     root: &R,
     visitor: impl IntoVisitor<M>,

--- a/rust/tvm-ffi/src/lib.rs
+++ b/rust/tvm-ffi/src/lib.rs
@@ -53,8 +53,8 @@ pub use crate::extra::structural_mutate::{
 };
 pub use crate::extra::structural_visit::{
     structural_visit, structural_walk, DefRegionKind, IntoVisitResult, IntoVisitor, IntoWalker,
-    StructuralVisitor, VisitChainLink, VisitDispatch, VisitInterrupt, VisitValue, VisitorRef,
-    WalkChainLink, WalkOrder, WalkResult,
+    StructuralVisitor, VisitChainLink, VisitInterrupt, VisitValue, VisitorRef, WalkChainLink,
+    WalkDispatch, WalkOrder, WalkResult,
 };
 pub use crate::function::Function;
 pub use crate::object::ObjectRefCast;

--- a/rust/tvm-ffi/src/lib.rs
+++ b/rust/tvm-ffi/src/lib.rs
@@ -47,13 +47,14 @@ pub use crate::error::{
 };
 pub use crate::extra::module::Module;
 pub use crate::extra::structural_mutate::{
-    structural_map, structural_mutate, InplaceValue, IntoMapResult, IntoMapper, MapChainLink,
-    MapDispatch, MapValue, StructuralMutator, StructuralVarRemap,
+    structural_map, structural_mutate, InplaceValue, IntoMapResult, IntoMapper, IntoMutator,
+    MapChainLink, MapDispatch, MapValue, MutateChainLink, MutatorRef, StructuralMutator,
+    StructuralVarRemap,
 };
 pub use crate::extra::structural_visit::{
-    structural_visit, structural_walk, DefRegionKind, IntoVisitResult, IntoWalker,
-    StructuralVisitor, VisitDispatch, VisitInterrupt, VisitValue, WalkChainLink, WalkOrder,
-    WalkResult,
+    structural_visit, structural_walk, DefRegionKind, IntoVisitResult, IntoVisitor, IntoWalker,
+    StructuralVisitor, VisitChainLink, VisitDispatch, VisitInterrupt, VisitValue, VisitorRef,
+    WalkChainLink, WalkOrder, WalkResult,
 };
 pub use crate::function::Function;
 pub use crate::object::ObjectRefCast;

--- a/rust/tvm-ffi/src/lib.rs
+++ b/rust/tvm-ffi/src/lib.rs
@@ -52,7 +52,7 @@ pub use crate::extra::structural_mutate::{
     StructuralMutator, StructuralVarRemap,
 };
 pub use crate::extra::structural_visit::{
-    structural_visit, structural_walk, DefRegionKind, IntoVisitResult, IntoVisitor, IntoWalker,
+    structural_visit, structural_walk, DefRegionKind, IntoVisitor, IntoWalkResult, IntoWalker,
     StructuralVisitor, VisitCallbacks, VisitChainLink, VisitContext, VisitInterrupt, VisitValue,
     WalkChainLink, WalkDispatch, WalkOrder, WalkResult,
 };

--- a/rust/tvm-ffi/src/lib.rs
+++ b/rust/tvm-ffi/src/lib.rs
@@ -48,13 +48,13 @@ pub use crate::error::{
 pub use crate::extra::module::Module;
 pub use crate::extra::structural_mutate::{
     structural_map, structural_mutate, InplaceValue, IntoMapResult, IntoMapper, IntoMutator,
-    MapChainLink, MapDispatch, MapValue, MutateChainLink, MutatorRef, StructuralMutator,
-    StructuralVarRemap,
+    MapChainLink, MapDispatch, MapValue, MutateCallbacks, MutateChainLink, MutateContext,
+    StructuralMutator, StructuralVarRemap,
 };
 pub use crate::extra::structural_visit::{
     structural_visit, structural_walk, DefRegionKind, IntoVisitResult, IntoVisitor, IntoWalker,
-    StructuralVisitor, VisitChainLink, VisitInterrupt, VisitValue, VisitorRef, WalkChainLink,
-    WalkDispatch, WalkOrder, WalkResult,
+    StructuralVisitor, VisitCallbacks, VisitChainLink, VisitContext, VisitInterrupt, VisitValue,
+    WalkChainLink, WalkDispatch, WalkOrder, WalkResult,
 };
 pub use crate::function::Function;
 pub use crate::object::ObjectRefCast;

--- a/rust/tvm-ffi/tests/test_structural_mutate.rs
+++ b/rust/tvm-ffi/tests/test_structural_mutate.rs
@@ -1376,6 +1376,133 @@ fn generated_map_dispatch_supports_kind_and_ordered_catch_all() {
     assert_eq!(mapper.catch_all, 1);
 }
 
+#[derive(Default)]
+struct GeneratedLeafMutator {
+    integers: Vec<(i64, DefRegionKind)>,
+}
+
+#[dispatch(mutate)]
+impl GeneratedLeafMutator {
+    fn mutate_integer(&mut self, value: i64, kind: DefRegionKind) -> Any {
+        self.integers.push((value, kind));
+        Any::from(value + 1)
+    }
+}
+
+#[test]
+fn generated_mutator_defaults_unmatched_values_and_preserves_inplace_permit() {
+    let root = Array::new(vec![1i64, 2]);
+    let root_pointer = array_pointer(&root);
+    let mut mutator = GeneratedLeafMutator::default();
+    let mapped = structural_mutate(root, &mut mutator)
+        .and_then(Array::<i64>::try_from)
+        .unwrap();
+
+    assert_eq!(array_pointer(&mapped), root_pointer);
+    assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![2, 3]);
+    assert_eq!(
+        mutator.integers,
+        vec![(1, DefRegionKind::None), (2, DefRegionKind::None)]
+    );
+}
+
+#[test]
+fn generated_mutator_default_remap_crosses_registered_hooks() {
+    ensure_test_types_registered();
+    let _guard = REGISTERED_HOOK_TEST_LOCK.lock().unwrap();
+    RETAINED_MUTATOR.with(|retained| {
+        retained.take();
+    });
+
+    let mut mutator = GeneratedLeafMutator::default();
+    let mapped = structural_mutate(rust_hook_node(), &mut mutator)
+        .and_then(i64::try_from)
+        .unwrap();
+    assert_eq!(mapped, 2);
+    assert_eq!(mutator.integers, vec![(1, DefRegionKind::None)]);
+    RETAINED_MUTATOR.with(|retained| {
+        retained.take();
+    });
+}
+
+#[derive(Default)]
+struct GeneratedRecursiveMutator {
+    integers: Vec<i64>,
+}
+
+#[dispatch(mutate)]
+impl GeneratedRecursiveMutator {
+    fn mutate_array(&mut self, array: Array<i64>, kind: DefRegionKind) -> Result<Any> {
+        let mut mapped = Vec::with_capacity(array.len());
+        for value in array.iter() {
+            mapped.push(i64::try_from(self.mutate_child(&value, kind)?)?);
+        }
+        Ok(Any::from(Array::new(mapped)))
+    }
+
+    fn mutate_integer(&mut self, value: i64) -> Any {
+        self.integers.push(value);
+        Any::from(value + 10)
+    }
+}
+
+#[test]
+fn generated_mutator_can_drive_recursion_through_mut_self() {
+    let mut mutator = GeneratedRecursiveMutator::default();
+    let mapped = structural_mutate(Array::new(vec![1i64, 2]), &mut mutator)
+        .and_then(Array::<i64>::try_from)
+        .unwrap();
+
+    assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![11, 12]);
+    assert_eq!(mutator.integers, vec![1, 2]);
+}
+
+struct GeneratedRemappingMutator {
+    type_index: i32,
+    calls: usize,
+}
+
+#[dispatch(mutate)]
+impl GeneratedRemappingMutator {
+    fn mutate_dag_node(&mut self, _value: &RustDagNodeObj) -> Any {
+        Any::from(42i64)
+    }
+
+    fn mutate_any(&mut self, value: &MapValue, kind: DefRegionKind) -> Result<Any> {
+        if value.type_index() != self.type_index {
+            return self.default_mutate(value, kind);
+        }
+        if let Some(mapped) = self.var_remap_get(value)? {
+            return Ok(mapped);
+        }
+        self.calls += 1;
+        let mapped = Any::from(41i64);
+        self.var_remap_set(value, &mapped)?;
+        Ok(mapped)
+    }
+}
+
+#[test]
+fn generated_mutator_uses_fresh_invocation_local_var_remap() {
+    ensure_test_types_registered();
+    let var = rust_free_var();
+    let mut mutator = GeneratedRemappingMutator {
+        type_index: RustFreeVarObj::type_index(),
+        calls: 0,
+    };
+
+    for expected_calls in [1, 2] {
+        let root = call_global(
+            "ffi.Array",
+            &[Any::from(var.clone()), Any::from(var.clone())],
+        );
+        let mapped = structural_mutate(root, &mut mutator).unwrap();
+        assert_eq!(mutator.calls, expected_calls);
+        assert_eq!(i64::try_from(array_item(&mapped, 0)).unwrap(), 41);
+        assert_eq!(i64::try_from(array_item(&mapped, 1)).unwrap(), 41);
+    }
+}
+
 #[test]
 fn pre_order_retained_alias_disables_in_place_mutation() {
     ensure_test_types_registered();

--- a/rust/tvm-ffi/tests/test_structural_mutate.rs
+++ b/rust/tvm-ffi/tests/test_structural_mutate.rs
@@ -1408,7 +1408,7 @@ fn closures_and_tuples_use_ordered_first_match() {
 }
 
 #[test]
-fn eight_link_tuple_reaches_final_map_dispatch() {
+fn twelve_link_tuple_reaches_final_map_dispatch() {
     let mut final_dispatch = IncrementIntegers;
     let mapped = structural_map(
         1i64,
@@ -1420,6 +1420,10 @@ fn eight_link_tuple_reaches_final_map_dispatch() {
             |_node: &RustDagNodeObj| Any::new(),
             |_node: &RustFreeVarObj| Any::new(),
             |value: Array<i64>| Any::from(value),
+            |value: Array<f64>| Any::from(value),
+            |value: Array<bool>| Any::from(value),
+            |value: Array<FfiString>, _kind: DefRegionKind| Any::from(value),
+            |value: Map<FfiString, i64>| Any::from(value),
             &mut final_dispatch,
         ),
         WalkOrder::PostOrder,
@@ -1428,6 +1432,51 @@ fn eight_link_tuple_reaches_final_map_dispatch() {
     .unwrap();
 
     assert_eq!(mapped, 2);
+}
+
+#[test]
+fn nested_tuple_chain_exceeds_flat_arity() {
+    // A tuple is itself a link, so nesting lifts the 12-wide flat cap:
+    // 12 + 3 = 15 links here, three levels deep. Order is the flattened
+    // depth-first order: the typed i64 link claims integers before the
+    // nested catch-all, which therefore only sees the array itself.
+    ensure_test_types_registered();
+    let root = Array::new(vec![1i64, 2, 3]);
+    let mut catch_all = 0;
+    let mapped = structural_map(
+        root,
+        (
+            (
+                |_value: bool| Any::from(false),
+                |_value: f64| Any::from(0.0f64),
+                |value: FfiString| Any::from(value),
+                |value: Function| Any::from(value),
+                |_node: &RustDagNodeObj| Any::new(),
+                |_node: &RustFreeVarObj| Any::new(),
+                |value: Array<f64>| Any::from(value),
+                |value: Array<bool>| Any::from(value),
+                |value: Array<Array<i64>>| Any::from(value),
+                |value: Map<FfiString, i64>| Any::from(value),
+                |value: Array<Function>, _kind: DefRegionKind| Any::from(value),
+                |value: Map<i64, i64>| Any::from(value),
+            ),
+            (
+                |value: i64| Any::from(value * 10),
+                (
+                    |value: Array<FfiString>| Any::from(value),
+                    (|value: &MapValue| {
+                        catch_all += 1;
+                        value.to_owned()
+                    },),
+                ),
+            ),
+        ),
+        WalkOrder::PostOrder,
+    )
+    .and_then(Array::<i64>::try_from)
+    .unwrap();
+    assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![10, 20, 30]);
+    assert_eq!(catch_all, 1);
 }
 
 #[test]

--- a/rust/tvm-ffi/tests/test_structural_mutate.rs
+++ b/rust/tvm-ffi/tests/test_structural_mutate.rs
@@ -29,7 +29,7 @@ use tvm_ffi::tvm_ffi_sys::{
 };
 use tvm_ffi::{
     dispatch, structural_map, structural_mutate, Any, AnyView, Array, DefRegionKind, Error,
-    Function, InplaceValue, Map, MapDispatch, MapValue, Object, ObjectArc, ObjectCore,
+    Function, InplaceValue, Map, MapDispatch, MapValue, MutatorRef, Object, ObjectArc, ObjectCore,
     ObjectRefCore, Result, String as FfiString, StructuralMutator, StructuralVarRemap, TypeIndex,
     WalkOrder, RUNTIME_ERROR,
 };
@@ -803,9 +803,11 @@ fn user_driven_mutator_controls_default_recursion_and_in_place_opt_in() {
     ensure_test_types_registered();
     let unique = Array::new(vec![1i64, 2]);
     let unique_pointer = array_pointer(&unique);
-    let mapped = structural_mutate(unique, &mut ManualIncrement::default())
-        .and_then(Array::<i64>::try_from)
-        .unwrap();
+    // Keep the original two-parameter turbofish form source-compatible.
+    let mapped =
+        structural_mutate::<Array<i64>, ManualIncrement>(unique, &mut ManualIncrement::default())
+            .and_then(Array::<i64>::try_from)
+            .unwrap();
     assert_eq!(array_pointer(&mapped), unique_pointer);
     assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![2, 3]);
 
@@ -1083,6 +1085,23 @@ fn callback_errors_preserve_message_and_add_object_context() {
     assert_eq!(error.message(), "mapper failed");
     assert!(error.backtrace().contains("origin"));
     assert!(error.backtrace().contains("object `ffi.Array`"));
+
+    let error = match structural_mutate(
+        Array::new(vec![1i64]),
+        |_integer: i64, _mutator: &MutatorRef<'_>| -> Result<Any> {
+            Err(Error::new(
+                RUNTIME_ERROR,
+                "callback mutator failed",
+                "callback origin",
+            ))
+        },
+    ) {
+        Ok(_) => panic!("fallible callback mutator unexpectedly succeeded"),
+        Err(error) => error,
+    };
+    assert_eq!(error.message(), "callback mutator failed");
+    assert!(error.backtrace().contains("callback origin"));
+    assert!(error.backtrace().contains("object `ffi.Array`"));
 }
 
 #[test]
@@ -1113,6 +1132,21 @@ fn registered_mutation_hooks_receive_the_rust_mutator() {
         Err(error) => error,
     };
     assert!(error.message().contains("retained after its active call"));
+
+    let mutate_calls_before = REGISTERED_MUTATE_CALLS.load(Ordering::Relaxed);
+    let mapped = structural_mutate(source.clone(), |value: i64, _mutator: &MutatorRef<'_>| {
+        Any::from(value + 1)
+    })
+    .and_then(i64::try_from)
+    .unwrap();
+    assert_eq!(mapped, 2);
+    assert_eq!(
+        REGISTERED_MUTATE_CALLS.load(Ordering::Relaxed),
+        mutate_calls_before + 1
+    );
+    RETAINED_MUTATOR.with(|retained| {
+        retained.take();
+    });
 
     let maybe_inplace_calls_before = REGISTERED_MAYBE_INPLACE_MUTATE_CALLS.load(Ordering::Relaxed);
     let mapped = structural_mutate(rust_hook_node(), &mut ManualIncrement::default())
@@ -1556,4 +1590,217 @@ fn map_keys_are_anchors_and_object_leaves_are_preserved() {
             .unwrap(),
         "leaf"
     );
+}
+
+#[test]
+fn callback_mutate_defaults_unmatched_values_and_preserves_root_permit() {
+    ensure_test_types_registered();
+    let root = Array::new(vec![1i64, 2]);
+    let root_pointer = array_pointer(&root);
+    let mapped = structural_mutate(root, |value: i64, _mutator: &MutatorRef<'_>| {
+        Any::from(value + 1)
+    })
+    .and_then(Array::<i64>::try_from)
+    .unwrap();
+    assert_eq!(array_pointer(&mapped), root_pointer);
+    assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![2, 3]);
+}
+
+#[test]
+fn callback_mutate_current_default_is_repeatable_copy_path() {
+    ensure_test_types_registered();
+    let root = Array::new(vec![1i64, 2]);
+    let root_pointer = array_pointer(&root);
+    let defaults = Cell::new(0);
+    let mapped = structural_mutate(
+        root,
+        (
+            |value: i64, _mutator: &MutatorRef<'_>| Any::from(value + 1),
+            |_value: &MapValue, mutator: &MutatorRef<'_>| -> Result<Any> {
+                defaults.set(defaults.get() + 1);
+                let first = mutator.default_mutate()?;
+                let second = mutator.default_mutate()?;
+                assert_ne!(any_object_pointer(&first), any_object_pointer(&second));
+                Ok(first)
+            },
+        ),
+    )
+    .and_then(Array::<i64>::try_from)
+    .unwrap();
+    assert_ne!(array_pointer(&mapped), root_pointer);
+    assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![2, 3]);
+    assert_eq!(defaults.get(), 1);
+}
+
+#[test]
+fn callback_mutate_match_is_final_and_same_fn_can_reenter() {
+    ensure_test_types_registered();
+    let integer_calls = Cell::new(0);
+    let mapped = structural_mutate(
+        Array::new(vec![1i64]),
+        (
+            |_array: Array<i64>, _mutator: &MutatorRef<'_>| Any::from(Array::new(vec![10i64])),
+            |value: i64, _mutator: &MutatorRef<'_>| {
+                integer_calls.set(integer_calls.get() + 1);
+                Any::from(value + 1)
+            },
+        ),
+    )
+    .and_then(Array::<i64>::try_from)
+    .unwrap();
+    assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![10]);
+    assert_eq!(integer_calls.get(), 0);
+
+    let calls = Cell::new(0);
+    let mapped = structural_mutate(
+        Array::new(vec![1i64, 2]),
+        |_value: &MapValue, mutator: &MutatorRef<'_>| {
+            calls.set(calls.get() + 1);
+            mutator.default_mutate()
+        },
+    )
+    .and_then(Array::<i64>::try_from)
+    .unwrap();
+    assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![1, 2]);
+    assert_eq!(calls.get(), 3);
+}
+
+#[test]
+fn callback_mutate_supports_node_links_nested_tuples_and_reflection() {
+    ensure_test_types_registered();
+    let _guard = REFLECTED_TEST_LOCK.lock().unwrap();
+    let root = call_global(
+        "ffi.Array",
+        &[Any::from(rust_dag_node()), Any::from(rust_pair(1i64, 9i64))],
+    );
+    let regions = RefCell::new(Vec::new());
+    let mapped = structural_mutate(
+        root,
+        (
+            (
+                |_value: f64, _mutator: &MutatorRef<'_>| Any::new(),
+                |_node: &RustDagNodeObj, _mutator: &MutatorRef<'_>| Any::from(7i64),
+            ),
+            |value: i64, mutator: &MutatorRef<'_>| {
+                regions.borrow_mut().push(mutator.def_region_kind());
+                Any::from(value + 1)
+            },
+        ),
+    )
+    .unwrap();
+
+    assert_eq!(i64::try_from(array_item(&mapped, 0)).unwrap(), 7);
+    let pair = RustPair::try_from(array_item(&mapped, 1)).unwrap();
+    assert_eq!(i64::try_from(pair.data.first.clone()).unwrap(), 2);
+    assert_eq!(i64::try_from(pair.data.ignored.clone()).unwrap(), 9);
+    assert_eq!(*regions.borrow(), vec![DefRegionKind::Recursive]);
+}
+
+#[test]
+fn callback_mutate_distinguishes_borrowed_and_owned_children() {
+    ensure_test_types_registered();
+    let borrowed_child = Array::new(vec![1i64]);
+    let borrowed_pointer = array_pointer(&borrowed_child);
+    let mapped = structural_mutate(
+        true,
+        (
+            |_value: bool, mutator: &MutatorRef<'_>| mutator.mutate(&borrowed_child),
+            |value: i64, _mutator: &MutatorRef<'_>| Any::from(value + 1),
+        ),
+    )
+    .and_then(Array::<i64>::try_from)
+    .unwrap();
+    assert_ne!(array_pointer(&mapped), borrowed_pointer);
+    assert_eq!(borrowed_child.get(0).unwrap(), 1);
+    assert_eq!(mapped.get(0).unwrap(), 2);
+
+    let owned_pointer = Cell::new(0usize);
+    let mapped = structural_mutate(
+        true,
+        (
+            |_value: bool, mutator: &MutatorRef<'_>| {
+                let child = Array::new(vec![1i64]);
+                owned_pointer.set(array_pointer(&child) as usize);
+                mutator.maybe_inplace_mutate(child)
+            },
+            |value: i64, _mutator: &MutatorRef<'_>| Any::from(value + 1),
+        ),
+    )
+    .and_then(Array::<i64>::try_from)
+    .unwrap();
+    assert_eq!(array_pointer(&mapped) as usize, owned_pointer.get());
+    assert_eq!(mapped.get(0).unwrap(), 2);
+}
+
+#[test]
+fn callback_mutate_can_use_its_invocation_local_var_remap() {
+    ensure_test_types_registered();
+    let var = rust_free_var();
+    let root = call_global("ffi.Array", &[Any::from(var.clone()), Any::from(var)]);
+    let calls = Cell::new(0);
+    let type_index = RustFreeVarObj::type_index();
+    let mapped = structural_mutate(
+        root,
+        |value: &MapValue, mutator: &MutatorRef<'_>| -> Result<Any> {
+            if value.type_index() != type_index {
+                return mutator.default_mutate();
+            }
+            if let Some(mapped) = mutator.var_remap_get(value)? {
+                return Ok(mapped);
+            }
+            calls.set(calls.get() + 1);
+            let mapped = Any::from(41i64);
+            mutator.var_remap_set(value, &mapped)?;
+            Ok(mapped)
+        },
+    )
+    .unwrap();
+    assert_eq!(calls.get(), 1);
+    assert_eq!(i64::try_from(array_item(&mapped, 0)).unwrap(), 41);
+    assert_eq!(i64::try_from(array_item(&mapped, 1)).unwrap(), 41);
+}
+
+#[test]
+fn nested_callback_mutate_restores_the_outer_active_mutator() {
+    let mapped = structural_mutate(
+        1i64,
+        |value: i64, mutator: &MutatorRef<'_>| -> Result<Any> {
+            if value != 1 {
+                return Ok(Any::from(value + 1));
+            }
+            let inner = structural_mutate(2i64, |value: i64, _mutator: &MutatorRef<'_>| {
+                Any::from(value + 10)
+            })?;
+            assert_eq!(i64::try_from(inner).unwrap(), 12);
+            mutator.mutate(&3i64)
+        },
+    )
+    .and_then(i64::try_from)
+    .unwrap();
+    assert_eq!(mapped, 4);
+}
+
+#[test]
+fn callback_mutate_panics_resume_and_leave_the_next_run_usable() {
+    let panic = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        structural_mutate(
+            Array::new(vec![1i64]),
+            |_value: i64, _mutator: &MutatorRef<'_>| -> Any { panic!("callback mutator panic") },
+        )
+    })) {
+        Err(panic) => panic,
+        Ok(_) => panic!("panicking callback mutator unexpectedly returned"),
+    };
+    assert_eq!(
+        panic.downcast_ref::<&str>().copied(),
+        Some("callback mutator panic")
+    );
+
+    let mapped = structural_mutate(
+        Array::new(vec![1i64]),
+        |value: i64, _mutator: &MutatorRef<'_>| Any::from(value + 1),
+    )
+    .and_then(Array::<i64>::try_from)
+    .unwrap();
+    assert_eq!(mapped.get(0).unwrap(), 2);
 }

--- a/rust/tvm-ffi/tests/test_structural_mutate.rs
+++ b/rust/tvm-ffi/tests/test_structural_mutate.rs
@@ -29,9 +29,9 @@ use tvm_ffi::tvm_ffi_sys::{
 };
 use tvm_ffi::{
     dispatch, structural_map, structural_mutate, Any, AnyView, Array, DefRegionKind, Error,
-    Function, InplaceValue, Map, MapDispatch, MapValue, MutatorRef, Object, ObjectArc, ObjectCore,
-    ObjectRefCore, Result, String as FfiString, StructuralMutator, StructuralVarRemap, TypeIndex,
-    WalkOrder, RUNTIME_ERROR,
+    Function, InplaceValue, Map, MapDispatch, MapValue, MutateCallbacks, MutateContext, Object,
+    ObjectArc, ObjectCore, ObjectRefCore, Result, String as FfiString, StructuralMutator,
+    StructuralVarRemap, TypeIndex, WalkOrder, RUNTIME_ERROR,
 };
 
 // These registration entry points are needed only to build reflected test
@@ -1088,7 +1088,7 @@ fn callback_errors_preserve_message_and_add_object_context() {
 
     let error = match structural_mutate(
         Array::new(vec![1i64]),
-        |_integer: i64, _mutator: &MutatorRef<'_>| -> Result<Any> {
+        |_integer: i64, _mutator: &mut MutateContext<'_, ()>| -> Result<Any> {
             Err(Error::new(
                 RUNTIME_ERROR,
                 "callback mutator failed",
@@ -1134,9 +1134,10 @@ fn registered_mutation_hooks_receive_the_rust_mutator() {
     assert!(error.message().contains("retained after its active call"));
 
     let mutate_calls_before = REGISTERED_MUTATE_CALLS.load(Ordering::Relaxed);
-    let mapped = structural_mutate(source.clone(), |value: i64, _mutator: &MutatorRef<'_>| {
-        Any::from(value + 1)
-    })
+    let mapped = structural_mutate(
+        source.clone(),
+        |value: i64, _mutator: &mut MutateContext<'_, ()>| Any::from(value + 1),
+    )
     .and_then(i64::try_from)
     .unwrap();
     assert_eq!(mapped, 2);
@@ -1724,13 +1725,105 @@ fn callback_mutate_defaults_unmatched_values_and_preserves_root_permit() {
     ensure_test_types_registered();
     let root = Array::new(vec![1i64, 2]);
     let root_pointer = array_pointer(&root);
-    let mapped = structural_mutate(root, |value: i64, _mutator: &MutatorRef<'_>| {
+    let mapped = structural_mutate(root, |value: i64, _mutator: &mut MutateContext<'_, ()>| {
         Any::from(value + 1)
     })
     .and_then(Array::<i64>::try_from)
     .unwrap();
     assert_eq!(array_pointer(&mapped), root_pointer);
     assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![2, 3]);
+}
+
+#[derive(Default)]
+struct CallbackMutateStats {
+    integers: Vec<i64>,
+    defaults: usize,
+}
+
+fn stateful_mutate_integer(
+    value: i64,
+    context: &mut MutateContext<'_, CallbackMutateStats>,
+) -> Any {
+    context.state_mut().integers.push(value);
+    Any::from(value + 1)
+}
+
+fn stateful_mutate_default(
+    _value: &MapValue,
+    context: &mut MutateContext<'_, CallbackMutateStats>,
+) -> Result<Any> {
+    context.state_mut().defaults += 1;
+    context.default_mutate()
+}
+
+#[test]
+fn callback_mutator_carries_reusable_mutable_state() {
+    ensure_test_types_registered();
+    let mut mutator = MutateCallbacks::new(
+        CallbackMutateStats::default(),
+        (stateful_mutate_integer, stateful_mutate_default),
+    );
+
+    let first = structural_mutate(Array::new(vec![1i64, 2]), &mut mutator)
+        .and_then(Array::<i64>::try_from)
+        .unwrap();
+    assert_eq!(first.iter().collect::<Vec<_>>(), vec![2, 3]);
+    assert_eq!(mutator.state().integers, vec![1, 2]);
+    assert_eq!(mutator.state().defaults, 1);
+
+    let second = structural_mutate(Array::new(vec![3i64]), &mut mutator)
+        .and_then(Array::<i64>::try_from)
+        .unwrap();
+    assert_eq!(second.iter().collect::<Vec<_>>(), vec![4]);
+
+    let state = mutator.into_state();
+    assert_eq!(state.integers, vec![1, 2, 3]);
+    assert_eq!(state.defaults, 2);
+}
+
+#[derive(Default)]
+struct CallbackMutateDepth {
+    current: usize,
+    maximum: usize,
+    exits: usize,
+}
+
+fn stateful_mutate_recursive(
+    value: &MapValue,
+    context: &mut MutateContext<'_, CallbackMutateDepth>,
+) -> Result<Any> {
+    assert_eq!(context.current().type_index(), value.type_index());
+    {
+        let state = context.state_mut();
+        state.current += 1;
+        state.maximum = state.maximum.max(state.current);
+    }
+    let mapped = context.default_mutate()?;
+    {
+        let state = context.state_mut();
+        state.current -= 1;
+        state.exits += 1;
+    }
+    Ok(mapped)
+}
+
+#[test]
+fn callback_mutator_state_can_change_around_recursive_reborrows() {
+    ensure_test_types_registered();
+    let root = Array::new(vec![Array::new(vec![1i64, 2])]);
+    let mut mutator =
+        MutateCallbacks::new(CallbackMutateDepth::default(), stateful_mutate_recursive);
+    let mapped = structural_mutate(root, &mut mutator)
+        .and_then(Array::<Array<i64>>::try_from)
+        .unwrap();
+
+    assert_eq!(
+        mapped.get(0).unwrap().iter().collect::<Vec<_>>(),
+        vec![1, 2]
+    );
+    assert_eq!(mutator.state().current, 0);
+    assert_eq!(mutator.state().maximum, 3);
+    assert_eq!(mutator.state().exits, 4);
 }
 
 #[test]
@@ -1742,8 +1835,8 @@ fn callback_mutate_current_default_is_repeatable_copy_path() {
     let mapped = structural_mutate(
         root,
         (
-            |value: i64, _mutator: &MutatorRef<'_>| Any::from(value + 1),
-            |_value: &MapValue, mutator: &MutatorRef<'_>| -> Result<Any> {
+            |value: i64, _mutator: &mut MutateContext<'_, ()>| Any::from(value + 1),
+            |_value: &MapValue, mutator: &mut MutateContext<'_, ()>| -> Result<Any> {
                 defaults.set(defaults.get() + 1);
                 let first = mutator.default_mutate()?;
                 let second = mutator.default_mutate()?;
@@ -1766,8 +1859,10 @@ fn callback_mutate_match_is_final_and_same_fn_can_reenter() {
     let mapped = structural_mutate(
         Array::new(vec![1i64]),
         (
-            |_array: Array<i64>, _mutator: &MutatorRef<'_>| Any::from(Array::new(vec![10i64])),
-            |value: i64, _mutator: &MutatorRef<'_>| {
+            |_array: Array<i64>, _mutator: &mut MutateContext<'_, ()>| {
+                Any::from(Array::new(vec![10i64]))
+            },
+            |value: i64, _mutator: &mut MutateContext<'_, ()>| {
                 integer_calls.set(integer_calls.get() + 1);
                 Any::from(value + 1)
             },
@@ -1781,7 +1876,7 @@ fn callback_mutate_match_is_final_and_same_fn_can_reenter() {
     let calls = Cell::new(0);
     let mapped = structural_mutate(
         Array::new(vec![1i64, 2]),
-        |_value: &MapValue, mutator: &MutatorRef<'_>| {
+        |_value: &MapValue, mutator: &mut MutateContext<'_, ()>| {
             calls.set(calls.get() + 1);
             mutator.default_mutate()
         },
@@ -1805,10 +1900,10 @@ fn callback_mutate_supports_node_links_nested_tuples_and_reflection() {
         root,
         (
             (
-                |_value: f64, _mutator: &MutatorRef<'_>| Any::new(),
-                |_node: &RustDagNodeObj, _mutator: &MutatorRef<'_>| Any::from(7i64),
+                |_value: f64, _mutator: &mut MutateContext<'_, ()>| Any::new(),
+                |_node: &RustDagNodeObj, _mutator: &mut MutateContext<'_, ()>| Any::from(7i64),
             ),
-            |value: i64, mutator: &MutatorRef<'_>| {
+            |value: i64, mutator: &mut MutateContext<'_, ()>| {
                 regions.borrow_mut().push(mutator.def_region_kind());
                 Any::from(value + 1)
             },
@@ -1831,8 +1926,8 @@ fn callback_mutate_distinguishes_borrowed_and_owned_children() {
     let mapped = structural_mutate(
         true,
         (
-            |_value: bool, mutator: &MutatorRef<'_>| mutator.mutate(&borrowed_child),
-            |value: i64, _mutator: &MutatorRef<'_>| Any::from(value + 1),
+            |_value: bool, mutator: &mut MutateContext<'_, ()>| mutator.mutate(&borrowed_child),
+            |value: i64, _mutator: &mut MutateContext<'_, ()>| Any::from(value + 1),
         ),
     )
     .and_then(Array::<i64>::try_from)
@@ -1845,12 +1940,12 @@ fn callback_mutate_distinguishes_borrowed_and_owned_children() {
     let mapped = structural_mutate(
         true,
         (
-            |_value: bool, mutator: &MutatorRef<'_>| {
+            |_value: bool, mutator: &mut MutateContext<'_, ()>| {
                 let child = Array::new(vec![1i64]);
                 owned_pointer.set(array_pointer(&child) as usize);
                 mutator.maybe_inplace_mutate(child)
             },
-            |value: i64, _mutator: &MutatorRef<'_>| Any::from(value + 1),
+            |value: i64, _mutator: &mut MutateContext<'_, ()>| Any::from(value + 1),
         ),
     )
     .and_then(Array::<i64>::try_from)
@@ -1863,12 +1958,11 @@ fn callback_mutate_distinguishes_borrowed_and_owned_children() {
 fn callback_mutate_can_use_its_invocation_local_var_remap() {
     ensure_test_types_registered();
     let var = rust_free_var();
-    let root = call_global("ffi.Array", &[Any::from(var.clone()), Any::from(var)]);
     let calls = Cell::new(0);
     let type_index = RustFreeVarObj::type_index();
-    let mapped = structural_mutate(
-        root,
-        |value: &MapValue, mutator: &MutatorRef<'_>| -> Result<Any> {
+    let mut mutator = MutateCallbacks::new(
+        (),
+        |value: &MapValue, mutator: &mut MutateContext<'_, ()>| -> Result<Any> {
             if value.type_index() != type_index {
                 return mutator.default_mutate();
             }
@@ -1880,24 +1974,32 @@ fn callback_mutate_can_use_its_invocation_local_var_remap() {
             mutator.var_remap_set(value, &mapped)?;
             Ok(mapped)
         },
-    )
-    .unwrap();
-    assert_eq!(calls.get(), 1);
-    assert_eq!(i64::try_from(array_item(&mapped, 0)).unwrap(), 41);
-    assert_eq!(i64::try_from(array_item(&mapped, 1)).unwrap(), 41);
+    );
+
+    for expected_calls in 1..=2 {
+        let root = call_global(
+            "ffi.Array",
+            &[Any::from(var.clone()), Any::from(var.clone())],
+        );
+        let mapped = structural_mutate(root, &mut mutator).unwrap();
+        assert_eq!(calls.get(), expected_calls);
+        assert_eq!(i64::try_from(array_item(&mapped, 0)).unwrap(), 41);
+        assert_eq!(i64::try_from(array_item(&mapped, 1)).unwrap(), 41);
+    }
 }
 
 #[test]
 fn nested_callback_mutate_restores_the_outer_active_mutator() {
     let mapped = structural_mutate(
         1i64,
-        |value: i64, mutator: &MutatorRef<'_>| -> Result<Any> {
+        |value: i64, mutator: &mut MutateContext<'_, ()>| -> Result<Any> {
             if value != 1 {
                 return Ok(Any::from(value + 1));
             }
-            let inner = structural_mutate(2i64, |value: i64, _mutator: &MutatorRef<'_>| {
-                Any::from(value + 10)
-            })?;
+            let inner =
+                structural_mutate(2i64, |value: i64, _mutator: &mut MutateContext<'_, ()>| {
+                    Any::from(value + 10)
+                })?;
             assert_eq!(i64::try_from(inner).unwrap(), 12);
             mutator.mutate(&3i64)
         },
@@ -1912,7 +2014,9 @@ fn callback_mutate_panics_resume_and_leave_the_next_run_usable() {
     let panic = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         structural_mutate(
             Array::new(vec![1i64]),
-            |_value: i64, _mutator: &MutatorRef<'_>| -> Any { panic!("callback mutator panic") },
+            |_value: i64, _mutator: &mut MutateContext<'_, ()>| -> Any {
+                panic!("callback mutator panic")
+            },
         )
     })) {
         Err(panic) => panic,
@@ -1925,7 +2029,7 @@ fn callback_mutate_panics_resume_and_leave_the_next_run_usable() {
 
     let mapped = structural_mutate(
         Array::new(vec![1i64]),
-        |value: i64, _mutator: &MutatorRef<'_>| Any::from(value + 1),
+        |value: i64, _mutator: &mut MutateContext<'_, ()>| Any::from(value + 1),
     )
     .and_then(Array::<i64>::try_from)
     .unwrap();

--- a/rust/tvm-ffi/tests/test_structural_mutate.rs
+++ b/rust/tvm-ffi/tests/test_structural_mutate.rs
@@ -212,14 +212,14 @@ fn run_registered_mutate_hook(args: &[AnyView<'_>], calls: &AtomicUsize) -> Resu
     }
 
     let child = Any::from(1i64);
-    let mapped = Function::get_global("ffi.StructuralMutatorMutate")
+    let mutated = Function::get_global("ffi.StructuralMutatorMutate")
         .unwrap()
         .call_packed(&[args[0], AnyView::from(&child)])?;
     Function::get_global("ffi.StructuralMutatorVarRemapSet")
         .unwrap()
-        .call_packed(&[args[0], args[1], AnyView::from(&mapped)])?;
+        .call_packed(&[args[0], args[1], AnyView::from(&mutated)])?;
     calls.fetch_add(1, Ordering::Relaxed);
-    Ok(mapped)
+    Ok(mutated)
 }
 
 unsafe extern "C" fn any_field_getter(field: *mut std::ffi::c_void, result: *mut TVMFFIAny) -> i32 {
@@ -570,8 +570,8 @@ impl StructuralMutator for ManualIncrement {
         self.remap.get(var)
     }
 
-    fn var_remap_set(&mut self, var: &MapValue, mapped_value: &Any) -> Result<()> {
-        self.remap.set(var, mapped_value)
+    fn var_remap_set(&mut self, var: &MapValue, mutated_value: &Any) -> Result<()> {
+        self.remap.set(var, mutated_value)
     }
 }
 
@@ -603,8 +603,8 @@ impl StructuralMutator for ReplaceNone {
         self.remap.get(var)
     }
 
-    fn var_remap_set(&mut self, var: &MapValue, mapped_value: &Any) -> Result<()> {
-        self.remap.set(var, mapped_value)
+    fn var_remap_set(&mut self, var: &MapValue, mutated_value: &Any) -> Result<()> {
+        self.remap.set(var, mutated_value)
     }
 }
 
@@ -617,13 +617,13 @@ struct RemappingFreeVar {
 impl StructuralMutator for RemappingFreeVar {
     fn mutate(&mut self, value: &MapValue, def_region_kind: DefRegionKind) -> Result<Any> {
         if value.type_index() == self.type_index {
-            if let Some(mapped) = self.remap.get(value)? {
-                return Ok(mapped);
+            if let Some(mutated) = self.remap.get(value)? {
+                return Ok(mutated);
             }
             self.calls += 1;
-            let mapped = Any::from(41i64);
-            self.remap.set(value, &mapped)?;
-            Ok(mapped)
+            let mutated = Any::from(41i64);
+            self.remap.set(value, &mutated)?;
+            Ok(mutated)
         } else {
             self.default_mutate(value, def_region_kind)
         }
@@ -641,8 +641,8 @@ impl StructuralMutator for RemappingFreeVar {
         self.remap.get(var)
     }
 
-    fn var_remap_set(&mut self, var: &MapValue, mapped_value: &Any) -> Result<()> {
-        self.remap.set(var, mapped_value)
+    fn var_remap_set(&mut self, var: &MapValue, mutated_value: &Any) -> Result<()> {
+        self.remap.set(var, mutated_value)
     }
 }
 
@@ -681,8 +681,8 @@ impl StructuralMutator for ChildHelperMutator {
         self.remap.get(var)
     }
 
-    fn var_remap_set(&mut self, var: &MapValue, mapped_value: &Any) -> Result<()> {
-        self.remap.set(var, mapped_value)
+    fn var_remap_set(&mut self, var: &MapValue, mutated_value: &Any) -> Result<()> {
+        self.remap.set(var, mutated_value)
     }
 }
 
@@ -725,8 +725,8 @@ impl StructuralMutator for RejectAliasedReentry {
         self.remap.get(var)
     }
 
-    fn var_remap_set(&mut self, var: &MapValue, mapped_value: &Any) -> Result<()> {
-        self.remap.set(var, mapped_value)
+    fn var_remap_set(&mut self, var: &MapValue, mutated_value: &Any) -> Result<()> {
+        self.remap.set(var, mutated_value)
     }
 }
 
@@ -803,36 +803,35 @@ fn user_driven_mutator_controls_default_recursion_and_in_place_opt_in() {
     ensure_test_types_registered();
     let unique = Array::new(vec![1i64, 2]);
     let unique_pointer = array_pointer(&unique);
-    // Keep the original two-parameter turbofish form source-compatible.
-    let mapped =
+    let mutated =
         structural_mutate::<Array<i64>, ManualIncrement>(unique, &mut ManualIncrement::default())
             .and_then(Array::<i64>::try_from)
             .unwrap();
-    assert_eq!(array_pointer(&mapped), unique_pointer);
-    assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![2, 3]);
+    assert_eq!(array_pointer(&mutated), unique_pointer);
+    assert_eq!(mutated.iter().collect::<Vec<_>>(), vec![2, 3]);
 
     let source = Array::new(vec![3i64]);
     let source_pointer = array_pointer(&source);
-    let mapped = structural_mutate(source.clone(), &mut ManualIncrement::default())
+    let mutated = structural_mutate(source.clone(), &mut ManualIncrement::default())
         .and_then(Array::<i64>::try_from)
         .unwrap();
-    assert_ne!(array_pointer(&mapped), source_pointer);
+    assert_ne!(array_pointer(&mutated), source_pointer);
     assert_eq!(source.get(0).unwrap(), 3);
-    assert_eq!(mapped.get(0).unwrap(), 4);
+    assert_eq!(mutated.get(0).unwrap(), 4);
 
     let map: Map<i64, i64> = [(1, 10)].into_iter().collect();
     let source_map_pointer = map_pointer(&map);
-    let mapped_map = structural_mutate(map, &mut ManualIncrement::default())
+    let mutated_map = structural_mutate(map, &mut ManualIncrement::default())
         .and_then(Map::<i64, i64>::try_from)
         .unwrap();
-    assert_eq!(map_pointer(&mapped_map), source_map_pointer);
-    assert_eq!(mapped_map.get(&1).unwrap(), Some(11));
+    assert_eq!(map_pointer(&mutated_map), source_map_pointer);
+    assert_eq!(mutated_map.get(&1).unwrap(), Some(11));
 
     let dict = call_global("ffi.Dict", &[Any::from(1i64), Any::from(10i64)]);
     let dict_pointer = any_object_pointer(&dict);
-    let mapped_dict = structural_mutate(dict, &mut ManualIncrement::default()).unwrap();
-    assert_eq!(any_object_pointer(&mapped_dict), dict_pointer);
-    assert_eq!(dict_item(&mapped_dict, 1), 11);
+    let mutated_dict = structural_mutate(dict, &mut ManualIncrement::default()).unwrap();
+    assert_eq!(any_object_pointer(&mutated_dict), dict_pointer);
+    assert_eq!(dict_item(&mutated_dict, 1), 11);
 }
 
 #[test]
@@ -853,10 +852,10 @@ fn none_values_are_dispatched_to_map_callbacks_and_user_mutators() {
     assert_eq!(map_calls, 1);
 
     let mut mutator = ReplaceNone::default();
-    let mapped = structural_mutate(Any::new(), &mut mutator)
+    let mutated = structural_mutate(Any::new(), &mut mutator)
         .and_then(i64::try_from)
         .unwrap();
-    assert_eq!(mapped, 8);
+    assert_eq!(mutated, 8);
     assert_eq!(mutator.calls, 1);
 }
 
@@ -872,10 +871,10 @@ fn user_mutator_can_store_a_changed_free_var_result() {
         calls: 0,
     };
 
-    let mapped = structural_mutate(root, &mut mutator).unwrap();
+    let mutated = structural_mutate(root, &mut mutator).unwrap();
     assert_eq!(mutator.calls, 1);
-    assert_eq!(i64::try_from(array_item(&mapped, 0)).unwrap(), 41);
-    assert_eq!(i64::try_from(array_item(&mapped, 1)).unwrap(), 41);
+    assert_eq!(i64::try_from(array_item(&mutated, 0)).unwrap(), 41);
+    assert_eq!(i64::try_from(array_item(&mutated, 1)).unwrap(), 41);
 }
 
 #[test]
@@ -885,24 +884,24 @@ fn user_mutator_child_helpers_reenter_the_same_mutator() {
         use_owned_child: false,
         owned_child_pointer: None,
     };
-    let mapped = structural_mutate(Any::new(), &mut borrowed)
+    let mutated = structural_mutate(Any::new(), &mut borrowed)
         .and_then(i64::try_from)
         .unwrap();
-    assert_eq!(mapped, 2);
+    assert_eq!(mutated, 2);
 
     let mut owned = ChildHelperMutator {
         remap: StructuralVarRemap::default(),
         use_owned_child: true,
         owned_child_pointer: None,
     };
-    let mapped = structural_mutate(Any::new(), &mut owned)
+    let mutated = structural_mutate(Any::new(), &mut owned)
         .and_then(Array::<i64>::try_from)
         .unwrap();
     assert_eq!(
-        array_pointer(&mapped) as usize,
+        array_pointer(&mutated) as usize,
         owned.owned_child_pointer.unwrap()
     );
-    assert_eq!(mapped.get(0).unwrap(), 2);
+    assert_eq!(mutated.get(0).unwrap(), 2);
 }
 
 #[test]
@@ -1114,10 +1113,10 @@ fn registered_mutation_hooks_receive_the_rust_mutator() {
 
     let source = rust_hook_node();
     let mutate_calls_before = REGISTERED_MUTATE_CALLS.load(Ordering::Relaxed);
-    let mapped = structural_mutate(source.clone(), &mut ManualIncrement::default())
+    let mutated = structural_mutate(source.clone(), &mut ManualIncrement::default())
         .and_then(i64::try_from)
         .unwrap();
-    assert_eq!(mapped, 2);
+    assert_eq!(mutated, 2);
     assert_eq!(
         REGISTERED_MUTATE_CALLS.load(Ordering::Relaxed),
         mutate_calls_before + 1
@@ -1134,13 +1133,13 @@ fn registered_mutation_hooks_receive_the_rust_mutator() {
     assert!(error.message().contains("retained after its active call"));
 
     let mutate_calls_before = REGISTERED_MUTATE_CALLS.load(Ordering::Relaxed);
-    let mapped = structural_mutate(
+    let mutated = structural_mutate(
         source.clone(),
         |value: i64, _mutator: &mut MutateContext<'_, ()>| Any::from(value + 1),
     )
     .and_then(i64::try_from)
     .unwrap();
-    assert_eq!(mapped, 2);
+    assert_eq!(mutated, 2);
     assert_eq!(
         REGISTERED_MUTATE_CALLS.load(Ordering::Relaxed),
         mutate_calls_before + 1
@@ -1150,10 +1149,10 @@ fn registered_mutation_hooks_receive_the_rust_mutator() {
     });
 
     let maybe_inplace_calls_before = REGISTERED_MAYBE_INPLACE_MUTATE_CALLS.load(Ordering::Relaxed);
-    let mapped = structural_mutate(rust_hook_node(), &mut ManualIncrement::default())
+    let mutated = structural_mutate(rust_hook_node(), &mut ManualIncrement::default())
         .and_then(i64::try_from)
         .unwrap();
-    assert_eq!(mapped, 2);
+    assert_eq!(mutated, 2);
     assert_eq!(
         REGISTERED_MAYBE_INPLACE_MUTATE_CALLS.load(Ordering::Relaxed),
         maybe_inplace_calls_before + 1
@@ -1172,11 +1171,11 @@ fn registered_hook_cannot_reenter_through_an_aliased_mutator_handle() {
     });
     let mut mutator = RejectAliasedReentry::default();
 
-    let mapped = structural_mutate(rust_hook_node(), &mut mutator)
+    let mutated = structural_mutate(rust_hook_node(), &mut mutator)
         .and_then(i64::try_from)
         .unwrap();
 
-    assert_eq!(mapped, 2);
+    assert_eq!(mutated, 2);
     assert!(mutator.rejected);
     RETAINED_MUTATOR.with(|retained| {
         retained.take();
@@ -1395,12 +1394,12 @@ fn generated_mutator_defaults_unmatched_values_and_preserves_inplace_permit() {
     let root = Array::new(vec![1i64, 2]);
     let root_pointer = array_pointer(&root);
     let mut mutator = GeneratedLeafMutator::default();
-    let mapped = structural_mutate(root, &mut mutator)
+    let mutated = structural_mutate(root, &mut mutator)
         .and_then(Array::<i64>::try_from)
         .unwrap();
 
-    assert_eq!(array_pointer(&mapped), root_pointer);
-    assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![2, 3]);
+    assert_eq!(array_pointer(&mutated), root_pointer);
+    assert_eq!(mutated.iter().collect::<Vec<_>>(), vec![2, 3]);
     assert_eq!(
         mutator.integers,
         vec![(1, DefRegionKind::None), (2, DefRegionKind::None)]
@@ -1416,10 +1415,10 @@ fn generated_mutator_default_remap_crosses_registered_hooks() {
     });
 
     let mut mutator = GeneratedLeafMutator::default();
-    let mapped = structural_mutate(rust_hook_node(), &mut mutator)
+    let mutated = structural_mutate(rust_hook_node(), &mut mutator)
         .and_then(i64::try_from)
         .unwrap();
-    assert_eq!(mapped, 2);
+    assert_eq!(mutated, 2);
     assert_eq!(mutator.integers, vec![(1, DefRegionKind::None)]);
     RETAINED_MUTATOR.with(|retained| {
         retained.take();
@@ -1434,11 +1433,11 @@ struct GeneratedRecursiveMutator {
 #[dispatch(mutate)]
 impl GeneratedRecursiveMutator {
     fn mutate_array(&mut self, array: Array<i64>, kind: DefRegionKind) -> Result<Any> {
-        let mut mapped = Vec::with_capacity(array.len());
+        let mut mutated = Vec::with_capacity(array.len());
         for value in array.iter() {
-            mapped.push(i64::try_from(self.mutate_child(&value, kind)?)?);
+            mutated.push(i64::try_from(self.mutate_child(&value, kind)?)?);
         }
-        Ok(Any::from(Array::new(mapped)))
+        Ok(Any::from(Array::new(mutated)))
     }
 
     fn mutate_integer(&mut self, value: i64) -> Any {
@@ -1450,11 +1449,11 @@ impl GeneratedRecursiveMutator {
 #[test]
 fn generated_mutator_can_drive_recursion_through_mut_self() {
     let mut mutator = GeneratedRecursiveMutator::default();
-    let mapped = structural_mutate(Array::new(vec![1i64, 2]), &mut mutator)
+    let mutated = structural_mutate(Array::new(vec![1i64, 2]), &mut mutator)
         .and_then(Array::<i64>::try_from)
         .unwrap();
 
-    assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![11, 12]);
+    assert_eq!(mutated.iter().collect::<Vec<_>>(), vec![11, 12]);
     assert_eq!(mutator.integers, vec![1, 2]);
 }
 
@@ -1473,13 +1472,13 @@ impl GeneratedRemappingMutator {
         if value.type_index() != self.type_index {
             return self.default_mutate(value, kind);
         }
-        if let Some(mapped) = self.var_remap_get(value)? {
-            return Ok(mapped);
+        if let Some(mutated) = self.var_remap_get(value)? {
+            return Ok(mutated);
         }
         self.calls += 1;
-        let mapped = Any::from(41i64);
-        self.var_remap_set(value, &mapped)?;
-        Ok(mapped)
+        let mutated = Any::from(41i64);
+        self.var_remap_set(value, &mutated)?;
+        Ok(mutated)
     }
 }
 
@@ -1497,10 +1496,10 @@ fn generated_mutator_uses_fresh_invocation_local_var_remap() {
             "ffi.Array",
             &[Any::from(var.clone()), Any::from(var.clone())],
         );
-        let mapped = structural_mutate(root, &mut mutator).unwrap();
+        let mutated = structural_mutate(root, &mut mutator).unwrap();
         assert_eq!(mutator.calls, expected_calls);
-        assert_eq!(i64::try_from(array_item(&mapped, 0)).unwrap(), 41);
-        assert_eq!(i64::try_from(array_item(&mapped, 1)).unwrap(), 41);
+        assert_eq!(i64::try_from(array_item(&mutated, 0)).unwrap(), 41);
+        assert_eq!(i64::try_from(array_item(&mutated, 1)).unwrap(), 41);
     }
 }
 
@@ -1598,10 +1597,6 @@ fn twelve_link_tuple_reaches_final_map_dispatch() {
 
 #[test]
 fn nested_tuple_chain_exceeds_flat_arity() {
-    // A tuple is itself a link, so nesting lifts the 12-wide flat cap:
-    // 12 + 3 = 15 links here, three levels deep. Order is the flattened
-    // depth-first order: the typed i64 link claims integers before the
-    // nested catch-all, which therefore only sees the array itself.
     ensure_test_types_registered();
     let root = Array::new(vec![1i64, 2, 3]);
     let mut catch_all = 0;
@@ -1725,13 +1720,13 @@ fn callback_mutate_defaults_unmatched_values_and_preserves_root_permit() {
     ensure_test_types_registered();
     let root = Array::new(vec![1i64, 2]);
     let root_pointer = array_pointer(&root);
-    let mapped = structural_mutate(root, |value: i64, _mutator: &mut MutateContext<'_, ()>| {
+    let mutated = structural_mutate(root, |value: i64, _mutator: &mut MutateContext<'_, ()>| {
         Any::from(value + 1)
     })
     .and_then(Array::<i64>::try_from)
     .unwrap();
-    assert_eq!(array_pointer(&mapped), root_pointer);
-    assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![2, 3]);
+    assert_eq!(array_pointer(&mutated), root_pointer);
+    assert_eq!(mutated.iter().collect::<Vec<_>>(), vec![2, 3]);
 }
 
 #[derive(Default)]
@@ -1742,18 +1737,18 @@ struct CallbackMutateStats {
 
 fn stateful_mutate_integer(
     value: i64,
-    context: &mut MutateContext<'_, CallbackMutateStats>,
+    mutator: &mut MutateContext<'_, CallbackMutateStats>,
 ) -> Any {
-    context.state_mut().integers.push(value);
+    mutator.state_mut().integers.push(value);
     Any::from(value + 1)
 }
 
 fn stateful_mutate_default(
     _value: &MapValue,
-    context: &mut MutateContext<'_, CallbackMutateStats>,
+    mutator: &mut MutateContext<'_, CallbackMutateStats>,
 ) -> Result<Any> {
-    context.state_mut().defaults += 1;
-    context.default_mutate()
+    mutator.state_mut().defaults += 1;
+    mutator.default_mutate()
 }
 
 #[test]
@@ -1790,21 +1785,21 @@ struct CallbackMutateDepth {
 
 fn stateful_mutate_recursive(
     value: &MapValue,
-    context: &mut MutateContext<'_, CallbackMutateDepth>,
+    mutator: &mut MutateContext<'_, CallbackMutateDepth>,
 ) -> Result<Any> {
-    assert_eq!(context.current().type_index(), value.type_index());
+    assert_eq!(mutator.current().type_index(), value.type_index());
     {
-        let state = context.state_mut();
+        let state = mutator.state_mut();
         state.current += 1;
         state.maximum = state.maximum.max(state.current);
     }
-    let mapped = context.default_mutate()?;
+    let mutated = mutator.default_mutate()?;
     {
-        let state = context.state_mut();
+        let state = mutator.state_mut();
         state.current -= 1;
         state.exits += 1;
     }
-    Ok(mapped)
+    Ok(mutated)
 }
 
 #[test]
@@ -1813,12 +1808,12 @@ fn callback_mutator_state_can_change_around_recursive_reborrows() {
     let root = Array::new(vec![Array::new(vec![1i64, 2])]);
     let mut mutator =
         MutateCallbacks::new(CallbackMutateDepth::default(), stateful_mutate_recursive);
-    let mapped = structural_mutate(root, &mut mutator)
+    let mutated = structural_mutate(root, &mut mutator)
         .and_then(Array::<Array<i64>>::try_from)
         .unwrap();
 
     assert_eq!(
-        mapped.get(0).unwrap().iter().collect::<Vec<_>>(),
+        mutated.get(0).unwrap().iter().collect::<Vec<_>>(),
         vec![1, 2]
     );
     assert_eq!(mutator.state().current, 0);
@@ -1832,7 +1827,7 @@ fn callback_mutate_current_default_is_repeatable_copy_path() {
     let root = Array::new(vec![1i64, 2]);
     let root_pointer = array_pointer(&root);
     let defaults = Cell::new(0);
-    let mapped = structural_mutate(
+    let mutated = structural_mutate(
         root,
         (
             |value: i64, _mutator: &mut MutateContext<'_, ()>| Any::from(value + 1),
@@ -1847,8 +1842,8 @@ fn callback_mutate_current_default_is_repeatable_copy_path() {
     )
     .and_then(Array::<i64>::try_from)
     .unwrap();
-    assert_ne!(array_pointer(&mapped), root_pointer);
-    assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![2, 3]);
+    assert_ne!(array_pointer(&mutated), root_pointer);
+    assert_eq!(mutated.iter().collect::<Vec<_>>(), vec![2, 3]);
     assert_eq!(defaults.get(), 1);
 }
 
@@ -1856,7 +1851,7 @@ fn callback_mutate_current_default_is_repeatable_copy_path() {
 fn callback_mutate_match_is_final_and_same_fn_can_reenter() {
     ensure_test_types_registered();
     let integer_calls = Cell::new(0);
-    let mapped = structural_mutate(
+    let mutated = structural_mutate(
         Array::new(vec![1i64]),
         (
             |_array: Array<i64>, _mutator: &mut MutateContext<'_, ()>| {
@@ -1870,11 +1865,11 @@ fn callback_mutate_match_is_final_and_same_fn_can_reenter() {
     )
     .and_then(Array::<i64>::try_from)
     .unwrap();
-    assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![10]);
+    assert_eq!(mutated.iter().collect::<Vec<_>>(), vec![10]);
     assert_eq!(integer_calls.get(), 0);
 
     let calls = Cell::new(0);
-    let mapped = structural_mutate(
+    let mutated = structural_mutate(
         Array::new(vec![1i64, 2]),
         |_value: &MapValue, mutator: &mut MutateContext<'_, ()>| {
             calls.set(calls.get() + 1);
@@ -1883,7 +1878,7 @@ fn callback_mutate_match_is_final_and_same_fn_can_reenter() {
     )
     .and_then(Array::<i64>::try_from)
     .unwrap();
-    assert_eq!(mapped.iter().collect::<Vec<_>>(), vec![1, 2]);
+    assert_eq!(mutated.iter().collect::<Vec<_>>(), vec![1, 2]);
     assert_eq!(calls.get(), 3);
 }
 
@@ -1896,7 +1891,7 @@ fn callback_mutate_supports_node_links_nested_tuples_and_reflection() {
         &[Any::from(rust_dag_node()), Any::from(rust_pair(1i64, 9i64))],
     );
     let regions = RefCell::new(Vec::new());
-    let mapped = structural_mutate(
+    let mutated = structural_mutate(
         root,
         (
             (
@@ -1911,8 +1906,8 @@ fn callback_mutate_supports_node_links_nested_tuples_and_reflection() {
     )
     .unwrap();
 
-    assert_eq!(i64::try_from(array_item(&mapped, 0)).unwrap(), 7);
-    let pair = RustPair::try_from(array_item(&mapped, 1)).unwrap();
+    assert_eq!(i64::try_from(array_item(&mutated, 0)).unwrap(), 7);
+    let pair = RustPair::try_from(array_item(&mutated, 1)).unwrap();
     assert_eq!(i64::try_from(pair.data.first.clone()).unwrap(), 2);
     assert_eq!(i64::try_from(pair.data.ignored.clone()).unwrap(), 9);
     assert_eq!(*regions.borrow(), vec![DefRegionKind::Recursive]);
@@ -1923,7 +1918,7 @@ fn callback_mutate_distinguishes_borrowed_and_owned_children() {
     ensure_test_types_registered();
     let borrowed_child = Array::new(vec![1i64]);
     let borrowed_pointer = array_pointer(&borrowed_child);
-    let mapped = structural_mutate(
+    let mutated = structural_mutate(
         true,
         (
             |_value: bool, mutator: &mut MutateContext<'_, ()>| mutator.mutate(&borrowed_child),
@@ -1932,12 +1927,12 @@ fn callback_mutate_distinguishes_borrowed_and_owned_children() {
     )
     .and_then(Array::<i64>::try_from)
     .unwrap();
-    assert_ne!(array_pointer(&mapped), borrowed_pointer);
+    assert_ne!(array_pointer(&mutated), borrowed_pointer);
     assert_eq!(borrowed_child.get(0).unwrap(), 1);
-    assert_eq!(mapped.get(0).unwrap(), 2);
+    assert_eq!(mutated.get(0).unwrap(), 2);
 
     let owned_pointer = Cell::new(0usize);
-    let mapped = structural_mutate(
+    let mutated = structural_mutate(
         true,
         (
             |_value: bool, mutator: &mut MutateContext<'_, ()>| {
@@ -1950,8 +1945,8 @@ fn callback_mutate_distinguishes_borrowed_and_owned_children() {
     )
     .and_then(Array::<i64>::try_from)
     .unwrap();
-    assert_eq!(array_pointer(&mapped) as usize, owned_pointer.get());
-    assert_eq!(mapped.get(0).unwrap(), 2);
+    assert_eq!(array_pointer(&mutated) as usize, owned_pointer.get());
+    assert_eq!(mutated.get(0).unwrap(), 2);
 }
 
 #[test]
@@ -1966,13 +1961,13 @@ fn callback_mutate_can_use_its_invocation_local_var_remap() {
             if value.type_index() != type_index {
                 return mutator.default_mutate();
             }
-            if let Some(mapped) = mutator.var_remap_get(value)? {
-                return Ok(mapped);
+            if let Some(mutated) = mutator.var_remap_get(value)? {
+                return Ok(mutated);
             }
             calls.set(calls.get() + 1);
-            let mapped = Any::from(41i64);
-            mutator.var_remap_set(value, &mapped)?;
-            Ok(mapped)
+            let mutated = Any::from(41i64);
+            mutator.var_remap_set(value, &mutated)?;
+            Ok(mutated)
         },
     );
 
@@ -1981,16 +1976,16 @@ fn callback_mutate_can_use_its_invocation_local_var_remap() {
             "ffi.Array",
             &[Any::from(var.clone()), Any::from(var.clone())],
         );
-        let mapped = structural_mutate(root, &mut mutator).unwrap();
+        let mutated = structural_mutate(root, &mut mutator).unwrap();
         assert_eq!(calls.get(), expected_calls);
-        assert_eq!(i64::try_from(array_item(&mapped, 0)).unwrap(), 41);
-        assert_eq!(i64::try_from(array_item(&mapped, 1)).unwrap(), 41);
+        assert_eq!(i64::try_from(array_item(&mutated, 0)).unwrap(), 41);
+        assert_eq!(i64::try_from(array_item(&mutated, 1)).unwrap(), 41);
     }
 }
 
 #[test]
 fn nested_callback_mutate_restores_the_outer_active_mutator() {
-    let mapped = structural_mutate(
+    let mutated = structural_mutate(
         1i64,
         |value: i64, mutator: &mut MutateContext<'_, ()>| -> Result<Any> {
             if value != 1 {
@@ -2006,7 +2001,7 @@ fn nested_callback_mutate_restores_the_outer_active_mutator() {
     )
     .and_then(i64::try_from)
     .unwrap();
-    assert_eq!(mapped, 4);
+    assert_eq!(mutated, 4);
 }
 
 #[test]
@@ -2027,11 +2022,11 @@ fn callback_mutate_panics_resume_and_leave_the_next_run_usable() {
         Some("callback mutator panic")
     );
 
-    let mapped = structural_mutate(
+    let mutated = structural_mutate(
         Array::new(vec![1i64]),
         |value: i64, _mutator: &mut MutateContext<'_, ()>| Any::from(value + 1),
     )
     .and_then(Array::<i64>::try_from)
     .unwrap();
-    assert_eq!(mapped.get(0).unwrap(), 2);
+    assert_eq!(mutated.get(0).unwrap(), 2);
 }

--- a/rust/tvm-ffi/tests/test_structural_visit.rs
+++ b/rust/tvm-ffi/tests/test_structural_visit.rs
@@ -1098,7 +1098,6 @@ fn visitor_interrupt_propagates_through_default_children() {
     }
 
     let root = Array::new(vec![1i64, 2, 3]);
-    // Keep the original two-parameter turbofish form source-compatible.
     let outcome =
         structural_visit::<Array<i64>, InterruptingVisitor>(&root, &mut InterruptingVisitor)
             .unwrap();
@@ -1192,8 +1191,6 @@ fn chain_accepts_owned_object_ref_links() {
 
 #[test]
 fn chain_links_may_mix_def_region_arity() {
-    // Like #[dispatch(walk)] handlers, each link independently opts into
-    // the trailing DefRegionKind argument.
     let root = Array::new(vec![1i64, 2]);
     let mut kinds = Vec::new();
     let mut objects = 0;
@@ -1263,8 +1260,6 @@ fn chain_link_errors_include_native_visit_path() {
 
 #[test]
 fn chain_supports_post_order() {
-    // Rust borrow rules apply per link: state shared across links goes
-    // through a RefCell (or a single #[dispatch(walk)] walker).
     let root = Array::new(vec![1i64, 2]);
     let events = std::cell::RefCell::new(Vec::new());
     assert!(structural_walk(
@@ -1301,8 +1296,6 @@ impl ObjectCounter {
 
 #[test]
 fn chain_splices_dispatch_walkers_between_closures() {
-    // A `&mut` typed walker participates in the chain like any other link,
-    // keeping its own no-match fall-through semantics.
     let root = Array::new(vec![1i64, 2]);
     let mut counter = ObjectCounter::default();
     let mut integers = 0;
@@ -1322,9 +1315,6 @@ fn chain_splices_dispatch_walkers_between_closures() {
 
 #[test]
 fn chain_supports_full_arity() {
-    // All 12 flat links. Doubles as the first-match ordering probe: earlier
-    // misses fall through, the first matching link claims the value, later
-    // links never run.
     let root = Array::new(vec![1i64, 2, 3]);
     let mut integers = Vec::new();
     let mut objects = 0;
@@ -1555,9 +1545,6 @@ fn non_recursive_region_is_clamped_for_free_var_children_only() {
 
 #[test]
 fn nested_tuple_chain_exceeds_flat_arity() {
-    // A tuple is itself a link, so nesting lifts the 12-wide flat cap:
-    // 12 + 4 = 16 links here, three levels deep. Order is the flattened
-    // depth-first order.
     let root = Array::new(vec![1i64, 2, 3]);
     let mut integers = Vec::new();
     let mut objects = 0;
@@ -1608,7 +1595,6 @@ fn nested_tuple_chain_exceeds_flat_arity() {
 
 #[test]
 fn nested_tuple_first_match_order_is_flattened() {
-    // An earlier nested catch-all claims everything before a later link.
     let root = Array::new(vec![1i64, 2]);
     let mut first = 0;
     let mut second = 0;
@@ -1691,7 +1677,6 @@ fn stateful_callback_visit_uses_ordinary_mutable_state() {
     assert_eq!(visitor.state().arrays, 1);
     assert_eq!(visitor.state().integer_sum, 6);
 
-    // The callback visitor is reusable and retains its state between runs.
     assert!(structural_visit(&root, &mut visitor).unwrap().is_none());
     assert_eq!(visitor.state().arrays, 2);
     assert_eq!(visitor.into_state().integer_sum, 12);
@@ -1705,7 +1690,7 @@ struct StatefulVisitDepth {
 }
 
 #[test]
-fn stateful_callback_visit_reborrows_context_during_recursion() {
+fn stateful_callback_visit_reborrows_visitor_during_recursion() {
     let root = Array::new(vec![Array::new(vec![1i64, 2])]);
     let mut visitor = VisitCallbacks::new(
         StatefulVisitDepth::default(),
@@ -1715,8 +1700,6 @@ fn stateful_callback_visit_reborrows_context_during_recursion() {
             let current = visitor.state().current;
             visitor.state_mut().maximum = visitor.state().maximum.max(current);
 
-            // Keep the outcome intact so both errors and interrupts propagate,
-            // while ordinary state is restored after the recursive reborrow.
             let outcome = visitor.visit_children();
             visitor.state_mut().current -= 1;
             outcome
@@ -1730,7 +1713,7 @@ fn stateful_callback_visit_reborrows_context_during_recursion() {
 }
 
 #[test]
-fn callback_visit_can_reenter_the_same_fn_through_context() {
+fn callback_visit_can_reenter_the_same_fn_through_visitor() {
     let root = Array::new(vec![1i64, 2]);
     let visits = Cell::new(0);
     assert!(structural_visit(

--- a/rust/tvm-ffi/tests/test_structural_visit.rs
+++ b/rust/tvm-ffi/tests/test_structural_visit.rs
@@ -29,8 +29,8 @@ use tvm_ffi::tvm_ffi_sys::{
 use tvm_ffi::{
     dispatch, structural_visit, structural_walk, Any, AnyView, Array, DLDataType, DLDataTypeCode,
     DefRegionKind, Error, Function, Map, Object, ObjectArc, ObjectCore, ObjectRefCast, Result,
-    String as FfiString, StructuralVisitor, TypeIndex, VisitInterrupt, VisitValue, VisitorRef,
-    WalkOrder, WalkResult, RUNTIME_ERROR,
+    String as FfiString, StructuralVisitor, TypeIndex, VisitCallbacks, VisitContext,
+    VisitInterrupt, VisitValue, WalkOrder, WalkResult, RUNTIME_ERROR,
 };
 
 unsafe extern "C" {
@@ -457,7 +457,7 @@ fn registered_function_hook_controls_children_interrupts_and_lifetime() {
 
     let callback_integers = RefCell::new(Vec::new());
     assert!(
-        structural_visit(&root, |value: i64, _visitor: &VisitorRef<'_>| {
+        structural_visit(&root, |value: i64, _visitor: &mut VisitContext<'_, ()>| {
             callback_integers.borrow_mut().push(value)
         },)
         .unwrap()
@@ -1049,7 +1049,7 @@ fn visitor_errors_include_native_visit_path() {
 
     let error = match structural_visit(
         &root,
-        |_value: i64, _visitor: &VisitorRef<'_>| -> Result<()> {
+        |_value: i64, _visitor: &mut VisitContext<'_, ()>| -> Result<()> {
             Err(runtime_error("callback visitor failed"))
         },
     ) {
@@ -1637,7 +1637,7 @@ fn callback_visit_defaults_only_when_no_link_matches() {
     let root = Array::new(vec![1i64, 2]);
     let integers = Cell::new(0);
     assert!(
-        structural_visit(&root, |value: i64, _visitor: &VisitorRef<'_>| {
+        structural_visit(&root, |value: i64, _visitor: &mut VisitContext<'_, ()>| {
             integers.set(integers.get() + value);
         })
         .unwrap()
@@ -1649,8 +1649,8 @@ fn callback_visit_defaults_only_when_no_link_matches() {
     assert!(structural_visit(
         &root,
         (
-            |_array: Array<i64>, _visitor: &VisitorRef<'_>| {},
-            |value: i64, _visitor: &VisitorRef<'_>| {
+            |_array: Array<i64>, _visitor: &mut VisitContext<'_, ()>| {},
+            |value: i64, _visitor: &mut VisitContext<'_, ()>| {
                 integers.set(integers.get() + value);
             },
         ),
@@ -1660,18 +1660,88 @@ fn callback_visit_defaults_only_when_no_link_matches() {
     assert_eq!(integers.get(), 0);
 }
 
+#[derive(Default)]
+struct StatefulVisitStats {
+    arrays: usize,
+    integer_sum: i64,
+}
+
+fn stateful_visit_array(
+    _array: Array<i64>,
+    visitor: &mut VisitContext<'_, StatefulVisitStats>,
+) -> Result<Option<VisitInterrupt>> {
+    visitor.state_mut().arrays += 1;
+    assert!(visitor.current().cast::<Array<i64>>().is_some());
+    visitor.visit_children()
+}
+
+fn stateful_visit_integer(value: i64, visitor: &mut VisitContext<'_, StatefulVisitStats>) {
+    visitor.state_mut().integer_sum += value;
+}
+
 #[test]
-fn callback_visit_can_reenter_the_same_fn_through_handle() {
+fn stateful_callback_visit_uses_ordinary_mutable_state() {
+    let root = Array::new(vec![1i64, 2, 3]);
+    let mut visitor = VisitCallbacks::new(
+        StatefulVisitStats::default(),
+        (stateful_visit_array, stateful_visit_integer),
+    );
+
+    assert!(structural_visit(&root, &mut visitor).unwrap().is_none());
+    assert_eq!(visitor.state().arrays, 1);
+    assert_eq!(visitor.state().integer_sum, 6);
+
+    // The callback visitor is reusable and retains its state between runs.
+    assert!(structural_visit(&root, &mut visitor).unwrap().is_none());
+    assert_eq!(visitor.state().arrays, 2);
+    assert_eq!(visitor.into_state().integer_sum, 12);
+}
+
+#[derive(Default)]
+struct StatefulVisitDepth {
+    current: usize,
+    maximum: usize,
+    calls: usize,
+}
+
+#[test]
+fn stateful_callback_visit_reborrows_context_during_recursion() {
+    let root = Array::new(vec![Array::new(vec![1i64, 2])]);
+    let mut visitor = VisitCallbacks::new(
+        StatefulVisitDepth::default(),
+        |_value: &VisitValue, visitor: &mut VisitContext<'_, StatefulVisitDepth>| {
+            visitor.state_mut().current += 1;
+            visitor.state_mut().calls += 1;
+            let current = visitor.state().current;
+            visitor.state_mut().maximum = visitor.state().maximum.max(current);
+
+            // Keep the outcome intact so both errors and interrupts propagate,
+            // while ordinary state is restored after the recursive reborrow.
+            let outcome = visitor.visit_children();
+            visitor.state_mut().current -= 1;
+            outcome
+        },
+    );
+
+    assert!(structural_visit(&root, &mut visitor).unwrap().is_none());
+    assert_eq!(visitor.state().current, 0);
+    assert_eq!(visitor.state().maximum, 3);
+    assert_eq!(visitor.state().calls, 4);
+}
+
+#[test]
+fn callback_visit_can_reenter_the_same_fn_through_context() {
     let root = Array::new(vec![1i64, 2]);
     let visits = Cell::new(0);
-    assert!(
-        structural_visit(&root, |_value: &VisitValue, visitor: &VisitorRef<'_>| {
+    assert!(structural_visit(
+        &root,
+        |_value: &VisitValue, visitor: &mut VisitContext<'_, ()>| {
             visits.set(visits.get() + 1);
             visitor.visit_children()
-        },)
-        .unwrap()
-        .is_none()
-    );
+        },
+    )
+    .unwrap()
+    .is_none());
     assert_eq!(visits.get(), 3);
 }
 
@@ -1682,10 +1752,10 @@ fn callback_visit_tuple_is_first_match_and_can_interrupt() {
     let interrupted = structural_visit(
         &root,
         (
-            |value: i64, _visitor: &VisitorRef<'_>| {
+            |value: i64, _visitor: &mut VisitContext<'_, ()>| {
                 (value == 2).then(|| VisitInterrupt::with(value))
             },
-            |_value: &VisitValue, visitor: &VisitorRef<'_>| {
+            |_value: &VisitValue, visitor: &mut VisitContext<'_, ()>| {
                 fallback.set(fallback.get() + 1);
                 visitor.visit_children()
             },
@@ -1716,13 +1786,13 @@ fn callback_visit_supports_node_links_nested_tuples_and_def_regions() {
         &root,
         (
             (
-                |_value: f64, _visitor: &VisitorRef<'_>| {},
-                |_node: &RustVisitDefRegionObj, visitor: &VisitorRef<'_>| {
+                |_value: f64, _visitor: &mut VisitContext<'_, ()>| {},
+                |_node: &RustVisitDefRegionObj, visitor: &mut VisitContext<'_, ()>| {
                     assert_eq!(visitor.def_region_kind(), DefRegionKind::None);
                     visitor.visit_children()
                 },
             ),
-            |value: i64, visitor: &VisitorRef<'_>| {
+            |value: i64, visitor: &mut VisitContext<'_, ()>| {
                 seen.borrow_mut().push((value, visitor.def_region_kind()));
             },
         ),
@@ -1747,7 +1817,7 @@ fn callback_visit_with_overrides_child_def_region() {
     assert!(structural_visit(
         &root,
         (
-            |array: Array<i64>, visitor: &VisitorRef<'_>| {
+            |array: Array<i64>, visitor: &mut VisitContext<'_, ()>| {
                 for value in array.iter() {
                     if let Some(interrupt) = visitor.visit_with(&value, DefRegionKind::Recursive)? {
                         return Ok(Some(interrupt));
@@ -1755,7 +1825,7 @@ fn callback_visit_with_overrides_child_def_region() {
                 }
                 Ok(None)
             },
-            |value: i64, visitor: &VisitorRef<'_>| {
+            |value: i64, visitor: &mut VisitContext<'_, ()>| {
                 seen.borrow_mut().push((value, visitor.def_region_kind()));
             },
         ),
@@ -1776,21 +1846,22 @@ fn nested_callback_visit_restores_the_outer_active_visitor() {
     let outer_values = RefCell::new(Vec::new());
     let inner_values = RefCell::new(Vec::new());
 
-    assert!(
-        structural_visit(&outer, |value: &VisitValue, visitor: &VisitorRef<'_>| {
+    assert!(structural_visit(
+        &outer,
+        |value: &VisitValue, visitor: &mut VisitContext<'_, ()>| {
             if let Some(value) = value.cast::<i64>() {
                 outer_values.borrow_mut().push(value);
             }
             if !entered_inner.replace(true) {
-                structural_visit(&inner, |value: i64, _visitor: &VisitorRef<'_>| {
+                structural_visit(&inner, |value: i64, _visitor: &mut VisitContext<'_, ()>| {
                     inner_values.borrow_mut().push(value);
                 })?;
             }
             visitor.visit_children()
-        },)
-        .unwrap()
-        .is_none()
-    );
+        },
+    )
+    .unwrap()
+    .is_none());
     assert_eq!(*outer_values.borrow(), vec![10, 20]);
     assert_eq!(*inner_values.borrow(), vec![1, 2]);
 }
@@ -1799,9 +1870,12 @@ fn nested_callback_visit_restores_the_outer_active_visitor() {
 fn callback_visit_panics_resume_and_leave_the_next_run_usable() {
     let root = Array::new(vec![1i64]);
     let panic = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        structural_visit(&root, |_value: i64, _visitor: &VisitorRef<'_>| -> () {
-            panic!("callback visitor panic")
-        })
+        structural_visit(
+            &root,
+            |_value: i64, _visitor: &mut VisitContext<'_, ()>| -> () {
+                panic!("callback visitor panic")
+            },
+        )
     })) {
         Err(panic) => panic,
         Ok(_) => panic!("panicking callback visitor unexpectedly returned"),
@@ -1813,7 +1887,7 @@ fn callback_visit_panics_resume_and_leave_the_next_run_usable() {
 
     let calls = Cell::new(0);
     assert!(
-        structural_visit(&root, |_value: i64, _visitor: &VisitorRef<'_>| {
+        structural_visit(&root, |_value: i64, _visitor: &mut VisitContext<'_, ()>| {
             calls.set(calls.get() + 1);
         })
         .unwrap()

--- a/rust/tvm-ffi/tests/test_structural_visit.rs
+++ b/rust/tvm-ffi/tests/test_structural_visit.rs
@@ -29,8 +29,8 @@ use tvm_ffi::tvm_ffi_sys::{
 use tvm_ffi::{
     dispatch, structural_visit, structural_walk, Any, AnyView, Array, DLDataType, DLDataTypeCode,
     DefRegionKind, Error, Function, Map, Object, ObjectArc, ObjectCore, ObjectRefCast, Result,
-    String as FfiString, StructuralVisitor, TypeIndex, VisitInterrupt, VisitValue, WalkOrder,
-    WalkResult, RUNTIME_ERROR,
+    String as FfiString, StructuralVisitor, TypeIndex, VisitInterrupt, VisitValue, VisitorRef,
+    WalkOrder, WalkResult, RUNTIME_ERROR,
 };
 
 unsafe extern "C" {
@@ -454,6 +454,16 @@ fn registered_function_hook_controls_children_interrupts_and_lifetime() {
     let mut visitor = RecordingVisitor::default();
     assert!(structural_visit(&root, &mut visitor).unwrap().is_none());
     assert_eq!(visitor.integers, vec![11]);
+
+    let callback_integers = RefCell::new(Vec::new());
+    assert!(
+        structural_visit(&root, |value: i64, _visitor: &VisitorRef<'_>| {
+            callback_integers.borrow_mut().push(value)
+        },)
+        .unwrap()
+        .is_none()
+    );
+    assert_eq!(*callback_integers.borrow(), vec![11]);
 
     test_prelude();
     let wrapped = RustVisitDefRegion {
@@ -974,6 +984,18 @@ fn visitor_errors_include_native_visit_path() {
     };
     assert_eq!(error.message(), "visitor failed");
     assert!(error.backtrace().contains("object `ffi.Array`"));
+
+    let error = match structural_visit(
+        &root,
+        |_value: i64, _visitor: &VisitorRef<'_>| -> Result<()> {
+            Err(runtime_error("callback visitor failed"))
+        },
+    ) {
+        Err(error) => error,
+        Ok(_) => panic!("callback visitor unexpectedly succeeded"),
+    };
+    assert_eq!(error.message(), "callback visitor failed");
+    assert!(error.backtrace().contains("object `ffi.Array`"));
 }
 
 #[test]
@@ -1014,7 +1036,10 @@ fn visitor_interrupt_propagates_through_default_children() {
     }
 
     let root = Array::new(vec![1i64, 2, 3]);
-    let outcome = structural_visit(&root, &mut InterruptingVisitor).unwrap();
+    // Keep the original two-parameter turbofish form source-compatible.
+    let outcome =
+        structural_visit::<Array<i64>, InterruptingVisitor>(&root, &mut InterruptingVisitor)
+            .unwrap();
     let Some(interrupt) = outcome else {
         panic!("visitor traversal unexpectedly completed");
     };
@@ -1543,4 +1568,194 @@ fn nested_tuple_first_match_order_is_flattened() {
     .is_none());
     assert_eq!(first, 3);
     assert_eq!(second, 0);
+}
+
+#[test]
+fn callback_visit_defaults_only_when_no_link_matches() {
+    let root = Array::new(vec![1i64, 2]);
+    let integers = Cell::new(0);
+    assert!(
+        structural_visit(&root, |value: i64, _visitor: &VisitorRef<'_>| {
+            integers.set(integers.get() + value);
+        })
+        .unwrap()
+        .is_none()
+    );
+    assert_eq!(integers.get(), 3);
+
+    let integers = Cell::new(0);
+    assert!(structural_visit(
+        &root,
+        (
+            |_array: Array<i64>, _visitor: &VisitorRef<'_>| {},
+            |value: i64, _visitor: &VisitorRef<'_>| {
+                integers.set(integers.get() + value);
+            },
+        ),
+    )
+    .unwrap()
+    .is_none());
+    assert_eq!(integers.get(), 0);
+}
+
+#[test]
+fn callback_visit_can_reenter_the_same_fn_through_handle() {
+    let root = Array::new(vec![1i64, 2]);
+    let visits = Cell::new(0);
+    assert!(
+        structural_visit(&root, |_value: &VisitValue, visitor: &VisitorRef<'_>| {
+            visits.set(visits.get() + 1);
+            visitor.visit_children()
+        },)
+        .unwrap()
+        .is_none()
+    );
+    assert_eq!(visits.get(), 3);
+}
+
+#[test]
+fn callback_visit_tuple_is_first_match_and_can_interrupt() {
+    let root = Array::new(vec![1i64, 2, 3]);
+    let fallback = Cell::new(0);
+    let interrupted = structural_visit(
+        &root,
+        (
+            |value: i64, _visitor: &VisitorRef<'_>| {
+                (value == 2).then(|| VisitInterrupt::with(value))
+            },
+            |_value: &VisitValue, visitor: &VisitorRef<'_>| {
+                fallback.set(fallback.get() + 1);
+                visitor.visit_children()
+            },
+        ),
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(i64::try_from(interrupted.value).unwrap(), 2);
+    assert_eq!(fallback.get(), 1);
+}
+
+#[test]
+fn callback_visit_supports_node_links_nested_tuples_and_def_regions() {
+    test_prelude();
+    let root = RustVisitDefRegion {
+        data: ObjectArc::new(RustVisitDefRegionObj {
+            base: Object::new(),
+            recursive: Any::from(1i64),
+            plain: Any::from(2i64),
+            non_recursive: Any::from(3i64),
+            both: Any::from(4i64),
+            ignored: Any::from(5i64),
+        }),
+    };
+    let seen = RefCell::new(Vec::new());
+
+    assert!(structural_visit(
+        &root,
+        (
+            (
+                |_value: f64, _visitor: &VisitorRef<'_>| {},
+                |_node: &RustVisitDefRegionObj, visitor: &VisitorRef<'_>| {
+                    assert_eq!(visitor.def_region_kind(), DefRegionKind::None);
+                    visitor.visit_children()
+                },
+            ),
+            |value: i64, visitor: &VisitorRef<'_>| {
+                seen.borrow_mut().push((value, visitor.def_region_kind()));
+            },
+        ),
+    )
+    .unwrap()
+    .is_none());
+    assert_eq!(
+        *seen.borrow(),
+        vec![
+            (1, DefRegionKind::Recursive),
+            (2, DefRegionKind::None),
+            (3, DefRegionKind::NonRecursive),
+            (4, DefRegionKind::NonRecursive),
+        ]
+    );
+}
+
+#[test]
+fn callback_visit_with_overrides_child_def_region() {
+    let root = Array::new(vec![1i64, 2]);
+    let seen = RefCell::new(Vec::new());
+    assert!(structural_visit(
+        &root,
+        (
+            |array: Array<i64>, visitor: &VisitorRef<'_>| {
+                for value in array.iter() {
+                    if let Some(interrupt) = visitor.visit_with(&value, DefRegionKind::Recursive)? {
+                        return Ok(Some(interrupt));
+                    }
+                }
+                Ok(None)
+            },
+            |value: i64, visitor: &VisitorRef<'_>| {
+                seen.borrow_mut().push((value, visitor.def_region_kind()));
+            },
+        ),
+    )
+    .unwrap()
+    .is_none());
+    assert_eq!(
+        *seen.borrow(),
+        vec![(1, DefRegionKind::Recursive), (2, DefRegionKind::Recursive),]
+    );
+}
+
+#[test]
+fn nested_callback_visit_restores_the_outer_active_visitor() {
+    let outer = Array::new(vec![10i64, 20]);
+    let inner = Array::new(vec![1i64, 2]);
+    let entered_inner = Cell::new(false);
+    let outer_values = RefCell::new(Vec::new());
+    let inner_values = RefCell::new(Vec::new());
+
+    assert!(
+        structural_visit(&outer, |value: &VisitValue, visitor: &VisitorRef<'_>| {
+            if let Some(value) = value.cast::<i64>() {
+                outer_values.borrow_mut().push(value);
+            }
+            if !entered_inner.replace(true) {
+                structural_visit(&inner, |value: i64, _visitor: &VisitorRef<'_>| {
+                    inner_values.borrow_mut().push(value);
+                })?;
+            }
+            visitor.visit_children()
+        },)
+        .unwrap()
+        .is_none()
+    );
+    assert_eq!(*outer_values.borrow(), vec![10, 20]);
+    assert_eq!(*inner_values.borrow(), vec![1, 2]);
+}
+
+#[test]
+fn callback_visit_panics_resume_and_leave_the_next_run_usable() {
+    let root = Array::new(vec![1i64]);
+    let panic = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        structural_visit(&root, |_value: i64, _visitor: &VisitorRef<'_>| -> () {
+            panic!("callback visitor panic")
+        })
+    })) {
+        Err(panic) => panic,
+        Ok(_) => panic!("panicking callback visitor unexpectedly returned"),
+    };
+    assert_eq!(
+        panic.downcast_ref::<&str>().copied(),
+        Some("callback visitor panic")
+    );
+
+    let calls = Cell::new(0);
+    assert!(
+        structural_visit(&root, |_value: i64, _visitor: &VisitorRef<'_>| {
+            calls.set(calls.get() + 1);
+        })
+        .unwrap()
+        .is_none()
+    );
+    assert_eq!(calls.get(), 1);
 }

--- a/rust/tvm-ffi/tests/test_structural_visit.rs
+++ b/rust/tvm-ffi/tests/test_structural_visit.rs
@@ -1235,9 +1235,9 @@ fn chain_splices_dispatch_visitors_between_closures() {
 
 #[test]
 fn chain_supports_full_arity() {
-    // Doubles as the first-match ordering probe: earlier misses fall
-    // through, the first matching link claims the value, later links
-    // never run.
+    // All 12 flat links. Doubles as the first-match ordering probe: earlier
+    // misses fall through, the first matching link claims the value, later
+    // links never run.
     let root = Array::new(vec![1i64, 2, 3]);
     let mut integers = Vec::new();
     let mut objects = 0;
@@ -1249,6 +1249,11 @@ fn chain_supports_full_arity() {
             |_value: bool| WalkResult::Advance,
             |_value: tvm_ffi::String| WalkResult::Advance,
             |_value: Array<f64>| WalkResult::Advance,
+            |_value: f32| WalkResult::Advance,
+            |_value: tvm_ffi::DLDevice| WalkResult::Advance,
+            |_value: Array<bool>| WalkResult::Advance,
+            |_value: Array<tvm_ffi::String>| WalkResult::Advance,
+            |_value: Map<FfiString, i64>, _kind: DefRegionKind| WalkResult::Advance,
             |value: i64| {
                 integers.push(value);
                 WalkResult::Advance
@@ -1261,7 +1266,6 @@ fn chain_supports_full_arity() {
                 others += 1;
                 WalkResult::Advance
             },
-            |_value: &VisitValue| WalkResult::Advance,
         ),
         WalkOrder::PreOrder,
     )
@@ -1460,4 +1464,83 @@ fn non_recursive_region_is_clamped_for_free_var_children_only() {
             ("array_child", DefRegionKind::NonRecursive),
         ]
     );
+}
+
+#[test]
+fn nested_tuple_chain_exceeds_flat_arity() {
+    // A tuple is itself a link, so nesting lifts the 12-wide flat cap:
+    // 12 + 4 = 16 links here, three levels deep. Order is the flattened
+    // depth-first order.
+    let root = Array::new(vec![1i64, 2, 3]);
+    let mut integers = Vec::new();
+    let mut objects = 0;
+    let mut others = 0;
+    assert!(structural_walk(
+        &root,
+        (
+            (
+                |_value: f64| WalkResult::Advance,
+                |_value: bool| WalkResult::Advance,
+                |_value: tvm_ffi::String| WalkResult::Advance,
+                |_value: Array<f64>| WalkResult::Advance,
+                |_value: f32| WalkResult::Advance,
+                |_value: tvm_ffi::DLDevice| WalkResult::Advance,
+                |_value: Array<bool>| WalkResult::Advance,
+                |_value: Array<tvm_ffi::String>| WalkResult::Advance,
+                |_value: Map<FfiString, i64>| WalkResult::Advance,
+                |_value: Map<i64, i64>, _kind: DefRegionKind| WalkResult::Advance,
+                |_value: Array<Array<i64>>| WalkResult::Advance,
+                |_value: tvm_ffi::Function| WalkResult::Advance,
+            ),
+            (
+                |value: i64| {
+                    integers.push(value);
+                    WalkResult::Advance
+                },
+                (
+                    |_object: &Object, _kind: DefRegionKind| {
+                        objects += 1;
+                        WalkResult::Advance
+                    },
+                    (|_value: &VisitValue, _kind: DefRegionKind| {
+                        others += 1;
+                        WalkResult::Advance
+                    },),
+                ),
+                |_value: &VisitValue| WalkResult::Advance,
+            ),
+        ),
+        WalkOrder::PreOrder,
+    )
+    .unwrap()
+    .is_none());
+    assert_eq!(integers, vec![1, 2, 3]);
+    assert_eq!(objects, 1);
+    assert_eq!(others, 0);
+}
+
+#[test]
+fn nested_tuple_first_match_order_is_flattened() {
+    // An earlier nested catch-all claims everything before a later link.
+    let root = Array::new(vec![1i64, 2]);
+    let mut first = 0;
+    let mut second = 0;
+    assert!(structural_walk(
+        &root,
+        (
+            (|_value: &VisitValue| {
+                first += 1;
+                WalkResult::Advance
+            },),
+            |_value: i64| {
+                second += 1;
+                WalkResult::Advance
+            },
+        ),
+        WalkOrder::PreOrder,
+    )
+    .unwrap()
+    .is_none());
+    assert_eq!(first, 3);
+    assert_eq!(second, 0);
 }

--- a/rust/tvm-ffi/tests/test_structural_visit.rs
+++ b/rust/tvm-ffi/tests/test_structural_visit.rs
@@ -765,27 +765,89 @@ fn manual_child_visit_can_override_def_region() {
 }
 
 #[derive(Default)]
+struct GeneratedLeafVisitor {
+    integers: Vec<(i64, DefRegionKind)>,
+}
+
+#[dispatch(visit)]
+impl GeneratedLeafVisitor {
+    fn visit_integer(&mut self, value: i64, kind: DefRegionKind) {
+        self.integers.push((value, kind));
+    }
+}
+
+#[test]
+fn generated_visitor_defaults_unmatched_values() {
+    let root = Array::new(vec![1i64, 2]);
+    let mut visitor = GeneratedLeafVisitor::default();
+    assert!(structural_visit(&root, &mut visitor).unwrap().is_none());
+    assert_eq!(
+        visitor.integers,
+        vec![(1, DefRegionKind::None), (2, DefRegionKind::None)]
+    );
+}
+
+#[derive(Default)]
+struct GeneratedRecursiveVisitor {
+    events: Vec<String>,
+}
+
+#[dispatch(visit)]
+impl GeneratedRecursiveVisitor {
+    fn visit_array(
+        &mut self,
+        array: Array<i64>,
+        kind: DefRegionKind,
+    ) -> Result<Option<VisitInterrupt>> {
+        self.events.push("enter:array".to_string());
+        for value in array.iter() {
+            if let Some(interrupt) = self.visit_child(&value, kind)? {
+                return Ok(Some(interrupt));
+            }
+        }
+        self.events.push("exit:array".to_string());
+        Ok(None)
+    }
+
+    fn visit_integer(&mut self, value: i64) -> Option<VisitInterrupt> {
+        self.events.push(format!("int:{value}"));
+        (value == 2).then(|| VisitInterrupt::with(value))
+    }
+
+    fn visit_other_object(&mut self, _value: &Object) {}
+}
+
+#[test]
+fn generated_visitor_can_drive_recursion_through_mut_self() {
+    let root = Array::new(vec![1i64, 2, 3]);
+    let mut visitor = GeneratedRecursiveVisitor::default();
+    let interrupt = structural_visit(&root, &mut visitor).unwrap().unwrap();
+    assert_eq!(i64::try_from(interrupt.value).unwrap(), 2);
+    assert_eq!(visitor.events, vec!["enter:array", "int:1", "int:2"]);
+}
+
+#[derive(Default)]
 struct GenericDispatchProbe {
     integers: Vec<i64>,
     objects: usize,
     catch_all: usize,
 }
 
-#[dispatch(visit)]
+#[dispatch(walk)]
 impl GenericDispatchProbe {
-    fn visit_integer(&mut self, value: i64) -> WalkResult {
+    fn walk_integer(&mut self, value: i64) -> WalkResult {
         self.integers.push(value);
         WalkResult::Advance
     }
 
     // Trailing DefRegionKind: handlers may mix arities within one impl.
-    fn visit_object(&mut self, _value: &tvm_ffi::Object, kind: DefRegionKind) -> WalkResult {
+    fn walk_object(&mut self, _value: &tvm_ffi::Object, kind: DefRegionKind) -> WalkResult {
         assert_eq!(kind, DefRegionKind::None);
         self.objects += 1;
         WalkResult::Advance
     }
 
-    fn visit_any(&mut self, _value: &VisitValue) -> WalkResult {
+    fn walk_any(&mut self, _value: &VisitValue) -> WalkResult {
         self.catch_all += 1;
         WalkResult::Advance
     }
@@ -859,14 +921,14 @@ struct OrderProbe {
     events: Vec<String>,
 }
 
-#[dispatch(visit)]
+#[dispatch(walk)]
 impl OrderProbe {
-    fn visit_array(&mut self, _array: Array<i64>) -> WalkResult {
+    fn walk_array(&mut self, _array: Array<i64>) -> WalkResult {
         self.events.push("array".to_string());
         WalkResult::Advance
     }
 
-    fn visit_integer(&mut self, value: i64) -> WalkResult {
+    fn walk_integer(&mut self, value: i64) -> WalkResult {
         self.events.push(format!("int:{value}"));
         WalkResult::Advance
     }
@@ -1130,7 +1192,7 @@ fn chain_accepts_owned_object_ref_links() {
 
 #[test]
 fn chain_links_may_mix_def_region_arity() {
-    // Like #[dispatch(visit)] handlers, each link independently opts into
+    // Like #[dispatch(walk)] handlers, each link independently opts into
     // the trailing DefRegionKind argument.
     let root = Array::new(vec![1i64, 2]);
     let mut kinds = Vec::new();
@@ -1202,7 +1264,7 @@ fn chain_link_errors_include_native_visit_path() {
 #[test]
 fn chain_supports_post_order() {
     // Rust borrow rules apply per link: state shared across links goes
-    // through a RefCell (or a single #[dispatch(visit)] visitor).
+    // through a RefCell (or a single #[dispatch(walk)] walker).
     let root = Array::new(vec![1i64, 2]);
     let events = std::cell::RefCell::new(Vec::new());
     assert!(structural_walk(
@@ -1229,17 +1291,17 @@ struct ObjectCounter {
     objects: usize,
 }
 
-#[dispatch(visit)]
+#[dispatch(walk)]
 impl ObjectCounter {
-    fn visit_object(&mut self, _value: &Object) -> WalkResult {
+    fn walk_object(&mut self, _value: &Object) -> WalkResult {
         self.objects += 1;
         WalkResult::Advance
     }
 }
 
 #[test]
-fn chain_splices_dispatch_visitors_between_closures() {
-    // A `&mut` typed visitor participates in the chain like any other link,
+fn chain_splices_dispatch_walkers_between_closures() {
+    // A `&mut` typed walker participates in the chain like any other link,
     // keeping its own no-match fall-through semantics.
     let root = Array::new(vec![1i64, 2]);
     let mut counter = ObjectCounter::default();


### PR DESCRIPTION
## Summary

This PR completes the Rust structural traversal API by giving all four structural operations a
typed callback and `#[dispatch(...)]` frontend while preserving the distinction between
engine-driven and user-driven recursion.

| API | Recursion owner | Callback state model | Generated dispatch |
|---|---|---|---|
| `structural_walk` | Engine | `FnMut` capture / walker fields | `#[dispatch(walk)]` |
| `structural_map` | Engine | `FnMut` capture / mapper fields | `#[dispatch(map)]` |
| `structural_visit` | Callback or visitor | `VisitCallbacks<State, ...>` + `VisitContext<State>` | `#[dispatch(visit)]` |
| `structural_mutate` | Callback or mutator | `MutateCallbacks<State, ...>` + `MutateContext<State>` | `#[dispatch(mutate)]` |

The callback-backed visit and mutate paths implement `StructuralVisitor` and
`StructuralMutator` directly. As a result, callbacks, generated dispatch types, and hand-written
visitors/mutators now share the same mutable runtime protocol and registered structural hooks.

## Motivation

Before this PR, the Rust walk/map layers already accepted typed callbacks, but user-driven visit
and mutate required hand-written trait implementations. In addition, `#[dispatch(visit)]` named
the engine-driven walk dispatcher rather than the `StructuralVisitor` layer, leaving the four APIs
asymmetric.

This PR aligns the names and entry points with their recursion model, adds lightweight callback
frontends for one-off user-driven traversals, and retains a fully borrow-checked state model for
callbacks that recursively re-enter themselves.

## Changes

### Extend `#[dispatch]` to four explicit modes

- Add `dispatch(walk)` for engine-driven observers using `walk_*` handlers.
- Keep `dispatch(map)` for engine-driven replacements using `map_*` handlers.
- Make `dispatch(visit)` generate `StructuralVisitor` from user-driven `visit_*` handlers.
- Add `dispatch(mutate)` to generate `StructuralMutator` from user-driven `mutate_*` handlers.
- Preserve source-order, first-match dispatch over owned FFI values, borrowed object nodes, and
  catch-all `VisitValue`/`MapValue` handlers.
- Forward an optional trailing `DefRegionKind` argument in every mode.
- Use mode-specific fallback behavior: `Advance` for walk, no replacement for map, default child
  traversal for visit, and the appropriate copy/in-place default for mutate.

### Add callback-driven structural visitors

- Allow `structural_visit` to accept either `&mut StructuralVisitor`, one typed callback, or a
  nested callback tuple.
- Add `VisitCallbacks<State, ...>` for reusable callback chains with ordinary mutable state.
- Add `VisitContext<State>` with access to state, the current value and definition region,
  selected-child recursion, and default child traversal.
- A matched callback owns traversal of its value; unmatched values use default child traversal.
- Support `()`, `Result<()>`, `Option<VisitInterrupt>`, and
  `Result<Option<VisitInterrupt>>` callback outcomes.

### Add callback-driven structural mutators

- Allow `structural_mutate` to accept either `&mut StructuralMutator`, one typed callback, or a
  nested callback tuple.
- Add `MutateCallbacks<State, ...>` for reusable callback chains with ordinary mutable state.
- Add `MutateContext<State>` with access to state, the current value and definition region,
  borrowed-child mutation, owned-child maybe-in-place mutation, default mutation, and
  invocation-local variable remapping.
- A matched callback supplies the final value; unmatched values retain the engine's current
  copy/maybe-in-place permission and use default mutation.
- Keep `MutateContext::default_mutate()` on the copy path because the callback may still hold a
  shared borrow of the current value. Owned children can explicitly use
  `maybe_inplace_mutate()` when reuse is safe.

### Make recursive callback state borrow-checked

- Visit and mutate callbacks remain `Fn`, allowing the same callback to be recursively
  re-entered.
- Callback code is stored independently behind `Rc`, while mutable state and the active driver
  remain in the callback wrapper.
- Recursive context methods require `&mut self`, so Rust rejects a state borrow that remains live
  across recursive visit/mutate calls instead of relying on external `Cell`/`RefCell` state.
- Direct callbacks are wrapped in a temporary `VisitCallbacks<(), ...>` or
  `MutateCallbacks<(), ...>`; users opt into state by constructing the wrapper explicitly.

### Preserve structural runtime semantics

- Registered `__s_visit__`, `__s_mutate__`, and `__s_maybe_inplace_mutate__` hooks continue to
  receive the active Rust-backed visitor/mutator and can re-enter Rust through the shared ABI.
- Definition-region propagation, reflected-field fallback, interrupt/error context, panic
  resumption, and nested traversal state restoration continue to work across callback paths.
- Mutation keeps invocation-local `FreeVar`/`DAGNode` remapping and rechecks uniqueness before an
  in-place write.
- No C or C++ ABI changes are introduced.

## Compatibility note

The former walk-layer naming is intentionally changed:

- `#[dispatch(visit)]` with `visit_*` observer methods becomes `#[dispatch(walk)]` with `walk_*`
  methods.
- `VisitDispatch` becomes `WalkDispatch`.
- `DispatchVisitor` becomes `DispatchWalker`.

`#[dispatch(visit)]` now denotes the user-driven visitor layer and generates
`StructuralVisitor`. Existing hand-written `StructuralVisitor` and `StructuralMutator` call sites
remain valid.

## Tests

- `cargo test --workspace`
- `cargo test --workspace --release`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- `uv run --group docs sphinx-build -W --keep-going -b html docs docs/_build/html`
- Pre-commit hooks on all changed files

The expanded regression coverage includes callback first-match behavior, nested tuples,
definition regions, selected-child recursion, stateful recursive re-entry, interrupts, registered
hooks, reflection, nested traversals, panic/error propagation, copy-on-write/in-place behavior,
and invocation-local identity remapping.