### PR TITLE
[PERF][EXTRA] Shorten DefaultMutateRaw error-path live range

### DIFF
--- a/include/tvm/ffi/extra/structural_mutate.h
+++ b/include/tvm/ffi/extra/structural_mutate.h
@@ -342,7 +342,10 @@ class StructuralMutatorObj : public Object {
   TVM_FFI_INLINE TVMFFIAny DefaultMutateRaw(AnyView value) noexcept {
     static reflection::TypeAttrColumn column(reflection::type_attr::kStructuralMutate);
     AnyView attr = column[value.type_index()];
-    const Object* node = value.as<Object>();
+    const Object* node =
+        value.type_index() >= TypeIndex::kTVMFFIStaticObjectBegin
+            ? details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const Object>(value)
+            : nullptr;
     // Exactly one frame per node: hooks propagate errors untouched, and this is the engine
     // dispatching into `value`, so both exits below name it here and nowhere else.
     TVMFFIAny result;

--- a/include/tvm/ffi/extra/structural_mutate.h
+++ b/include/tvm/ffi/extra/structural_mutate.h
@@ -342,6 +342,7 @@ class StructuralMutatorObj : public Object {
   TVM_FFI_INLINE TVMFFIAny DefaultMutateRaw(AnyView value) noexcept {
     static reflection::TypeAttrColumn column(reflection::type_attr::kStructuralMutate);
     AnyView attr = column[value.type_index()];
+    const Object* node = value.as<Object>();
     // Exactly one frame per node: hooks propagate errors untouched, and this is the engine
     // dispatching into `value`, so both exits below name it here and nowhere else.
     TVMFFIAny result;
@@ -350,8 +351,8 @@ class StructuralMutatorObj : public Object {
     } else {
       result = DefaultMutateRawTail(value, attr);
     }
-    if (TVM_FFI_PREDICT_FALSE(result.type_index == TypeIndex::kTVMFFIError)) {
-      details::UpdateVisitErrorContext(result, value);
+    if (TVM_FFI_PREDICT_FALSE(result.type_index == TypeIndex::kTVMFFIError && node != nullptr)) {
+      details::UpdateVisitErrorContext(result, node);
     }
     return result;
   }


### PR DESCRIPTION
## Summary

- classify the input before `DefaultMutateRaw` dispatch and retain only its guarded borrowed node pointer for cold error-context reporting
- avoid keeping the original `AnyView` type index live across the hook or tail call
- preserve primitive handling and the existing one-frame-per-object error-context behavior

## Validation

- all 493 enabled C++ tests pass (two existing cycle tests remain disabled)
- all 23 structural hook bodies match the pinned TVM port, and both benchmark harnesses pass their untimed correctness gates
- a GCC 11.4 `-O3` probe confirms the original type index no longer crosses dispatch and the stack frame is unchanged; instantiated dispatch code grows by 77--206 bytes

Two independent five-process H200 comparisons did not establish a repeatable speedup. The first run's valid non-Call split/fuse identity rows improved 3.0--3.7%, while the replicate ranged from -2.1% to +2.7%. Moved-sequence floor controls that bypass this path shifted 5.8--8.7%, invalidating those rows. This PR therefore makes no runtime speedup claim.
