### PR TITLE
[FFI][REFACTOR] Remove TVM_FFI_S_VISIT_RETURN_NONE

### DIFF
--- a/include/tvm/ffi/extra/structural_visit.h
+++ b/include/tvm/ffi/extra/structural_visit.h
@@ -505,12 +505,11 @@ namespace details {
  *       details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const FooNode>(value);
  *   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->a));
  *   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->b));
- *   TVM_FFI_S_VISIT_RETURN_NONE();
+ *   return AnyView(nullptr).CopyToTVMFFIAny();
  * }
  * \endcode
  *
  * \param Result An expression yielding the descent result to inspect.
- * \sa TVM_FFI_S_VISIT_RETURN_NONE
  */
 #define TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(Result)                                \
   do {                                                                            \
@@ -520,18 +519,6 @@ namespace details {
       return ::tvm::ffi::details::MaybeReturnHelper(::std::move(tvm_ffi_res_));   \
     }                                                                             \
   } while (0)
-
-/*!
- * \brief Return the completed result -- no interrupt -- from a visit hook.
- *
- * Terminal statement of a hook that traversed every field it intends to. Works
- * from a raw ``TVMFFIAny`` hook and a typed ``Expected`` helper alike.
- *
- * \sa TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN
- */
-#define TVM_FFI_S_VISIT_RETURN_NONE()            \
-  return ::tvm::ffi::details::MaybeReturnHelper( \
-      ::tvm::ffi::Expected<::tvm::ffi::Optional<::tvm::ffi::VisitInterrupt>>(::std::nullopt))
 
 }  // namespace details
 

--- a/src/ffi/extra/structural_visit.cc
+++ b/src/ffi/extra/structural_visit.cc
@@ -115,7 +115,7 @@ TVMFFIAny VisitSeqContainer(StructuralVisitorObj* visitor, const SeqBaseObj* sel
   for (const Any& item : *self) {
     TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(item));
   }
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 /*! \brief Visit values in a map container while treating keys as structural anchors. */
@@ -123,7 +123,7 @@ TVMFFIAny VisitMapContainer(StructuralVisitorObj* visitor, const MapBaseObj* sel
   for (const auto& kv : *self) {
     TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(kv.second));
   }
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 /*! \brief Structural visit hook for ArrayObj. */


### PR DESCRIPTION
The macro only spelled `Expected<Optional<VisitInterrupt>>(std::nullopt)` through `MaybeReturnHelper`. A raw hook returns `AnyView(nullptr).CopyToTVMFFIAny()` and a typed helper returns `std::nullopt` directly, so the macro added a name and nothing else. `TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN` stays; it is the one that needs the helper.

Two uses in `structural_visit.cc` and the doc example updated. No behaviour change.