### PR TITLE
[FFI][FIX] Use int64_t for the parsed TVM_TRACEBACK_LIMIT

### DIFF
--- a/src/ffi/backtrace_utils.h
+++ b/src/ffi/backtrace_utils.h
@@ -44,7 +44,7 @@ namespace ffi {
 inline int32_t GetBacktraceLimit() {
   if (const char* env = std::getenv("TVM_TRACEBACK_LIMIT")) {
     char* end = nullptr;
-    long value = std::strtol(env, &end, 10);  // NOLINT(runtime/int)
+    int64_t value = std::strtol(env, &end, 10);
     // An empty, non-numeric, negative, or out-of-range value falls back to the
     // default rather than throwing from inside the error reporter.
     if (end != env && *end == '\0' && value >= 0 && value <= INT32_MAX) {


### PR DESCRIPTION
clang-tidy `google-runtime-int` rejects the `long` introduced in #763 at `backtrace_utils.h:47`. Store the `strtol` result in `int64_t`; the range check is unchanged.