### PR TITLE
[CORE] Inherit behavioral type attributes

### DIFF
--- a/docs/concepts/structural_eq_hash.rst
+++ b/docs/concepts/structural_eq_hash.rst
@@ -715,6 +715,14 @@ still managed by the framework — the custom callback only controls
 *which* sub-values are compared or hashed, *in what order*, and *with
 what* ``def_region`` flag.
 
+A hook also serves every subclass of the type that registered it.  A
+base class can therefore define equality and hashing for its whole
+hierarchy without each subclass restating the hooks.  A subclass that
+needs different behavior can register its own hook, which takes
+priority.  An inherited hook remains responsible for selecting the
+sub-values it compares or hashes, so subclasses that add relevant
+fields should override it.
+
 Signatures
 ~~~~~~~~~~
 

--- a/include/tvm/ffi/reflection/accessor.h
+++ b/include/tvm/ffi/reflection/accessor.h
@@ -190,6 +190,31 @@ class TypeAttrColumn {
     const AnyView* any_view_data = reinterpret_cast<const AnyView*>(column_->data);
     return any_view_data[offset];
   }
+  /*!
+   * \brief Get the type attribute of a type or its nearest ancestor with one.
+   *
+   * Registration is per type index, so `operator[]` on a subclass does not
+   * return an attribute registered by a base class. Use this method for
+   * attributes that define behavior for a hierarchy. A subclass's own
+   * attribute takes priority over inherited attributes.
+   *
+   * \param type_index The type index.
+   * \return The nearest matching attribute, or an empty `AnyView`.
+   */
+  AnyView GetInherited(int32_t type_index) const {
+    AnyView result = (*this)[type_index];
+    if (result != nullptr) {
+      return result;
+    }
+    const TVMFFITypeInfo* type_info = TVMFFIGetTypeInfo(type_index);
+    for (int32_t i = type_info->type_depth - 1; i >= 0; --i) {
+      result = (*this)[type_info->type_ancestors[i]->type_index];
+      if (result != nullptr) {
+        return result;
+      }
+    }
+    return AnyView();
+  }
 
  private:
   const TVMFFITypeAttrColumn* column_;

