### PR TITLE
[FFI][PERF] Strip cv in IsObjectInstance so as<Object>() folds to true

### DIFF
--- a/include/tvm/ffi/object.h
+++ b/include/tvm/ffi/object.h
@@ -1202,7 +1202,7 @@ template <typename TargetType>
 TVM_FFI_INLINE bool IsObjectInstance(int32_t object_type_index) {
   static_assert(std::is_base_of_v<Object, TargetType>);
   // Everything is a subclass of object.
-  if constexpr (std::is_same_v<TargetType, Object>) {
+  if constexpr (std::is_same_v<std::remove_cv_t<TargetType>, Object>) {
     return true;
   } else if constexpr (TargetType::_type_final) {
     // if the target type is a final type


### PR DESCRIPTION
`AnyView::as<Object>()` is `as<const T*>()`, so it instantiates `IsObjectInstance<const Object>` and the `std::is_same_v<TargetType, Object>` short-circuit misses on the `const`. Every derived object then falls through to a `TVMFFIGetTypeInfo` call and an ancestor walk to answer a question that is always yes.

One line: strip cv on the check. Zero runtime cost; `as<Object>()` on a derived type now compiles to a plain pointer read with no call.