### PR TITLE
[PERF] Use adaptive identity table in StructuralMap

### DIFF
--- a/include/tvm/ffi/extra/structural_mutate.h
+++ b/include/tvm/ffi/extra/structural_mutate.h
@@ -40,11 +40,14 @@
 
 #include <cstddef>
 #include <exception>
+#include <memory>
 #include <optional>
 #include <string>
 #include <tuple>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
+#include <vector>
 
 namespace tvm {
 namespace ffi {
@@ -657,11 +660,16 @@ class StructuralMapMutatorObj : public StructuralMutatorObj {
     }
     try {
       ObjectRef var_ref = var.cast<ObjectRef>();
-      std::optional<Any> result = var_remap_.Get(var_ref);
-      if (!result.has_value()) {
-        return Any(nullptr);
+      if (var_remap_overflow_ != nullptr) {
+        auto it = var_remap_overflow_->find(var_ref);
+        return it == var_remap_overflow_->end() ? Any(nullptr) : it->second;
       }
-      return *std::move(result);
+      for (const auto& entry : var_remap_) {
+        if (entry.first.same_as(var_ref)) {
+          return entry.second;
+        }
+      }
+      return Any(nullptr);
     } catch (const Error& err) {
       return Unexpected(err);
     }
@@ -681,7 +689,27 @@ class StructuralMapMutatorObj : public StructuralMutatorObj {
     try {
       ObjectRef var_ref = var.cast<ObjectRef>();
       Any owned_mapped_value(mapped_value);
-      var_remap_.Set(var_ref, owned_mapped_value);
+      if (var_remap_overflow_ != nullptr) {
+        var_remap_overflow_->insert_or_assign(std::move(var_ref), std::move(owned_mapped_value));
+        return Expected<void>();
+      }
+      for (auto& entry : var_remap_) {
+        if (entry.first.same_as(var_ref)) {
+          entry.second = std::move(owned_mapped_value);
+          return Expected<void>();
+        }
+      }
+      if (var_remap_.size() == kLinearVarRemapLimit) {
+        var_remap_overflow_ = std::make_unique<VarRemapTable>();
+        var_remap_overflow_->reserve(kLinearVarRemapLimit * 2);
+        for (auto& entry : var_remap_) {
+          var_remap_overflow_->emplace(std::move(entry.first), std::move(entry.second));
+        }
+        var_remap_.clear();
+        var_remap_overflow_->emplace(std::move(var_ref), std::move(owned_mapped_value));
+        return Expected<void>();
+      }
+      var_remap_.emplace_back(std::move(var_ref), std::move(owned_mapped_value));
       return Expected<void>();
     } catch (const Error& err) {
       return Unexpected(err);
@@ -825,8 +853,11 @@ class StructuralMapMutatorObj : public StructuralMutatorObj {
   /*! \brief Composed callback dispatcher owned by this mutator. */
   Dispatch dispatch_;
 
-  /*! \brief Identity-substitution table. */
-  Map<ObjectRef, Any> var_remap_;
+  /*! \brief Identity-substitution table, linear for tiny traversals and hashed after growth. */
+  static constexpr size_t kLinearVarRemapLimit = 8;
+  using VarRemapTable = std::unordered_map<ObjectRef, Any, ObjectPtrHash, ObjectPtrEqual>;
+  std::vector<std::pair<ObjectRef, Any>> var_remap_;
+  std::unique_ptr<VarRemapTable> var_remap_overflow_;
 };
 
 // Build a callback dispatcher from a typed callback chain. The dispatcher answers "which link

--- a/tests/cpp/extra/test_structural_mutate.cc
+++ b/tests/cpp/extra/test_structural_mutate.cc
@@ -291,6 +291,25 @@ TEST(StructuralMap, ReusesFinalCallbackResultForRepeatedVar) {
   CheckRepeatedVarRemap<WalkOrder::kPostOrder>();
 }
 
+TEST(StructuralMap, ReusesManyVarResultsAfterRemapTableGrowth) {
+  AnyArray values;
+  for (int i = 0; i < 16; ++i) values.push_back(TVar("v" + std::to_string(i)));
+  AnyArray root = values;
+  for (const Any& value : values) root.push_back(value);
+  int callback_count = 0;
+
+  AnyArray mapped =
+      StructuralMap<WalkOrder::kPostOrder>(root, [&](const TVarObj* value) -> Expected<Any> {
+        ++callback_count;
+        return Any(TVar(value->name + "-mapped"));
+      }).cast<AnyArray>();
+
+  EXPECT_EQ(callback_count, 16);
+  for (int i = 0; i < 16; ++i) {
+    EXPECT_TRUE(mapped[i].same_as(mapped[i + 16]));
+  }
+}
+
 AnyArray MakeStringAndBytesLeaves() {
   return AnyArray{int64_t{1}, String("1234567"), String("12345678"), Bytes("1234567", 7),
                   Bytes("12345678", 8)};


### PR DESCRIPTION
StructuralMap currently uses the persistent `ffi::Map` container for its per-invocation identity-remap environment. This makes tiny expression rewrites pay hashing and persistent-node allocation costs even when only one or two variables are present.

Use an owning linear vector for up to eight identities, then migrate once to an owning `std::unordered_map` so larger traversals retain scalable lookup. The key and mapped value remain owned throughout the traversal, and replacement of an existing identity preserves current semantics.

The accompanying regression crosses the growth boundary with 16 distinct free variables and proves that each callback runs once and both uses share the final output identity.

Measured with GCC 14.3, `-O3 -DNDEBUG`, pinned to one Ryzen 7950X CPU, a two-node minimal registered-hook fixture with a repeated free variable dropped from approximately 153 ns total (`ffi::Map`) to 79.6 ns total (adaptive table). In the motivating 15-node TVM distinct split/fuse no-op fixture, StructuralMap reaches parity with the existing virtual mutator at approximately 34.8 vs 35.0 ns/node. The full ASan-enabled C++ suite passes (476 tests).