--- a/src/ffi/extra/serialization.cc
+++ b/src/ffi/extra/serialization.cc
@@ -202,8 +202,9 @@ class ObjectGraphSerializer {
     if (obj->IsInstance<EnumObj>()) return static_cast<const EnumObj*>(obj)->_str_index;
     static reflection::TypeAttrColumn data_to_json =
         reflection::TypeAttrColumn(reflection::type_attr::kDataToJson);
-    if (data_to_json[value.type_index()] != nullptr) {
-      return data_to_json[value.type_index()].cast<Function>()(value);
+    AnyView to_json = data_to_json.GetInherited(value.type_index());
+    if (to_json != nullptr) {
+      return to_json.cast<Function>()(value);
     }
     // NOTE: invariant: lhs and rhs are already the same type
     const TVMFFITypeInfo* type_info = TVMFFIGetTypeInfo(value.type_index());
@@ -265,6 +266,20 @@ class ObjectGraphSerializer {
 json::Value ToJSONGraph(const Any& value, const Any& metadata) {
   return ObjectGraphSerializer::Serialize(value, metadata);
 }
+
+namespace {
+
+// Whether `type_index` is `ancestor_index` or descends from it.
+bool DerivesFrom(int32_t type_index, int32_t ancestor_index) {
+  if (type_index == ancestor_index) return true;
+  const TVMFFITypeInfo* type_info = TVMFFIGetTypeInfo(type_index);
+  for (int32_t i = 0; i < type_info->type_depth; ++i) {
+    if (type_info->type_ancestors[i]->type_index == ancestor_index) return true;
+  }
+  return false;
+}
+
+}  // namespace
 
 class ObjectGraphDeserializer {
  public:
@@ -395,8 +410,19 @@ class ObjectGraphDeserializer {
     }
     static reflection::TypeAttrColumn data_from_json =
         reflection::TypeAttrColumn(reflection::type_attr::kDataFromJson);
-    if (data_from_json[type_index] != nullptr) {
-      return data_from_json[type_index].cast<Function>()(data);
+    AnyView from_json = data_from_json.GetInherited(type_index);
+    if (from_json != nullptr) {
+      Any decoded = from_json.cast<Function>()(data);
+      // The hook chooses the concrete result but must honor the node type from
+      // the serialized graph.
+      const Object* object = decoded.as<Object>();
+      TVM_FFI_CHECK(object != nullptr && DerivesFrom(object->type_index(), type_index), TypeError)
+          << "`" << reflection::type_attr::kDataFromJson << "` for type `"
+          << TypeIndexToTypeKey(type_index) << "` returned "
+          << (object == nullptr
+                  ? std::string("a non-object")
+                  : "a `" + std::string(TypeIndexToTypeKey(object->type_index())) + "`");
+      return decoded;
     }
     // otherwise, we go over the fields and create the data.
     const TVMFFITypeInfo* type_info = TVMFFIGetTypeInfo(type_index);

--- a/src/ffi/extra/structural_equal.cc
+++ b/src/ffi/extra/structural_equal.cc
@@ -209,8 +209,12 @@ class StructEqualHandler {
     static reflection::TypeAttrColumn custom_s_equal =
         reflection::TypeAttrColumn(reflection::type_attr::kSEqual);
 
+    // A custom hook serves the hierarchy below the type that registered it.
+    // A subclass can override the inherited behavior by registering its own.
+    AnyView custom = custom_s_equal.GetInherited(type_info->type_index);
+
     bool success = true;
-    if (custom_s_equal[type_info->type_index] == nullptr) {
+    if (custom == nullptr) {
       // We recursively compare the fields the object
       reflection::ForEachFieldInfoWithEarlyStop(type_info, [&](const TVMFFIFieldInfo* field_info) {
         // skip fields that are marked as structural eq hash ignore
@@ -277,9 +281,7 @@ class StructEqualHandler {
               return sub_success;
             });
       }
-      success = custom_s_equal[type_info->type_index]
-                    .cast<ffi::Function>()(lhs, rhs, s_equal_callback_)
-                    .cast<bool>();
+      success = custom.cast<ffi::Function>()(lhs, rhs, s_equal_callback_).cast<bool>();
     }
     return success;
   }

--- a/src/ffi/extra/structural_hash.cc
+++ b/src/ffi/extra/structural_hash.cc
@@ -175,7 +175,11 @@ class StructuralHashHandler {
     static reflection::TypeAttrColumn custom_s_hash =
         reflection::TypeAttrColumn(reflection::type_attr::kSHash);
 
-    if (custom_s_hash[type_info->type_index] == nullptr) {
+    // Mirror structural equality: a custom hook serves subclasses unless one
+    // registers a more specific override.
+    AnyView custom = custom_s_hash.GetInherited(type_info->type_index);
+
+    if (custom == nullptr) {
       // go over the content and hash the fields
       reflection::ForEachFieldInfo(type_info, [&](const TVMFFIFieldInfo* field_info) {
         // skip fields that are marked as structural eq hash ignore
@@ -218,9 +222,9 @@ class StructuralHashHandler {
               return static_cast<int64_t>(details::StableHashCombine(inner_init, hv));
             });
       }
-      init_hash = custom_s_hash[type_info->type_index]
-                      .cast<ffi::Function>()(obj, static_cast<int64_t>(init_hash), s_hash_callback_)
-                      .cast<uint64_t>();
+      init_hash =
+          custom.cast<ffi::Function>()(obj, static_cast<int64_t>(init_hash), s_hash_callback_)
+              .cast<uint64_t>();
     }
     return init_hash;
   }

--- a/tests/python/test_dataclass_py_class.py
+++ b/tests/python/test_dataclass_py_class.py
@@ -88,6 +88,31 @@ def test_field_accepts_converter_metadata() -> None:
     assert f.converter is converter
 
 
+def test_structural_hooks_are_inherited_by_subclasses() -> None:
+    @py_class(_unique_key("InheritedStructuralHookBase"))
+    class Base(Object):
+        key: int
+        ignored: int
+
+        def __s_equal__(self, other: Any, equal: Any) -> bool:
+            return equal(self.key, other.key, False, "key")
+
+        def __s_hash__(self, init_hash: int, hash_value: Any) -> int:
+            return hash_value(self.key, init_hash, False)
+
+    @py_class(_unique_key("InheritedStructuralHookChild"))
+    class Child(Base):
+        extra: int
+
+    lhs = Child(key=1, ignored=2, extra=3)
+    rhs = Child(key=1, ignored=20, extra=30)
+    different = Child(key=2, ignored=2, extra=3)
+
+    assert tvm_ffi.structural_equal(lhs, rhs)
+    assert tvm_ffi.structural_hash(lhs) == tvm_ffi.structural_hash(rhs)
+    assert not tvm_ffi.structural_equal(lhs, different)
+
+
 # ---------------------------------------------------------------------------
 # Low-level helpers for _make_type-based tests
 # ---------------------------------------------------------------------------

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import itertools
 import json
 from typing import Any, Callable
 
@@ -25,6 +26,8 @@ import pytest
 import tvm_ffi
 import tvm_ffi.testing
 from tvm_ffi.serialization import from_json_graph_str, to_json_graph_str
+
+_type_counter = itertools.count()
 
 
 # ---------------------------------------------------------------------------
@@ -66,6 +69,33 @@ def _assert_any_equal(a: Any, b: Any) -> None:
         assert str(a) == str(b)
     else:
         assert a == b
+
+
+def test_serialization_hooks_are_inherited_by_subclasses() -> None:
+    restored_values: dict[int, tvm_ffi.Object] = {}
+
+    @tvm_ffi.dataclasses.py_class(f"testing.serialization.HookBase{next(_type_counter)}")
+    class Base(tvm_ffi.Object):
+        key: int
+
+        def __data_to_json__(self) -> int:
+            return self.key
+
+        @staticmethod
+        def __data_from_json__(key: int) -> tvm_ffi.Object:
+            return restored_values[key]
+
+    @tvm_ffi.dataclasses.py_class(f"testing.serialization.HookChild{next(_type_counter)}")
+    class Child(Base):
+        extra: int
+
+    child = Child(key=1, extra=2)
+    restored_values[1] = child
+    assert _roundtrip(child).same_as(child)
+
+    restored_values[1] = Base(key=1)
+    with pytest.raises(TypeError, match="__data_from_json__"):
+        _roundtrip(child)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add `TypeAttrColumn::GetInherited` for nearest-ancestor behavioral dispatch
- inherit structural equality, structural hash, and JSON serialization hooks in subclasses while allowing subclass overrides
- validate that inherited JSON deserialization hooks return an object compatible with the serialized node type
- document the inheritance behavior and add regression coverage

## Testing

- editable package rebuild
- `uv run pytest -vvs tests/python/test_dataclass_c_class.py tests/python/test_dataclass_enum.py tests/python/test_dataclass_py_class.py tests/python/test_serialization.py` (534 passed, 1 skipped)
- changed-file pre-commit hooks