### PR TITLE
[Rust][Fix] Preserve object lifetime and thread-safety contracts

### DIFF
--- a/examples/rust_stubgen/README.md
+++ b/examples/rust_stubgen/README.md
@@ -123,27 +123,18 @@ A complete layout does not always permit direct allocation. For a registry-owned
 type, keep its readable fields but suppress both generated allocators:
 
 ```rust
-// tvm-ffi-stubgen(no-alloc): ir.SourceName
+// tvm-ffi-stubgen(no-alloc): <type_key>
 ```
 
-`no-alloc` takes precedence over `custom-new` and also applies to descendants
-across all input files in the same invocation. Include the file declaring this
-policy when generating descendants. The binding supplies the existing registry
-lookup; stubgen does not infer or translate native constructor semantics.
+`no-alloc` takes precedence over `custom-new` and also applies to descendants.
+`no-alloc`, `nullable`, and `opaque` are shared across all input files in the same
+invocation, so include the files declaring these policies when generating
+descendants. Directives containing Rust type names remain file-local. The binding
+supplies the registry lookup; stubgen does not infer native constructor semantics.
 
-If native code can move an object-reference field out and leave it null, reuse
-`nullable` and `custom-new` in the file containing that binding:
-
-```rust
-// tvm-ffi-stubgen(nullable): tirx.PrimFunc.body
-// tvm-ffi-stubgen(custom-new): tirx.PrimFunc
-```
-
-The generated field is `pub body: Option<Stmt>`. The hand-written `new` takes a
-`Stmt` and passes `Some(body)` to `from_complete_fields`. Read it with `as_ref()`
-or a binding-level `body()` helper. The low-level allocator still accepts `None`;
-this preserves nullable storage, not a private-field invariant. Native mutation
-must not invalidate a live Rust borrow. Other directives remain file-local.
+Layout metadata and pointer sizes describe the loaded libraries and the current
+process. Run stubgen against the ABI you intend to build for, not a different
+cross-compilation target.
 
 ## Thread safety
 
@@ -153,10 +144,8 @@ not change their ABI layout. `Function` remains shareable, so its `from_packed`
 and `from_typed` callbacks require `Send + Sync` captures. Scoped structural
 callbacks are unaffected. `ObjectArc` requires unique ownership for mutable access.
 
-These are source-compatibility changes: pass factories must forward the callback
-bounds, and a process-wide `OnceLock<Module>` needs a separate ownership design.
-Do not add unsafe thread-safety implementations just to restore compilation;
-they must cover hidden native state, destruction, and all accepted dynamic subtypes.
+These are source-compatibility changes. Any unsafe thread-safety opt-in must
+cover hidden native state, destruction, and all accepted dynamic subtypes.
 
 ## Partial generation
 

--- a/examples/rust_stubgen/README.md
+++ b/examples/rust_stubgen/README.md
@@ -111,11 +111,72 @@ Besides `prefix` and `custom-new`, this example declares the integer field
 // tvm-ffi-stubgen(enum): rust_stubgen.IntPair.kind -> PairKind(i32) { Unordered=0, Ordered=1 }
 ```
 
-Three more are available: `field` names the Rust type of a field
+`field` names the Rust type of a field
 (`// tvm-ffi-stubgen(field): rust_stubgen.IntPair.a -> MyInt`), `nullable`
-wraps it in `Option` (`// tvm-ffi-stubgen(nullable): rust_stubgen.IntPair.a`),
+wraps an object-reference field in `Option` (for example, a nullable `span`),
 and `upcast` adds a conversion to a hand-written typed view
 (`// tvm-ffi-stubgen(upcast): rust_stubgen.IntPair -> MyView`).
+
+## Object lifetime and construction policies
+
+Complete byte layout alone does not say whether a type may be allocated, shared
+between threads, or have its fields moved out by native code. Declare these
+policies outside the generated blocks; no type names are hard-coded in stubgen:
+
+```rust
+// tvm-ffi-stubgen(no-alloc): ir.SourceName
+// tvm-ffi-stubgen(nullable-storage): tirx.PrimFunc.body
+```
+
+- `no-alloc` keeps complete readable fields but omits both `<Type>Obj::new`
+  and the wrapper allocator. It also applies to descendants, and takes precedence
+  over `custom-new`. An interned type can keep a hand-written method that calls
+  its existing registry lookup; generating a binding does not require Rust to
+  allocate the object.
+- `nullable-storage` applies to a required, pointer-sized object-reference
+  field in a complete layout. It generates private `Option<T>` storage, a
+  borrowing accessor `field(&self) -> &T`, and an allocator that takes `T`
+  and stores `Some(value)`. Native code may leave the slot null after a move,
+  including on error; Rust can then drop the object safely. The accessor panics
+  on that moved-from state. Use ordinary `nullable` instead if callers are
+  allowed to construct an absent value. Optional/scalar fields and conflicting
+  directives are rejected, and the generated storage's size, alignment and
+  offset are checked at compile time.
+
+These two policies apply across **all input files in the same invocation**,
+so a descendant in another module cannot bypass its base's allocation policy.
+When generating a subset of files, include the files declaring its ancestors'
+policies too. Existing `field`, `nullable`, `enum`, `opaque`, `upcast`, and
+`custom-new` directives remain file-local.
+
+These directives encode reviewed native behavior, not behavior inferred from
+field sizes. In particular, `nullable-storage` does not make concurrent native
+mutation of a borrowed Rust field safe, and `no-alloc` does not automatically
+translate a C++ constructor's validation into Rust.
+
+Generated objects, both complete and opaque, inherit `!Send` and `!Sync` from
+`tvm_ffi::Object`. Atomic reference counts do not prove that hidden native state
+or its destructor is thread-safe. The base marker has zero size and does not
+change the ABI; upcasting to a base node or `ObjectRef`, or retaining an
+`ObjectIdentity`, does not erase the restriction. No per-type directive is needed.
+An explicit unsafe thread-safety implementation must cover all dynamic subtypes,
+not just the fields visible in Rust. This is a Rust compile-time restriction,
+not a lock or a runtime check on foreign code.
+
+`Function` remains shareable for global function caches. `from_packed` and
+`from_typed` therefore require `Send + Sync` captures; an `Rc`, `Cell`, or local
+object cannot be smuggled to another thread inside a closure. Use synchronized
+shared state when necessary. This restriction does not apply to the scoped
+callbacks passed to structural walk/map/visit/mutate, nor to a packed function's
+arguments and results, which are created and consumed on the calling thread.
+
+This tightens Rust source compatibility. Downstream pass factories that wrap
+callbacks in `Function` must forward the `Send + Sync` bounds. A process-wide
+`OnceLock<Module>` also needs a separate loading/ownership design; an opaque
+`Module` is not automatically thread-safe. Do not add blanket unsafe implementations
+just to restore compilation. `ObjectArc` also rejects mutable dereferencing while
+another strong or external weak owner exists, instead of creating aliased `&mut`
+references.
 
 ## Partial generation
 

--- a/examples/rust_stubgen/README.md
+++ b/examples/rust_stubgen/README.md
@@ -117,66 +117,46 @@ wraps an object-reference field in `Option` (for example, a nullable `span`),
 and `upcast` adds a conversion to a hand-written typed view
 (`// tvm-ffi-stubgen(upcast): rust_stubgen.IntPair -> MyView`).
 
-## Object lifetime and construction policies
+## Construction and ownership
 
-Complete byte layout alone does not say whether a type may be allocated, shared
-between threads, or have its fields moved out by native code. Declare these
-policies outside the generated blocks; no type names are hard-coded in stubgen:
+A complete layout does not always permit direct allocation. For a registry-owned
+type, keep its readable fields but suppress both generated allocators:
 
 ```rust
 // tvm-ffi-stubgen(no-alloc): ir.SourceName
-// tvm-ffi-stubgen(nullable-storage): tirx.PrimFunc.body
 ```
 
-- `no-alloc` keeps complete readable fields but omits both `<Type>Obj::new`
-  and the wrapper allocator. It also applies to descendants, and takes precedence
-  over `custom-new`. An interned type can keep a hand-written method that calls
-  its existing registry lookup; generating a binding does not require Rust to
-  allocate the object.
-- `nullable-storage` applies to a required, pointer-sized object-reference
-  field in a complete layout. It generates private `Option<T>` storage, a
-  borrowing accessor `field(&self) -> &T`, and an allocator that takes `T`
-  and stores `Some(value)`. Native code may leave the slot null after a move,
-  including on error; Rust can then drop the object safely. The accessor panics
-  on that moved-from state. Use ordinary `nullable` instead if callers are
-  allowed to construct an absent value. Optional/scalar fields and conflicting
-  directives are rejected, and the generated storage's size, alignment and
-  offset are checked at compile time.
+`no-alloc` takes precedence over `custom-new` and also applies to descendants
+across all input files in the same invocation. Include the file declaring this
+policy when generating descendants. The binding supplies the existing registry
+lookup; stubgen does not infer or translate native constructor semantics.
 
-These two policies apply across **all input files in the same invocation**,
-so a descendant in another module cannot bypass its base's allocation policy.
-When generating a subset of files, include the files declaring its ancestors'
-policies too. Existing `field`, `nullable`, `enum`, `opaque`, `upcast`, and
-`custom-new` directives remain file-local.
+If native code can move an object-reference field out and leave it null, reuse
+`nullable` and `custom-new` in the file containing that binding:
 
-These directives encode reviewed native behavior, not behavior inferred from
-field sizes. In particular, `nullable-storage` does not make concurrent native
-mutation of a borrowed Rust field safe, and `no-alloc` does not automatically
-translate a C++ constructor's validation into Rust.
+```rust
+// tvm-ffi-stubgen(nullable): tirx.PrimFunc.body
+// tvm-ffi-stubgen(custom-new): tirx.PrimFunc
+```
 
-Generated objects, both complete and opaque, inherit `!Send` and `!Sync` from
-`tvm_ffi::Object`. Atomic reference counts do not prove that hidden native state
-or its destructor is thread-safe. The base marker has zero size and does not
-change the ABI; upcasting to a base node or `ObjectRef`, or retaining an
-`ObjectIdentity`, does not erase the restriction. No per-type directive is needed.
-An explicit unsafe thread-safety implementation must cover all dynamic subtypes,
-not just the fields visible in Rust. This is a Rust compile-time restriction,
-not a lock or a runtime check on foreign code.
+The generated field is `pub body: Option<Stmt>`. The hand-written `new` takes a
+`Stmt` and passes `Some(body)` to `from_complete_fields`. Read it with `as_ref()`
+or a binding-level `body()` helper. The low-level allocator still accepts `None`;
+this preserves nullable storage, not a private-field invariant. Native mutation
+must not invalidate a live Rust borrow. Other directives remain file-local.
 
-`Function` remains shareable for global function caches. `from_packed` and
-`from_typed` therefore require `Send + Sync` captures; an `Rc`, `Cell`, or local
-object cannot be smuggled to another thread inside a closure. Use synchronized
-shared state when necessary. This restriction does not apply to the scoped
-callbacks passed to structural walk/map/visit/mutate, nor to a packed function's
-arguments and results, which are created and consumed on the calling thread.
+## Thread safety
 
-This tightens Rust source compatibility. Downstream pass factories that wrap
-callbacks in `Function` must forward the `Send + Sync` bounds. A process-wide
-`OnceLock<Module>` also needs a separate loading/ownership design; an opaque
-`Module` is not automatically thread-safe. Do not add blanket unsafe implementations
-just to restore compilation. `ObjectArc` also rejects mutable dereferencing while
-another strong or external weak owner exists, instead of creating aliased `&mut`
-references.
+Complete and opaque objects inherit `!Send` and `!Sync` from `tvm_ffi::Object`,
+including when viewed through a base or `ObjectRef`. The zero-sized marker does
+not change their ABI layout. `Function` remains shareable, so its `from_packed`
+and `from_typed` callbacks require `Send + Sync` captures. Scoped structural
+callbacks are unaffected. `ObjectArc` requires unique ownership for mutable access.
+
+These are source-compatibility changes: pass factories must forward the callback
+bounds, and a process-wide `OnceLock<Module>` needs a separate ownership design.
+Do not add unsafe thread-safety implementations just to restore compilation;
+they must cover hidden native state, destruction, and all accepted dynamic subtypes.
 
 ## Partial generation
 

--- a/python/tvm_ffi/stub/cli.py
+++ b/python/tvm_ffi/stub/cli.py
@@ -345,7 +345,6 @@ def _stage_3(  # noqa: PLR0912
         if name not in generator.directive_kinds:
             raise ValueError(f"Unknown directive `{name}` at line {code.lineno_start}")
         generator.add_directive(imports, name, payload, code.lineno_start)
-    generator.validate_directives(imports)
     # Stage 2. Process `tvm-ffi-stubgen(begin): global/...`
     for code in file.code_blocks:
         if code.kind == "global":

--- a/python/tvm_ffi/stub/cli.py
+++ b/python/tvm_ffi/stub/cli.py
@@ -39,7 +39,7 @@ from .lib_state import (
 from .utils import FuncInfo, InitConfig, Options
 
 if TYPE_CHECKING:
-    from collections.abc import Container
+    from collections.abc import Container, Sequence
 
     from .generator import Generator
 
@@ -110,6 +110,12 @@ def __main__() -> int:
         for code in file.code_blocks
         if code.kind == "object" and isinstance(code.param, str)
     )
+    shared_directives = [
+        code
+        for file in files
+        for code in file.code_blocks
+        if code.kind == "directive" and code.param[0] in generator.shared_directive_kinds
+    ]
     for file in files:
         if opt.verbose:
             print(f"{C.TERM_CYAN}[File] {file.path}{C.TERM_RESET}")
@@ -121,6 +127,7 @@ def __main__() -> int:
                 global_funcs,
                 generator=generator,
                 declared=declared,
+                shared_directives=shared_directives,
             )
         except Exception:
             failed += 1
@@ -322,13 +329,14 @@ def _stage_3(  # noqa: PLR0912
     global_funcs: dict[str, list[FuncInfo]],
     generator: Generator,
     declared: Container[str] = frozenset(),
+    shared_directives: Sequence[CodeBlock] = (),
 ) -> bool:
     """Process one file's blocks; return whether its content is (or would be) changed."""
     defined_funcs: set[str] = set()
     defined_types: set[str] = set()
     imports = generator.new_imports()
     # Stage 1. Hand the one-line directives the pipeline does not consume itself to the generator.
-    for code in file.code_blocks:
+    for code in [*shared_directives, *file.code_blocks]:
         if code.kind != "directive":
             continue
         name, payload = code.param
@@ -337,6 +345,7 @@ def _stage_3(  # noqa: PLR0912
         if name not in generator.directive_kinds:
             raise ValueError(f"Unknown directive `{name}` at line {code.lineno_start}")
         generator.add_directive(imports, name, payload, code.lineno_start)
+    generator.validate_directives(imports)
     # Stage 2. Process `tvm-ffi-stubgen(begin): global/...`
     for code in file.code_blocks:
         if code.kind == "global":

--- a/python/tvm_ffi/stub/generator.py
+++ b/python/tvm_ffi/stub/generator.py
@@ -82,6 +82,10 @@ class Generator(Protocol):
     #: to the pipeline; any other undeclared name is an error.
     directive_kinds: frozenset[str]
 
+    #: Type policies that also apply to references/descendants in other input files.
+    #: Unlike local type spellings, these directives must not depend on Rust imports.
+    shared_directive_kinds: frozenset[str]
+
     def default_ty_map(self) -> dict[str, str]:
         """Return the default FFI-origin -> target-type name map for this language."""
         ...
@@ -95,10 +99,15 @@ class Generator(Protocol):
     def add_directive(self, imports: Any, name: str, payload: str, lineno: int) -> None:
         """Record a one-line directive (raw payload) into ``imports``.
 
-        The collector is per file, so a directive applies to the blocks of the
-        file it appears in. ``name`` is always one of :attr:`directive_kinds`;
+        The collector is per file. The pipeline also seeds it with directives
+        in :attr:`shared_directive_kinds` from the other input files.
+        ``name`` is always one of :attr:`directive_kinds`;
         the payload's grammar is the generator's to define.
         """
+        ...
+
+    def validate_directives(self, imports: Any) -> None:
+        """Validate collected directives before generating any blocks in this file."""
         ...
 
     def canonical_type_name(self, type_key: str) -> str:

--- a/python/tvm_ffi/stub/generator.py
+++ b/python/tvm_ffi/stub/generator.py
@@ -106,10 +106,6 @@ class Generator(Protocol):
         """
         ...
 
-    def validate_directives(self, imports: Any) -> None:
-        """Validate collected directives before generating any blocks in this file."""
-        ...
-
     def canonical_type_name(self, type_key: str) -> str:
         """Return the canonical identifier for a locally-defined type key.
 

--- a/python/tvm_ffi/stub/python_generator/generator.py
+++ b/python/tvm_ffi/stub/python_generator/generator.py
@@ -68,9 +68,6 @@ class PythonGenerator:
         if alias == "_FFI_LOAD_LIB" or full_name.endswith("libinfo.load_lib_module"):
             imports.has_lib_load = True
 
-    def validate_directives(self, imports: PythonImports) -> None:
-        """Python import directives need no registry validation."""
-
     def canonical_type_name(self, type_key: str) -> str:
         """Return the canonical (import-comparable) full name for a defined type key."""
         return ImportItem(type_key).full_name

--- a/python/tvm_ffi/stub/python_generator/generator.py
+++ b/python/tvm_ffi/stub/python_generator/generator.py
@@ -46,6 +46,7 @@ class PythonGenerator:
     syntax = C.PYTHON_SYNTAX
     source_exts = frozenset({".py", ".pyi"})
     directive_kinds: frozenset[str] = frozenset({"import-object"})
+    shared_directive_kinds: frozenset[str] = frozenset()
 
     def default_ty_map(self) -> dict[str, str]:
         """Return the default FFI-origin -> Python-type name map."""
@@ -66,6 +67,9 @@ class PythonGenerator:
         imports.items.append(ImportItem(full_name, type_checking_only=tco, alias=alias or None))
         if alias == "_FFI_LOAD_LIB" or full_name.endswith("libinfo.load_lib_module"):
             imports.has_lib_load = True
+
+    def validate_directives(self, imports: PythonImports) -> None:
+        """Python import directives need no registry validation."""
 
     def canonical_type_name(self, type_key: str) -> str:
         """Return the canonical (import-comparable) full name for a defined type key."""

--- a/python/tvm_ffi/stub/rust_generator/codegen.py
+++ b/python/tvm_ffi/stub/rust_generator/codegen.py
@@ -45,8 +45,6 @@ missing keys, so a partial binding never references a module that does not exist
 Layout and allocation are separate: ``no-alloc`` suppresses both allocators
 without hiding readable fields. Thread restrictions are inherited from the
 crate's ``Object`` base, including for opaque views.
-``nullable-storage`` models object-reference slots that native code may move
-out of, without making the constructor argument optional.
 """
 
 from __future__ import annotations
@@ -215,34 +213,6 @@ class _ObjectRenderer:
 
     # --- field types -------------------------------------------------------
 
-    def _nullable_storage_type(self, owner: str, field: NamedTypeSchema, mirror: str) -> str:
-        """Require an object handle, not merely something pointer-sized (e.g. i64)."""
-        target = f"{owner}.{field.name}"
-        if target in self.imports.directives.nullable or field.origin == "Optional":
-            raise ValueError(f"`nullable-storage` on `{target}` requires a non-optional field")
-        object_origin = field.origin in {
-            "Object",
-            "Array",
-            "Map",
-            "Tensor",
-            "Shape",
-            "Callable",
-        } or (
-            "." in field.origin
-            and not field.origin.startswith("ctypes.")
-            and field.origin not in {"ffi.String", "ffi.Bytes"}
-        )
-        if (
-            not object_origin
-            or field.size != C_RUST.RUST_POINTER_SIZE
-            or mirror.startswith(("Option<", "Optional<"))
-            or mirror in C_RUST.RUST_SCALAR_WIDTHS
-        ):
-            raise ValueError(
-                f"`nullable-storage` on `{target}` requires a pointer-sized object-reference field"
-            )
-        return f"Option<{mirror}>"
-
     def _field_mirror(self, owner: str, field: NamedTypeSchema, imports: RustImports) -> str | None:
         """Render the ``#[repr(C)]`` mirror type of ``field``, or ``None``.
 
@@ -252,8 +222,6 @@ class _ObjectRenderer:
         target = f"{owner}.{field.name}"
         enum = directives.enums.get(target)
         if enum is not None:
-            if target in directives.nullable_storage:
-                raise ValueError(f"`nullable-storage` on `{target}` cannot be combined with `enum`")
             _check_width(target, field, enum.repr, C_RUST.RUST_SCALAR_WIDTHS[enum.repr])
             return enum.name
         override = directives.field_types.get(target)
@@ -269,8 +237,6 @@ class _ObjectRenderer:
             mirror = narrowed or render_rust_type(field, lambda o: self._resolve(o, imports))
         if mirror is None:
             return None
-        if target in directives.nullable_storage:
-            return self._nullable_storage_type(owner, field, mirror)
         if target in directives.nullable and not mirror.startswith("Option<"):
             if field.size not in (None, C_RUST.RUST_POINTER_SIZE):
                 raise ValueError(
@@ -419,19 +385,10 @@ class _ObjectRenderer:
                 "}",
             ]
         members = []
-        storage_checks = []
         for field in sorted(self.info.fields, key=lambda f: f.offset or 0):
             mirror = self._field_mirror(self.type_key, field, self.imports)
             assert mirror is not None  # the verdict already ran the renderability check
-            visibility = "" if self._has_nullable_storage(self.type_key, field.name) else "pub "
-            members.append(f"    {visibility}{rust_ident(field.name)}: {mirror},")
-            if not visibility:
-                storage_checks += [
-                    f"    assert!(::core::mem::size_of::<{mirror}>() == {field.size});",
-                    f"    assert!(::core::mem::align_of::<{mirror}>() == {field.alignment});",
-                    f"    assert!(::core::mem::offset_of!({self.obj_struct}, "
-                    f"{rust_ident(field.name)}) == {field.offset});",
-                ]
+            members.append(f"    pub {rust_ident(field.name)}: {mirror},")
         return [
             f"/// Complete: {verdict.detail}.",
             *header,
@@ -441,45 +398,8 @@ class _ObjectRenderer:
             "const _: () = {",
             f"    assert!(::core::mem::size_of::<{self.obj_struct}>() == {verdict.total_size});",
             f"    assert!(::core::mem::align_of::<{self.obj_struct}>() == {verdict.alignment});",
-            *storage_checks,
             "};",
         ]
-
-    def _has_nullable_storage(self, owner: str, name: str) -> bool:
-        return f"{owner}.{name}" in self.imports.directives.nullable_storage
-
-    def _storage_accessors(self) -> list[str]:
-        lines = []
-        for field in self.info.fields:
-            if not self._has_nullable_storage(self.type_key, field.name):
-                continue
-            mirror = self._field_mirror(self.type_key, field, self.imports)
-            assert mirror is not None and mirror.startswith("Option<")
-            value_type = mirror.removeprefix("Option<").removesuffix(">")
-            name = rust_ident(field.name)
-            lines += [
-                "    /// Borrow the field; panics if native code has moved it out.",
-                "    #[inline]",
-                f"    pub fn {name}(&self) -> &{value_type} {{",
-                f'        self.{name}.as_ref().expect("{self.leaf}.{field.name} has been moved out")',
-                "    }",
-            ]
-        return [f"impl {self.obj_struct} {{", *lines, "}"] if lines else []
-
-    def _validate_storage_directives(self, verdict: Verdict) -> None:
-        prefix = f"{self.type_key}."
-        targets = {
-            t
-            for t in self.imports.directives.nullable_storage
-            if t.rpartition(".")[0] == self.type_key
-        }
-        fields = {f"{prefix}{f.name}": f for f in self.info.fields}
-        for target in sorted(targets):
-            if target not in fields:
-                raise ValueError(f"`nullable-storage` names unknown own field `{target}`")
-            if not verdict.is_complete:
-                raise ValueError(f"`nullable-storage` on `{target}` requires a complete layout")
-            self._field_mirror(self.type_key, fields[target], self.imports)
 
     # --- allocators --------------------------------------------------------
 
@@ -503,8 +423,6 @@ class _ObjectRenderer:
         for field in sorted(info.fields, key=lambda f: f.offset or 0):
             mirror = self._field_mirror(key, field, self.imports)
             assert mirror is not None  # complete: every field along the chain has a mirror
-            if self._has_nullable_storage(key, field.name):
-                mirror = mirror.removeprefix("Option<").removesuffix(">")
             params.append((field.name, mirror))
         return params
 
@@ -542,12 +460,7 @@ class _ObjectRenderer:
             f"{rust_ident(name)}.into()" if rust_type != parent_type else rust_ident(name)
             for (name, rust_type), (_, parent_type) in zip(params, inherited)
         ]
-        own = [
-            f"{rust_ident(f.name)}: Some({rust_ident(f.name)})"
-            if self._has_nullable_storage(self.type_key, f.name)
-            else rust_ident(f.name)
-            for f in sorted(self.info.fields, key=lambda f: f.offset or 0)
-        ]
+        own = [rust_ident(f.name) for f in sorted(self.info.fields, key=lambda f: f.offset or 0)]
         forward = [rust_ident(name) for name, _ in params]
         sections = [
             [
@@ -580,7 +493,6 @@ class _ObjectRenderer:
     def body(self) -> list[str]:
         """Build the Rust source lines for the object."""
         verdict = self.classify()
-        self._validate_storage_directives(verdict)
         # Derive macros are spelled by full path: their leaves collide with `Object` / `ObjectRef`.
         self.imports.record("std::ops::Deref")
         self.imports.record("tvm_ffi::ObjectArc")
@@ -626,8 +538,6 @@ class _ObjectRenderer:
                 ]
             )
         elif verdict.is_complete:
-            if storage_accessors := self._storage_accessors():
-                sections.append(storage_accessors)
             hierarchy = {self.type_key, *self.info.ancestors}
             if not hierarchy.intersection(self.imports.directives.no_alloc):
                 sections += self._allocator_sections(base, has_parent)

--- a/python/tvm_ffi/stub/rust_generator/codegen.py
+++ b/python/tvm_ffi/stub/rust_generator/codegen.py
@@ -41,6 +41,12 @@ provided in the same run: ``ffi.*`` by the crate, a ``ty-map`` by a hand-written
 binding whose object struct is ``<Name>Obj``, anything else by an ``object/``
 block in one of the processed files. Otherwise the block is an error naming the
 missing keys, so a partial binding never references a module that does not exist.
+
+Layout and allocation are separate: ``no-alloc`` suppresses both allocators
+without hiding readable fields. Thread restrictions are inherited from the
+crate's ``Object`` base, including for opaque views.
+``nullable-storage`` models object-reference slots that native code may move
+out of, without making the constructor argument optional.
 """
 
 from __future__ import annotations
@@ -209,6 +215,34 @@ class _ObjectRenderer:
 
     # --- field types -------------------------------------------------------
 
+    def _nullable_storage_type(self, owner: str, field: NamedTypeSchema, mirror: str) -> str:
+        """Require an object handle, not merely something pointer-sized (e.g. i64)."""
+        target = f"{owner}.{field.name}"
+        if target in self.imports.directives.nullable or field.origin == "Optional":
+            raise ValueError(f"`nullable-storage` on `{target}` requires a non-optional field")
+        object_origin = field.origin in {
+            "Object",
+            "Array",
+            "Map",
+            "Tensor",
+            "Shape",
+            "Callable",
+        } or (
+            "." in field.origin
+            and not field.origin.startswith("ctypes.")
+            and field.origin not in {"ffi.String", "ffi.Bytes"}
+        )
+        if (
+            not object_origin
+            or field.size != C_RUST.RUST_POINTER_SIZE
+            or mirror.startswith(("Option<", "Optional<"))
+            or mirror in C_RUST.RUST_SCALAR_WIDTHS
+        ):
+            raise ValueError(
+                f"`nullable-storage` on `{target}` requires a pointer-sized object-reference field"
+            )
+        return f"Option<{mirror}>"
+
     def _field_mirror(self, owner: str, field: NamedTypeSchema, imports: RustImports) -> str | None:
         """Render the ``#[repr(C)]`` mirror type of ``field``, or ``None``.
 
@@ -218,6 +252,8 @@ class _ObjectRenderer:
         target = f"{owner}.{field.name}"
         enum = directives.enums.get(target)
         if enum is not None:
+            if target in directives.nullable_storage:
+                raise ValueError(f"`nullable-storage` on `{target}` cannot be combined with `enum`")
             _check_width(target, field, enum.repr, C_RUST.RUST_SCALAR_WIDTHS[enum.repr])
             return enum.name
         override = directives.field_types.get(target)
@@ -233,6 +269,8 @@ class _ObjectRenderer:
             mirror = narrowed or render_rust_type(field, lambda o: self._resolve(o, imports))
         if mirror is None:
             return None
+        if target in directives.nullable_storage:
+            return self._nullable_storage_type(owner, field, mirror)
         if target in directives.nullable and not mirror.startswith("Option<"):
             if field.size not in (None, C_RUST.RUST_POINTER_SIZE):
                 raise ValueError(
@@ -381,10 +419,19 @@ class _ObjectRenderer:
                 "}",
             ]
         members = []
+        storage_checks = []
         for field in sorted(self.info.fields, key=lambda f: f.offset or 0):
             mirror = self._field_mirror(self.type_key, field, self.imports)
             assert mirror is not None  # the verdict already ran the renderability check
-            members.append(f"    pub {rust_ident(field.name)}: {mirror},")
+            visibility = "" if self._has_nullable_storage(self.type_key, field.name) else "pub "
+            members.append(f"    {visibility}{rust_ident(field.name)}: {mirror},")
+            if not visibility:
+                storage_checks += [
+                    f"    assert!(::core::mem::size_of::<{mirror}>() == {field.size});",
+                    f"    assert!(::core::mem::align_of::<{mirror}>() == {field.alignment});",
+                    f"    assert!(::core::mem::offset_of!({self.obj_struct}, "
+                    f"{rust_ident(field.name)}) == {field.offset});",
+                ]
         return [
             f"/// Complete: {verdict.detail}.",
             *header,
@@ -394,8 +441,45 @@ class _ObjectRenderer:
             "const _: () = {",
             f"    assert!(::core::mem::size_of::<{self.obj_struct}>() == {verdict.total_size});",
             f"    assert!(::core::mem::align_of::<{self.obj_struct}>() == {verdict.alignment});",
+            *storage_checks,
             "};",
         ]
+
+    def _has_nullable_storage(self, owner: str, name: str) -> bool:
+        return f"{owner}.{name}" in self.imports.directives.nullable_storage
+
+    def _storage_accessors(self) -> list[str]:
+        lines = []
+        for field in self.info.fields:
+            if not self._has_nullable_storage(self.type_key, field.name):
+                continue
+            mirror = self._field_mirror(self.type_key, field, self.imports)
+            assert mirror is not None and mirror.startswith("Option<")
+            value_type = mirror.removeprefix("Option<").removesuffix(">")
+            name = rust_ident(field.name)
+            lines += [
+                "    /// Borrow the field; panics if native code has moved it out.",
+                "    #[inline]",
+                f"    pub fn {name}(&self) -> &{value_type} {{",
+                f'        self.{name}.as_ref().expect("{self.leaf}.{field.name} has been moved out")',
+                "    }",
+            ]
+        return [f"impl {self.obj_struct} {{", *lines, "}"] if lines else []
+
+    def _validate_storage_directives(self, verdict: Verdict) -> None:
+        prefix = f"{self.type_key}."
+        targets = {
+            t
+            for t in self.imports.directives.nullable_storage
+            if t.rpartition(".")[0] == self.type_key
+        }
+        fields = {f"{prefix}{f.name}": f for f in self.info.fields}
+        for target in sorted(targets):
+            if target not in fields:
+                raise ValueError(f"`nullable-storage` names unknown own field `{target}`")
+            if not verdict.is_complete:
+                raise ValueError(f"`nullable-storage` on `{target}` requires a complete layout")
+            self._field_mirror(self.type_key, fields[target], self.imports)
 
     # --- allocators --------------------------------------------------------
 
@@ -419,6 +503,8 @@ class _ObjectRenderer:
         for field in sorted(info.fields, key=lambda f: f.offset or 0):
             mirror = self._field_mirror(key, field, self.imports)
             assert mirror is not None  # complete: every field along the chain has a mirror
+            if self._has_nullable_storage(key, field.name):
+                mirror = mirror.removeprefix("Option<").removesuffix(">")
             params.append((field.name, mirror))
         return params
 
@@ -456,7 +542,12 @@ class _ObjectRenderer:
             f"{rust_ident(name)}.into()" if rust_type != parent_type else rust_ident(name)
             for (name, rust_type), (_, parent_type) in zip(params, inherited)
         ]
-        own = [rust_ident(f.name) for f in sorted(self.info.fields, key=lambda f: f.offset or 0)]
+        own = [
+            f"{rust_ident(f.name)}: Some({rust_ident(f.name)})"
+            if self._has_nullable_storage(self.type_key, f.name)
+            else rust_ident(f.name)
+            for f in sorted(self.info.fields, key=lambda f: f.offset or 0)
+        ]
         forward = [rust_ident(name) for name, _ in params]
         sections = [
             [
@@ -489,6 +580,7 @@ class _ObjectRenderer:
     def body(self) -> list[str]:
         """Build the Rust source lines for the object."""
         verdict = self.classify()
+        self._validate_storage_directives(verdict)
         # Derive macros are spelled by full path: their leaves collide with `Object` / `ObjectRef`.
         self.imports.record("std::ops::Deref")
         self.imports.record("tvm_ffi::ObjectArc")
@@ -534,7 +626,11 @@ class _ObjectRenderer:
                 ]
             )
         elif verdict.is_complete:
-            sections += self._allocator_sections(base, has_parent)
+            if storage_accessors := self._storage_accessors():
+                sections.append(storage_accessors)
+            hierarchy = {self.type_key, *self.info.ancestors}
+            if not hierarchy.intersection(self.imports.directives.no_alloc):
+                sections += self._allocator_sections(base, has_parent)
         upcasts = self._upcast_lines()
         if upcasts:
             sections.append(upcasts)

--- a/python/tvm_ffi/stub/rust_generator/codegen.py
+++ b/python/tvm_ffi/stub/rust_generator/codegen.py
@@ -263,11 +263,7 @@ class _ObjectRenderer:
             payload.origin in C_RUST.RUST_ANY_BACKED_OPTIONAL_PAYLOADS
             or payload.origin == "Optional"
         )
-        expected = (
-            C_RUST.RUST_OPTIONAL_FIELD_SIZE
-            if any_backed
-            else C_RUST.RUST_OBJECT_OPTIONAL_FIELD_SIZE
-        )
+        expected = C_RUST.RUST_OPTIONAL_FIELD_SIZE if any_backed else C_RUST.RUST_POINTER_SIZE
         if field.size not in (None, expected):
             return None
         if any_backed:

--- a/python/tvm_ffi/stub/rust_generator/consts.py
+++ b/python/tvm_ffi/stub/rust_generator/consts.py
@@ -18,6 +18,8 @@
 
 from __future__ import annotations
 
+import ctypes
+
 #: One-line directives the Rust backend consumes.
 RUST_DIRECTIVE_KINDS = frozenset(
     {
@@ -90,13 +92,12 @@ RUST_SCALAR_WIDTHS = {
     "f64": 8,
 }
 
-#: Size of an object reference field; ``nullable`` may only wrap those.
-RUST_POINTER_SIZE = 8
+#: The registry is loaded in this process, so its object pointers have the host ABI size.
+RUST_POINTER_SIZE = ctypes.sizeof(ctypes.c_void_p)
 
 #: C++ ``Optional<T>`` is a 16-byte ``TVMFFIAny`` cell, or a nullable pointer for object payloads.
 RUST_OPTIONAL_PATH = "tvm_ffi::Optional"
 RUST_OPTIONAL_FIELD_SIZE = 16
-RUST_OBJECT_OPTIONAL_FIELD_SIZE = 8
 
 #: ``Optional`` payloads kept as the 16-byte cell (a nested ``Optional`` too); the size is checked.
 RUST_ANY_BACKED_OPTIONAL_PAYLOADS = frozenset(

--- a/python/tvm_ffi/stub/rust_generator/consts.py
+++ b/python/tvm_ffi/stub/rust_generator/consts.py
@@ -29,7 +29,6 @@ RUST_DIRECTIVE_KINDS = frozenset(
         "upcast",
         "custom-new",
         "no-alloc",
-        "nullable-storage",
     }
 )
 

--- a/python/tvm_ffi/stub/rust_generator/consts.py
+++ b/python/tvm_ffi/stub/rust_generator/consts.py
@@ -20,7 +20,17 @@ from __future__ import annotations
 
 #: One-line directives the Rust backend consumes.
 RUST_DIRECTIVE_KINDS = frozenset(
-    {"import-object", "field", "nullable", "enum", "opaque", "upcast", "custom-new"}
+    {
+        "import-object",
+        "field",
+        "nullable",
+        "enum",
+        "opaque",
+        "upcast",
+        "custom-new",
+        "no-alloc",
+        "nullable-storage",
+    }
 )
 
 #: Default FFI-origin -> Rust-type map; ``::`` paths get a ``use``, bare names do not.

--- a/python/tvm_ffi/stub/rust_generator/directives.py
+++ b/python/tvm_ffi/stub/rust_generator/directives.py
@@ -35,7 +35,8 @@ reproducible. ``upcast`` adds a typed view outside the ancestor chain;
 named ``from_complete_fields`` instead.
 
 ``no-alloc`` preserves readable fields but suppresses both allocators, including
-in descendants. It applies across all files in a generation run.
+in descendants. Like ``nullable`` and ``opaque``, it applies across all files in
+a generation run. Directives containing Rust type names remain file-local.
 """
 
 from __future__ import annotations

--- a/python/tvm_ffi/stub/rust_generator/directives.py
+++ b/python/tvm_ffi/stub/rust_generator/directives.py
@@ -25,7 +25,6 @@ Field directives address ``<type_key>.<field>``; type directives address ``<type
     // tvm-ffi-stubgen(upcast): tirx.Add -> PrimExpr
     // tvm-ffi-stubgen(custom-new): tirx.Add
     // tvm-ffi-stubgen(no-alloc): ir.SourceName
-    // tvm-ffi-stubgen(nullable-storage): tirx.PrimFunc.body
 
 ``field`` sets the field's Rust type (a name in scope, or a ``::`` path to
 ``use``); on a field inherited from an ancestor it narrows the allocator
@@ -36,10 +35,7 @@ reproducible. ``upcast`` adds a typed view outside the ancestor chain;
 named ``from_complete_fields`` instead.
 
 ``no-alloc`` preserves readable fields but suppresses both allocators, including
-in descendants.
-``nullable-storage`` keeps an object-reference field private and nullable while
-requiring a non-null constructor argument and exposing a borrowing accessor.
-These two policies are shared across all files in a generation run.
+in descendants. It applies across all files in a generation run.
 """
 
 from __future__ import annotations
@@ -74,7 +70,6 @@ class Directives:
     upcasts: dict[str, list[str]] = dataclasses.field(default_factory=dict)
     custom_new: set[str] = dataclasses.field(default_factory=set)
     no_alloc: set[str] = dataclasses.field(default_factory=set)
-    nullable_storage: set[str] = dataclasses.field(default_factory=set)
 
     def add(self, name: str, payload: str, lineno: int) -> None:
         """Parse and store one directive; raise ``ValueError`` on a malformed payload."""
@@ -95,8 +90,6 @@ class Directives:
             self.custom_new.add(_type_target(name, payload, lineno))
         elif name == "no-alloc":
             self.no_alloc.add(_type_target(name, payload, lineno))
-        elif name == "nullable-storage":
-            self.nullable_storage.add(_field_target(name, payload, lineno))
         else:
             raise ValueError(f"Unknown directive `{name}` at line {lineno}")
 

--- a/python/tvm_ffi/stub/rust_generator/directives.py
+++ b/python/tvm_ffi/stub/rust_generator/directives.py
@@ -16,7 +16,7 @@
 # under the License.
 """The Rust backend's one-line directives: payload grammar and per-file storage.
 
-Three address one reflected field as ``<type_key>.<field>``, three address a type::
+Field directives address ``<type_key>.<field>``; type directives address ``<type_key>``::
 
     // tvm-ffi-stubgen(field): tirx.Add.a -> PrimExpr
     // tvm-ffi-stubgen(nullable): ir.Expr.span
@@ -24,6 +24,8 @@ Three address one reflected field as ``<type_key>.<field>``, three address a typ
     // tvm-ffi-stubgen(opaque): ir.SourceName
     // tvm-ffi-stubgen(upcast): tirx.Add -> PrimExpr
     // tvm-ffi-stubgen(custom-new): tirx.Add
+    // tvm-ffi-stubgen(no-alloc): ir.SourceName
+    // tvm-ffi-stubgen(nullable-storage): tirx.PrimFunc.body
 
 ``field`` sets the field's Rust type (a name in scope, or a ``::`` path to
 ``use``); on a field inherited from an ancestor it narrows the allocator
@@ -32,6 +34,12 @@ integer newtype for it; ``opaque`` keeps a type opaque even when its layout is
 reproducible. ``upcast`` adds a typed view outside the ancestor chain;
 ``custom-new`` says the wrapper's ``new`` is hand-written; the generated one is
 named ``from_complete_fields`` instead.
+
+``no-alloc`` preserves readable fields but suppresses both allocators, including
+in descendants.
+``nullable-storage`` keeps an object-reference field private and nullable while
+requiring a non-null constructor argument and exposing a borrowing accessor.
+These two policies are shared across all files in a generation run.
 """
 
 from __future__ import annotations
@@ -65,6 +73,8 @@ class Directives:
     opaque: set[str] = dataclasses.field(default_factory=set)
     upcasts: dict[str, list[str]] = dataclasses.field(default_factory=dict)
     custom_new: set[str] = dataclasses.field(default_factory=set)
+    no_alloc: set[str] = dataclasses.field(default_factory=set)
+    nullable_storage: set[str] = dataclasses.field(default_factory=set)
 
     def add(self, name: str, payload: str, lineno: int) -> None:
         """Parse and store one directive; raise ``ValueError`` on a malformed payload."""
@@ -83,6 +93,10 @@ class Directives:
             self.upcasts.setdefault(_type_target(name, lhs, lineno), []).append(rust_type)
         elif name == "custom-new":
             self.custom_new.add(_type_target(name, payload, lineno))
+        elif name == "no-alloc":
+            self.no_alloc.add(_type_target(name, payload, lineno))
+        elif name == "nullable-storage":
+            self.nullable_storage.add(_field_target(name, payload, lineno))
         else:
             raise ValueError(f"Unknown directive `{name}` at line {lineno}")
 

--- a/python/tvm_ffi/stub/rust_generator/generator.py
+++ b/python/tvm_ffi/stub/rust_generator/generator.py
@@ -50,7 +50,7 @@ class RustGenerator:
     syntax = C.RUST_SYNTAX
     source_exts = frozenset({".rs"})
     directive_kinds = C_RUST.RUST_DIRECTIVE_KINDS
-    shared_directive_kinds = frozenset({"no-alloc"})
+    shared_directive_kinds = frozenset({"no-alloc", "nullable", "opaque"})
 
     def default_ty_map(self) -> dict[str, str]:
         """Return the default FFI-origin -> Rust-type name map."""

--- a/python/tvm_ffi/stub/rust_generator/generator.py
+++ b/python/tvm_ffi/stub/rust_generator/generator.py
@@ -69,7 +69,6 @@ class RustGenerator:
         else:
             imports.directives.add(name, payload, lineno)
             if name == "no-alloc":
-                # A misspelled type must not silently leave its allocator enabled.
                 object_info_from_type_key(payload.strip())
 
     def canonical_type_name(self, type_key: str) -> str:

--- a/python/tvm_ffi/stub/rust_generator/generator.py
+++ b/python/tvm_ffi/stub/rust_generator/generator.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from .. import consts as C
+from ..lib_state import object_info_from_type_key
 from . import consts as C_RUST
 from .codegen import (
     finalize_rust_module_tree,
@@ -43,12 +44,13 @@ if TYPE_CHECKING:
 
 
 class RustGenerator:
-    """Generator that emits opaque Rust bindings for reflected objects (see :mod:`.codegen`)."""
+    """Generator for complete and opaque Rust bindings (see :mod:`.codegen`)."""
 
     name = "rust"
     syntax = C.RUST_SYNTAX
     source_exts = frozenset({".rs"})
     directive_kinds = C_RUST.RUST_DIRECTIVE_KINDS
+    shared_directive_kinds = frozenset({"no-alloc", "nullable-storage"})
 
     def default_ty_map(self) -> dict[str, str]:
         """Return the default FFI-origin -> Rust-type name map."""
@@ -66,6 +68,17 @@ class RustGenerator:
             imports.record(payload.split(";", 1)[0].strip())
         else:
             imports.directives.add(name, payload, lineno)
+
+    def validate_directives(self, imports: RustImports) -> None:
+        """Do not silently ignore a misspelled safety policy target."""
+        rules = imports.directives
+        owners = rules.no_alloc | {target.rpartition(".")[0] for target in rules.nullable_storage}
+        for key in sorted(owners):
+            info = object_info_from_type_key(key)
+            for target in rules.nullable_storage:
+                owner, _, field = target.rpartition(".")
+                if owner == key and field not in {f.name for f in info.fields}:
+                    raise ValueError(f"`nullable-storage` names unknown own field `{target}`")
 
     def canonical_type_name(self, type_key: str) -> str:
         """Return the Rust path for a defined type key (matches :attr:`RustUse.path`)."""
@@ -100,7 +113,7 @@ class RustGenerator:
         obj_info: ObjectInfo,
         declared: Container[str] = frozenset(),
     ) -> None:
-        """Emit the opaque Rust binding for an ``object/<key>`` block."""
+        """Emit the Rust binding for an ``object/<key>`` block."""
         generate_rust_object(code, ty_map, imports, opt, obj_info, declared)
 
     def generate_import_section_block(

--- a/python/tvm_ffi/stub/rust_generator/generator.py
+++ b/python/tvm_ffi/stub/rust_generator/generator.py
@@ -50,7 +50,7 @@ class RustGenerator:
     syntax = C.RUST_SYNTAX
     source_exts = frozenset({".rs"})
     directive_kinds = C_RUST.RUST_DIRECTIVE_KINDS
-    shared_directive_kinds = frozenset({"no-alloc", "nullable-storage"})
+    shared_directive_kinds = frozenset({"no-alloc"})
 
     def default_ty_map(self) -> dict[str, str]:
         """Return the default FFI-origin -> Rust-type name map."""
@@ -68,17 +68,9 @@ class RustGenerator:
             imports.record(payload.split(";", 1)[0].strip())
         else:
             imports.directives.add(name, payload, lineno)
-
-    def validate_directives(self, imports: RustImports) -> None:
-        """Do not silently ignore a misspelled safety policy target."""
-        rules = imports.directives
-        owners = rules.no_alloc | {target.rpartition(".")[0] for target in rules.nullable_storage}
-        for key in sorted(owners):
-            info = object_info_from_type_key(key)
-            for target in rules.nullable_storage:
-                owner, _, field = target.rpartition(".")
-                if owner == key and field not in {f.name for f in info.fields}:
-                    raise ValueError(f"`nullable-storage` names unknown own field `{target}`")
+            if name == "no-alloc":
+                # A misspelled type must not silently leave its allocator enabled.
+                object_info_from_type_key(payload.strip())
 
     def canonical_type_name(self, type_key: str) -> str:
         """Return the Rust path for a defined type key (matches :attr:`RustUse.path`)."""

--- a/rust/tvm-ffi/src/function.rs
+++ b/rust/tvm-ffi/src/function.rs
@@ -38,11 +38,17 @@ pub struct FunctionObj {
     cell: TVMFFIFunctionCell,
 }
 
-/// Error reference class
+/// A shareable packed function. Rust callbacks must have thread-safe captures.
 #[derive(Clone, ObjectRef)]
 pub struct Function {
     data: ObjectArc<FunctionObj>,
 }
+
+// SAFETY: Rust callbacks require Send + Sync, including their captured state.
+// Foreign callbacks must uphold the same contract (see from_extern_c). Opt in
+// only the handle, not FunctionObj or its potentially stateful derived layouts.
+unsafe impl Send for Function {}
+unsafe impl Sync for Function {}
 
 //------------------------------------------------------------------------
 // CallbackFunctionObjImpl
@@ -311,7 +317,18 @@ impl Function {
             Ok(())
         }
     }
-    /// Construct a function from a packed function
+    /// Construct a function from a packed function.
+    ///
+    /// A Function can be called, retained, and dropped on another thread, so its
+    /// captured state must be `Send + Sync`. This does not require its arguments
+    /// or result to be `Send`: they are supplied and returned on the calling thread.
+    ///
+    /// ```compile_fail
+    /// use std::rc::Rc;
+    /// use tvm_ffi::{Any, Function};
+    /// let state = Rc::new(1i64);
+    /// let _ = Function::from_packed(move |_| Ok(Any::from(*state)));
+    /// ```
     /// # Arguments
     /// * `func` - The packed function in signature of `Fn(&[AnyView]) -> Result<Any>`
     ///
@@ -319,7 +336,7 @@ impl Function {
     /// * `Function` - The function
     pub fn from_packed<F>(func: F) -> Self
     where
-        F: Fn(&[AnyView]) -> Result<Any> + 'static,
+        F: Fn(&[AnyView]) -> Result<Any> + Send + Sync + 'static,
     {
         unsafe {
             let callback_arc = ObjectArc::new(CallbackFunctionObjImpl::from_callback(func));
@@ -330,7 +347,19 @@ impl Function {
         }
     }
 
-    /// Construct a function from a typed function
+    /// Construct a function from a typed function.
+    ///
+    /// Captured state must be `Send + Sync`, as for [`Self::from_packed`].
+    ///
+    /// ```compile_fail
+    /// use std::cell::Cell;
+    /// use tvm_ffi::Function;
+    /// let state = Cell::new(0i64); // Send, but not Sync.
+    /// let _ = Function::from_typed(move || {
+    ///     state.set(state.get() + 1);
+    ///     Ok(state.get())
+    /// });
+    /// ```
     /// # Arguments
     /// * `func` - The typed function with function signature of `F(T0, T1, ...) -> Result<O>`
     ///
@@ -338,7 +367,7 @@ impl Function {
     /// * `Function` - The function
     pub fn from_typed<F, I, O>(func: F) -> Self
     where
-        F: AsPackedCallable<I, O> + 'static,
+        F: AsPackedCallable<I, O> + Send + Sync + 'static,
     {
         let closure = move |packed_args: &[AnyView]| -> Result<Any> {
             let ret_value = func.call_packed(packed_args)?;
@@ -352,6 +381,9 @@ impl Function {
     /// `handle` must be a valid pointer (or null) that is compatible with
     /// `safe_call` and `deleter`. The caller must ensure the handle outlives
     /// the returned `Function` (or that `deleter` properly frees it).
+    /// `safe_call` must support concurrent calls from arbitrary threads, and
+    /// `deleter` must be safe to run on any thread. These requirements also apply
+    /// to the state behind `handle`.
     pub unsafe fn from_extern_c(
         handle: *mut std::ffi::c_void,
         safe_call: TVMFFISafeCallType,

--- a/rust/tvm-ffi/src/object.rs
+++ b/rust/tvm-ffi/src/object.rs
@@ -25,14 +25,30 @@ pub use tvm_ffi_sys::TVMFFITypeIndex as TypeIndex;
 /// Object related ABI handling
 use tvm_ffi_sys::{TVMFFIAny, TVMFFIGetTypeInfo, TVMFFIObject, COMBINED_REF_COUNT_BOTH_ONE};
 
-/// Object type is by default the TVMFFIObject
+/// The common object header, including for objects with unknown native state.
+///
+/// Objects are not `Send` or `Sync` by default: atomic reference counting does
+/// not make an object's fields or destructor thread-safe. Keeping this marker
+/// in the base also prevents casts to a base node or [`ObjectRef`] from erasing
+/// a derived object's thread restrictions. It does not change the C ABI layout.
+///
+/// An explicit unsafe `Send`/`Sync` implementation for a binding must account for
+/// every dynamic subtype it accepts, including hidden state and destruction.
 #[repr(C)]
 pub struct Object {
-    /// example implementation of the object
     header: TVMFFIObject,
+    _thread_confined: std::marker::PhantomData<std::rc::Rc<()>>,
 }
 
-/// Arc-like wrapper for Object that allows shared ownership
+const _: () = {
+    assert!(std::mem::size_of::<Object>() == std::mem::size_of::<TVMFFIObject>());
+    assert!(std::mem::align_of::<Object>() == std::mem::align_of::<TVMFFIObject>());
+    assert!(std::mem::offset_of!(Object, header) == 0);
+};
+
+/// Arc-like wrapper for Object that allows shared ownership.
+///
+/// Mutable dereferencing panics if another strong or external weak owner exists.
 ///
 /// \tparam T The type of the object to be wrapped
 #[repr(C)]
@@ -43,6 +59,19 @@ pub struct ObjectArc<T: ObjectCore> {
 
 unsafe impl<T: Send + Sync + ObjectCore> Send for ObjectArc<T> {}
 unsafe impl<T: Send + Sync + ObjectCore> Sync for ObjectArc<T> {}
+
+// The allocation length must outlive T's destructor when weak owners remain.
+// Keep it before the ABI-visible object, never in the live reference-count header.
+fn extra_items_layout<T: ObjectCoreWithExtraItems>(count: usize) -> (std::alloc::Layout, usize) {
+    use std::alloc::Layout;
+    let items = Layout::array::<T::ExtraItem>(count).expect("extra items layout overflow");
+    let (body, _) = Layout::new::<T>()
+        .extend(items)
+        .expect("object layout overflow");
+    Layout::new::<usize>()
+        .extend(body)
+        .expect("allocation layout overflow")
+}
 
 /// Traits that can be used to check if a type is an object
 ///
@@ -340,7 +369,7 @@ pub mod unsafe_ {
     /// * `obj` - The object to increase the reference count
     #[inline]
     pub unsafe fn inc_ref(handle: *mut TVMFFIObject) {
-        let obj = &mut *handle;
+        let obj = &*handle;
         obj.combined_ref_count.fetch_add(1, Ordering::Relaxed);
     }
 
@@ -352,17 +381,16 @@ pub mod unsafe_ {
     /// * `obj` - The object to decrease the reference count
     #[inline]
     pub(crate) unsafe fn dec_ref(handle: *mut TVMFFIObject) {
-        let obj = &mut *handle;
-        let old_combined_count = obj
+        // Do not keep a Rust reference to the header across a deleter call.
+        let old_combined_count = (*handle)
             .combined_ref_count
-            .fetch_sub(COMBINED_REF_COUNT_STRONG_ONE, Ordering::Relaxed);
+            // Match C++ Object::DecRef: publish this owner's writes before the
+            // last owner acquires them and runs the destructor.
+            .fetch_sub(COMBINED_REF_COUNT_STRONG_ONE, Ordering::Release);
         if old_combined_count == COMBINED_REF_COUNT_BOTH_ONE {
-            if let Some(deleter) = obj.deleter {
-                fence(Ordering::Acquire);
-                deleter(
-                    obj as *mut TVMFFIObject as *mut c_void,
-                    kTVMFFIObjectDeleterFlagBitMaskBoth as i32,
-                );
+            fence(Ordering::Acquire);
+            if let Some(deleter) = (*handle).deleter {
+                deleter(handle.cast(), kTVMFFIObjectDeleterFlagBitMaskBoth as i32);
             }
         } else if (old_combined_count & COMBINED_REF_COUNT_MASK_U32)
             == COMBINED_REF_COUNT_STRONG_ONE
@@ -370,22 +398,16 @@ pub mod unsafe_ {
             // slow path, there is still a weak reference left
             // need to run two phase decrement
             fence(Ordering::Acquire);
-            if let Some(deleter) = obj.deleter {
-                deleter(
-                    obj as *mut TVMFFIObject as *mut c_void,
-                    kTVMFFIObjectDeleterFlagBitMaskStrong as i32,
-                );
+            if let Some(deleter) = (*handle).deleter {
+                deleter(handle.cast(), kTVMFFIObjectDeleterFlagBitMaskStrong as i32);
             }
-            let old_weak_count = obj
+            let old_weak_count = (*handle)
                 .combined_ref_count
                 .fetch_sub(COMBINED_REF_COUNT_WEAK_ONE, Ordering::Release);
             if old_weak_count == COMBINED_REF_COUNT_WEAK_ONE {
                 fence(Ordering::Acquire);
-                if let Some(deleter) = obj.deleter {
-                    deleter(
-                        obj as *mut TVMFFIObject as *mut c_void,
-                        kTVMFFIObjectDeleterFlagBitMaskWeak as i32,
-                    );
+                if let Some(deleter) = (*handle).deleter {
+                    deleter(handle.cast(), kTVMFFIObjectDeleterFlagBitMaskWeak as i32);
                 }
             }
         }
@@ -393,13 +415,13 @@ pub mod unsafe_ {
 
     #[inline]
     pub(crate) unsafe fn strong_count(handle: *mut TVMFFIObject) -> usize {
-        let obj = &mut *handle;
+        let obj = &*handle;
         (obj.combined_ref_count.load(Ordering::Relaxed) & COMBINED_REF_COUNT_MASK_U32) as usize
     }
 
     #[inline]
     pub(crate) unsafe fn weak_count(handle: *mut TVMFFIObject) -> usize {
-        let obj = &mut *handle;
+        let obj = &*handle;
         (obj.combined_ref_count.load(Ordering::Relaxed) >> 32) as usize
     }
 
@@ -424,31 +446,16 @@ pub mod unsafe_ {
         T: super::ObjectCoreWithExtraItems<ExtraItem = U>,
     {
         let obj = ptr as *mut T;
-        if flags == kTVMFFIObjectDeleterFlagBitMaskBoth as i32 {
-            let extra_items_count = T::extra_items_count(&(*obj));
+        if flags & kTVMFFIObjectDeleterFlagBitMaskStrong as i32 != 0 {
             std::ptr::drop_in_place(obj);
-            let layout = std::alloc::Layout::from_size_align(
-                std::mem::size_of::<T>() + extra_items_count * std::mem::size_of::<U>(),
-                std::mem::align_of::<T>(),
-            )
-            .unwrap();
-            std::alloc::dealloc(ptr as *mut u8, layout);
-        } else {
-            assert_eq!(std::mem::size_of::<T>() % std::mem::size_of::<u64>(), 0);
-            if flags & kTVMFFIObjectDeleterFlagBitMaskStrong as i32 != 0 {
-                let extra_items_count = T::extra_items_count(&(*obj));
-                std::ptr::drop_in_place(obj);
-                std::ptr::write(obj as *mut u64, extra_items_count as u64);
-            }
-            if flags & kTVMFFIObjectDeleterFlagBitMaskWeak as i32 != 0 {
-                let extra_items_count = std::ptr::read(obj as *mut u64) as usize;
-                let layout = std::alloc::Layout::from_size_align(
-                    std::mem::size_of::<T>() + extra_items_count * std::mem::size_of::<U>(),
-                    std::mem::align_of::<T>(),
-                )
-                .unwrap();
-                std::alloc::dealloc(ptr as *mut u8, layout);
-            }
+        }
+        if flags & kTVMFFIObjectDeleterFlagBitMaskWeak as i32 != 0 {
+            // The object's offset depends only on alignment, not item count.
+            let (_, offset) = super::extra_items_layout::<T>(0);
+            let allocation = ptr.cast::<u8>().sub(offset);
+            let count = allocation.cast::<usize>().read();
+            let (layout, _) = super::extra_items_layout::<T>(count);
+            std::alloc::dealloc(allocation, layout);
         }
     }
 }
@@ -461,6 +468,7 @@ impl Object {
     pub fn new() -> Self {
         Self {
             header: TVMFFIObject::new(),
+            _thread_confined: std::marker::PhantomData,
         }
     }
 }
@@ -519,16 +527,13 @@ impl<T: ObjectCore> ObjectArc<T> {
             assert_eq!(std::mem::align_of::<T>() % std::mem::align_of::<U>(), 0);
             assert_eq!(std::mem::size_of::<T>() % std::mem::align_of::<U>(), 0);
             let extra_items_count = T::extra_items_count(&data);
-            let layout = std::alloc::Layout::from_size_align(
-                std::mem::size_of::<T>() + extra_items_count * std::mem::size_of::<U>(),
-                std::mem::align_of::<T>(),
-            )
-            .unwrap();
+            let (layout, offset) = extra_items_layout::<T>(extra_items_count);
             let raw_data_ptr = std::alloc::alloc(layout);
             if raw_data_ptr.is_null() {
                 std::alloc::handle_alloc_error(layout);
             }
-            let ptr = raw_data_ptr as *mut T;
+            raw_data_ptr.cast::<usize>().write(extra_items_count);
+            let ptr = raw_data_ptr.add(offset).cast::<T>();
             std::ptr::write(ptr, data);
             // now override the header directly
             std::ptr::write(
@@ -603,7 +608,7 @@ impl<T: ObjectCore> ObjectArc<T> {
     /// * `*mut T` - The raw pointer
     #[inline]
     pub unsafe fn as_raw_mut(this: &mut Self) -> *mut T {
-        this.ptr.as_mut()
+        this.ptr.as_ptr()
     }
 
     /// Get the strong reference count of the ObjectArc
@@ -615,9 +620,7 @@ impl<T: ObjectCore> ObjectArc<T> {
     /// * `usize` - The strong reference count
     #[inline]
     pub fn strong_count(this: &Self) -> usize {
-        unsafe {
-            unsafe_::strong_count(this.ptr.as_ref() as *const T as *mut T as *mut TVMFFIObject)
-        }
+        unsafe { unsafe_::strong_count(this.ptr.as_ptr().cast::<TVMFFIObject>()) }
     }
 
     /// Get the weak reference count of the ObjectArc
@@ -629,7 +632,7 @@ impl<T: ObjectCore> ObjectArc<T> {
     /// * `usize` - The weak reference count
     #[inline]
     pub fn weak_count(this: &Self) -> usize {
-        unsafe { unsafe_::weak_count(this.ptr.as_ref() as *const T as *mut T as *mut TVMFFIObject) }
+        unsafe { unsafe_::weak_count(this.ptr.as_ptr().cast::<TVMFFIObject>()) }
     }
 }
 
@@ -642,18 +645,29 @@ impl<T: ObjectCore> Deref for ObjectArc<T> {
     }
 }
 
-// implement DerefMut for ObjectArc
+// Exclusive Rust access requires both a single strong owner and no external
+// weak owners that could acquire another strong reference during the borrow.
 impl<T: ObjectCore> DerefMut for ObjectArc<T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { self.ptr.as_mut() }
+        unsafe {
+            let header = &*self.ptr.as_ptr().cast::<TVMFFIObject>();
+            assert_eq!(
+                header
+                    .combined_ref_count
+                    .load(std::sync::atomic::Ordering::Acquire),
+                COMBINED_REF_COUNT_BOTH_ONE,
+                "cannot mutably borrow a shared ObjectArc"
+            );
+            self.ptr.as_mut()
+        }
     }
 }
 
 // implement Drop for ObjectArc
 impl<T: ObjectCore> Drop for ObjectArc<T> {
     fn drop(&mut self) {
-        unsafe { unsafe_::dec_ref(self.ptr.as_mut() as *mut T as *mut TVMFFIObject) }
+        unsafe { unsafe_::dec_ref(self.ptr.as_ptr().cast::<TVMFFIObject>()) }
     }
 }
 
@@ -661,7 +675,7 @@ impl<T: ObjectCore> Drop for ObjectArc<T> {
 impl<T: ObjectCore> Clone for ObjectArc<T> {
     #[inline]
     fn clone(&self) -> Self {
-        unsafe { unsafe_::inc_ref(self.ptr.as_ref() as *const T as *mut T as *mut TVMFFIObject) }
+        unsafe { unsafe_::inc_ref(self.ptr.as_ptr().cast::<TVMFFIObject>()) }
         Self {
             ptr: self.ptr,
             _phantom: std::marker::PhantomData,

--- a/rust/tvm-ffi/src/object.rs
+++ b/rust/tvm-ffi/src/object.rs
@@ -40,12 +40,6 @@ pub struct Object {
     _thread_confined: std::marker::PhantomData<std::rc::Rc<()>>,
 }
 
-const _: () = {
-    assert!(std::mem::size_of::<Object>() == std::mem::size_of::<TVMFFIObject>());
-    assert!(std::mem::align_of::<Object>() == std::mem::align_of::<TVMFFIObject>());
-    assert!(std::mem::offset_of!(Object, header) == 0);
-};
-
 /// Arc-like wrapper for Object that allows shared ownership.
 ///
 /// Mutable dereferencing panics if another strong or external weak owner exists.

--- a/rust/tvm-ffi/tests/test_function.rs
+++ b/rust/tvm-ffi/tests/test_function.rs
@@ -54,6 +54,32 @@ fn test_function_from_packed() {
 }
 
 #[test]
+fn test_function_thread_safe_captures_and_global_cache() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let state = calls.clone();
+    let function = Function::from_typed(move |value: i64| {
+        state.fetch_add(1, Ordering::Relaxed);
+        // Neither the argument holder nor the returned Any needs to be Send.
+        cached_global_func!("testing.echo").call_tuple((value,))
+    });
+    std::thread::scope(|scope| {
+        for value in 0..4i64 {
+            let function = &function;
+            scope.spawn(move || {
+                let result: i64 = function.call_tuple((value,)).unwrap().try_into().unwrap();
+                assert_eq!(result, value);
+            });
+        }
+    });
+    assert_eq!(calls.load(Ordering::Relaxed), 4);
+    std::thread::spawn(move || drop(function)).join().unwrap();
+    assert_eq!(Arc::strong_count(&calls), 1);
+}
+
+#[test]
 fn test_function_from_typed() {
     let offset = 2;
     // test one argument

--- a/rust/tvm-ffi/tests/test_object.rs
+++ b/rust/tvm-ffi/tests/test_object.rs
@@ -21,6 +21,34 @@ use std::sync::Arc;
 use std::{collections::HashMap, hash::Hash};
 use tvm_ffi::*;
 
+// An erased owning or borrowed view must not acquire thread-safety merely
+// because its concrete object's non-thread-safe fields are no longer visible.
+macro_rules! assert_not_impl {
+    ($ty:ty: $bound:path) => {
+        const _: fn() = || {
+            trait AmbiguousIfImpl<A> {
+                fn check() {}
+            }
+            impl<T: ?Sized> AmbiguousIfImpl<()> for T {}
+            struct ImplementsBound;
+            impl<T: ?Sized + $bound> AmbiguousIfImpl<ImplementsBound> for T {}
+            let _ = <$ty as AmbiguousIfImpl<_>>::check;
+        };
+    };
+}
+
+assert_not_impl!(Object: Send);
+assert_not_impl!(Object: Sync);
+assert_not_impl!(ObjectArc<Object>: Send);
+assert_not_impl!(ObjectArc<Object>: Sync);
+assert_not_impl!(tvm_ffi::object::ObjectRef: Send);
+assert_not_impl!(tvm_ffi::object::ObjectRef: Sync);
+assert_not_impl!(ObjectIdentity: Send);
+assert_not_impl!(ObjectIdentity: Sync);
+assert_not_impl!(&Object: Send);
+assert_not_impl!(Any: Send);
+assert_not_impl!(AnyView<'static>: Send);
+
 // must have repr(C) for the object header stays in the same position
 #[repr(C)]
 struct TestIntObj {
@@ -101,6 +129,21 @@ fn test_object_arc() {
 }
 
 #[test]
+fn test_object_arc_mutable_borrow_requires_unique_ownership() {
+    let deleted = Arc::new(AtomicU32::new(0));
+    let mut value = ObjectArc::new(TestIntObj::new(1, deleted, 0));
+    let alias = value.clone();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        value.value = 2;
+    }));
+    assert!(result.is_err());
+    assert_eq!(alias.value, 1);
+    drop(alias);
+    value.value = 3;
+    assert_eq!(value.value, 3);
+}
+
+#[test]
 fn test_object_arc_with_extra_items() {
     let delete_counter = Arc::new(AtomicU32::new(0));
     let mut obj_arc =
@@ -121,6 +164,39 @@ fn test_object_arc_with_extra_items() {
     }
     drop(obj_arc);
     assert_eq!(delete_counter.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn test_extra_items_with_a_surviving_weak_owner() {
+    use tvm_ffi::tvm_ffi_sys::{
+        TVMFFIObjectDeleterFlagBitMask::kTVMFFIObjectDeleterFlagBitMaskWeak,
+        COMBINED_REF_COUNT_WEAK_ONE,
+    };
+    for count in [0, 3] {
+        let deleted = Arc::new(AtomicU32::new(0));
+        let value = ObjectArc::new_with_extra_items(TestIntObj::new(1, deleted.clone(), count));
+        // Model a native weak reference through the existing combined-count ABI.
+        unsafe {
+            let header = ObjectArc::as_raw(&value).cast::<TVMFFIObject>();
+            (*header)
+                .combined_ref_count
+                .fetch_add(COMBINED_REF_COUNT_WEAK_ONE, Ordering::Relaxed);
+            drop(value);
+            assert_eq!(deleted.load(Ordering::Relaxed), 1);
+            assert_eq!(
+                (*header)
+                    .combined_ref_count
+                    .fetch_sub(COMBINED_REF_COUNT_WEAK_ONE, Ordering::Release),
+                COMBINED_REF_COUNT_WEAK_ONE,
+            );
+            std::sync::atomic::fence(Ordering::Acquire);
+            (*header).deleter.unwrap()(
+                header.cast_mut().cast(),
+                kTVMFFIObjectDeleterFlagBitMaskWeak as i32,
+            );
+        }
+        assert_eq!(deleted.load(Ordering::Relaxed), 1);
+    }
 }
 
 #[test]

--- a/tests/python/test_stubgen_rust.py
+++ b/tests/python/test_stubgen_rust.py
@@ -1302,7 +1302,6 @@ fn native_null_storage_is_safe_to_drop() {
         f'[dependencies]\ntvm-ffi = {{ path = "{crate.as_posix()}" }}\n',
         encoding="utf-8",
     )
-    shutil.copyfile(crate.parent / "Cargo.lock", tmp_path / "Cargo.lock")
     env = os.environ.copy()
     # Do not inherit a workspace target directory: parallel test runs are independent.
     env["CARGO_TARGET_DIR"] = str(tmp_path / "target")

--- a/tests/python/test_stubgen_rust.py
+++ b/tests/python/test_stubgen_rust.py
@@ -18,7 +18,11 @@
 
 from __future__ import annotations
 
+import os
 import re
+import shutil
+import subprocess
+import sys
 from collections.abc import Container, Iterator
 from pathlib import Path
 
@@ -26,6 +30,7 @@ import pytest
 import tvm_ffi.stub.cli as stub_cli
 import tvm_ffi.testing  # noqa: F401  (loads the `testing.*` fixture types)
 from tvm_ffi.core import TypeSchema
+from tvm_ffi.libinfo import find_libtvm_ffi
 from tvm_ffi.stub import consts as C
 from tvm_ffi.stub.cli import _stage_1, _stage_3
 from tvm_ffi.stub.file_utils import CodeBlock, FileInfo
@@ -241,6 +246,8 @@ def test_directives_parse() -> None:
     directives.add("upcast", "tirx.Add -> PrimExpr", 6)
     directives.add("upcast", "tirx.Add -> crate::typed::TypedExpr", 7)
     directives.add("custom-new", " tirx.Add ", 8)
+    directives.add("no-alloc", " ir.SourceName ", 9)
+    directives.add("nullable-storage", " tirx.PrimFunc.body ", 10)
     assert directives.field_types == {"tirx.Add.a": "PrimExpr"}
     assert directives.nullable == {"ir.Expr.span"}
     assert directives.enums == {
@@ -250,6 +257,8 @@ def test_directives_parse() -> None:
     assert directives.opaque == {"ir.SourceName"}
     assert directives.upcasts == {"tirx.Add": ["PrimExpr", "crate::typed::TypedExpr"]}
     assert directives.custom_new == {"tirx.Add"}
+    assert directives.no_alloc == {"ir.SourceName"}
+    assert directives.nullable_storage == {"tirx.PrimFunc.body"}
 
 
 @pytest.mark.parametrize(
@@ -284,6 +293,8 @@ def test_generator_declares_its_directives_and_records_imports() -> None:
         "opaque",
         "upcast",
         "custom-new",
+        "no-alloc",
+        "nullable-storage",
     }
     imports = RUST.new_imports()
     RUST.add_directive(imports, "import-object", "tvm_ffi.libinfo.Foo;False;_Foo", 1)
@@ -921,6 +932,75 @@ def test_custom_new_renames_the_wrapper_allocator() -> None:
     assert "    pub fn new(" not in text
 
 
+def test_object_policies_preserve_fields_and_apply_to_descendants() -> None:
+    base = _info("demo.Base", (_field("value", "Object", 24, 8),), total_size=32)
+    child = _info("demo.Child", parent="demo.Base", total_size=32)
+    _register(base)
+    imports = RustImports()
+    for name in ("no-alloc", "custom-new"):
+        RUST.add_directive(imports, name, "demo.Base", 1)
+    for info in (base, child):
+        text, _ = _render(info, imports)
+        assert "/// Complete:" in text
+        assert "fn new(" not in text
+        assert "from_complete_fields" not in text
+    text, _ = _render(base, imports)
+    assert "pub value: ObjectRef," in text
+
+
+def test_nullable_storage_keeps_constructor_required_and_accessor_borrowed() -> None:
+    base = _info("demo.Base", (_field("body", "Object", 24, 8),), total_size=32)
+    child = _info("demo.Child", parent="demo.Base", total_size=32)
+    _register(base)
+    imports = RustImports()
+    RUST.add_directive(imports, "nullable-storage", "demo.Base.body", 1)
+    text, _ = _render(base, imports)
+    assert "    body: Option<ObjectRef>," in text
+    assert "pub body:" not in text
+    assert "pub fn body(&self) -> &ObjectRef" in text
+    assert 'self.body.as_ref().expect("Base.body has been moved out")' in text
+    assert "pub fn new(body: ObjectRef) -> Self" in text
+    assert "Self { base, body: Some(body) }" in text
+    assert "assert!(::core::mem::size_of::<Option<ObjectRef>>() == 8);" in text
+    assert "assert!(::core::mem::offset_of!(BaseObj, body) == 24);" in text
+    text, _ = _render(child, imports)
+    assert "pub fn new(body: ObjectRef) -> Self" in text
+    assert "BaseObj::new(body)" in text  # not Some(body); the base owns that conversion
+
+
+@pytest.mark.parametrize(
+    ("schema", "size", "extra", "message"),
+    [
+        ("int", 8, None, "requires a pointer-sized object-reference field"),
+        ("str", 16, None, "requires a pointer-sized object-reference field"),
+        ("Object", 16, None, "requires a pointer-sized object-reference field"),
+        (TypeSchema("Optional", (TypeSchema("Object"),)), 8, None, "requires a non-optional field"),
+        ("Object", 8, ("nullable", "demo.Node.body"), "requires a non-optional field"),
+        ("Object", 8, ("field", "demo.Node.body -> i64"), "object-reference field"),
+        ("Object", 8, ("enum", "demo.Node.body -> Kind(i64)"), "cannot be combined with `enum`"),
+    ],
+)
+def test_nullable_storage_rejects_incompatible_fields(
+    schema: str | TypeSchema, size: int, extra: tuple[str, str] | None, message: str
+) -> None:
+    info = _info("demo.Node", (_field("body", schema, 24, size),), total_size=24 + size)
+    imports = RustImports()
+    RUST.add_directive(imports, "nullable-storage", "demo.Node.body", 1)
+    if extra is not None:
+        RUST.add_directive(imports, *extra, 2)
+    with pytest.raises(ValueError, match=re.escape(message)):
+        _render(info, imports)
+
+
+def test_nullable_storage_rejects_unknown_fields_and_opaque_layouts() -> None:
+    imports = RustImports()
+    RUST.add_directive(imports, "nullable-storage", "demo.Node.body", 1)
+    with pytest.raises(ValueError, match="unknown own field"):
+        _render(_info("demo.Node", total_size=24), imports)
+    with pytest.raises(ValueError, match="requires a complete layout"):
+        _render(_info("demo.Node", (_field("body", "Object", 24, 8),)), imports)
+
+
 def test_upcast_directive_adds_typed_views() -> None:
     """`upcast` targets follow the ancestor chain; a `::` path is imported. Opaque: no allocator."""
     info = _info("demo.Leaf", parent="demo.Base")
@@ -1119,6 +1199,132 @@ def test_stage_3_applies_directives_to_a_registered_type(tmp_path: Path) -> None
     assert "pub struct Kind(i32);" in text
     assert "    pub v_i32: Kind,\n" in text
     assert "use tvm_ffi::Error;" in text
+
+
+def test_cli_shares_object_policies_across_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The child lives in a separate file; it must not bypass the base's allocation policy.
+    for filename, key, directives in (
+        ("base.rs", "testing.TestCxxClassBase", ["no-alloc"]),
+        ("child.rs", "testing.TestCxxClassDerived", []),
+    ):
+        (tmp_path / filename).write_text(
+            "\n".join(
+                [f"{C.RUST_SYNTAX.directive(name)} {key}" for name in directives]
+                + [f"{C.RUST_SYNTAX.begin} object/{key}", C.RUST_SYNTAX.end, ""]
+            ),
+            encoding="utf-8",
+        )
+    monkeypatch.setattr("sys.argv", ["tvm-ffi-stubgen", "--target", "rust", str(tmp_path)])
+    assert stub_cli.__main__() == 0
+    for filename in ("base.rs", "child.rs"):
+        text = (tmp_path / filename).read_text(encoding="utf-8")
+        assert "/// Complete:" in text
+        assert "fn new(" not in text
+    assert stub_cli.__main__() == 0
+
+
+@pytest.mark.skipif(shutil.which("cargo") is None, reason="Rust toolchain not installed")
+def test_generated_object_contracts_compile_and_drop(tmp_path: Path) -> None:
+    """Compile the generated code, including negative API checks, against the real crate."""
+    imports = RustImports()
+    RUST.add_directive(imports, "no-alloc", "testing.TestCxxClassBase", 1)
+    RUST.add_directive(imports, "nullable-storage", "testing.TestDeepCopyEdges.v_obj", 2)
+    keys = ["TestCxxClassBase", "TestCxxClassHiddenField", "TestObjectBase", "TestDeepCopyEdges"]
+    bodies = [_render(object_info_from_type_key(f"testing.{key}"), imports)[0] for key in keys]
+    docs = "\n".join(
+        f"//! ```compile_fail\n//! {snippet}\n//! ```"
+        for snippet in (
+            "use generated_contracts::TestCxxClassBase; let _ = TestCxxClassBase::new(1, 2);",
+            "fn send<T: Send>() {} send::<generated_contracts::TestCxxClassHiddenField>();",
+            "fn sync<T: Sync>() {} sync::<generated_contracts::TestCxxClassHiddenField>();",
+            "fn send<T: Send>() {} send::<generated_contracts::TestObjectBase>();",
+            "use generated_contracts::TestDeepCopyEdges; let _ = TestDeepCopyEdges::new(1.into(), None);",
+        )
+    )
+    source = docs + "\n" + "\n".join(item.as_use_line() for item in imports.items)
+    source += "\n" + "\n".join(bodies)
+    source += r"""
+#[test]
+fn native_null_storage_is_safe_to_drop() {
+    use tvm_ffi::object::ObjectRefCore;
+    use tvm_ffi::tvm_ffi_sys::{TVMFFIAny, TVMFFIGetTypeInfo, TVMFFIFieldSetter, TVMFFITestingDummyTarget};
+    use tvm_ffi::tvm_ffi_sys::TVMFFIFieldFlagBitMask::kTVMFFIFieldFlagBitSetterIsFunctionObj;
+    assert_eq!(unsafe { TVMFFITestingDummyTarget() }, 0);
+    let child = TestObjectBase::new(1, 2.0, "child".into());
+    let object = tvm_ffi::object::ObjectRef::try_from(tvm_ffi::Any::from(child.clone())).unwrap();
+    let holder = TestDeepCopyEdges::new(7i64.into(), object);
+    assert!(holder.v_obj().same_as(&child));
+    let native_child = FieldGetter::new(TestDeepCopyEdgesObj::type_index(), "v_obj")
+        .unwrap().get_any(&*holder).unwrap();
+    assert!(tvm_ffi::object::ObjectRef::try_from(native_child).unwrap().same_as(&child));
+    // Clear the field using the existing C++ reflection setter, leaving the same
+    // null storage as a native move-out. No borrowed field reference is live here.
+    unsafe {
+        let info = &*TVMFFIGetTypeInfo(TestDeepCopyEdgesObj::type_index());
+        let field = (0..info.num_fields as usize).map(|i| &*info.fields.add(i))
+            .find(|f| f.name.as_str() == "v_obj").unwrap();
+        assert!(!field.setter.is_null());
+        assert_eq!(field.flags & (kTVMFFIFieldFlagBitSetterIsFunctionObj as i64), 0);
+        let setter: TVMFFIFieldSetter = std::mem::transmute(field.setter);
+        let ptr = ObjectArc::as_raw(TestDeepCopyEdges::data(&holder));
+        assert_eq!(setter(ptr.cast_mut().cast::<u8>().offset(field.offset as isize).cast(),
+                         &TVMFFIAny::new()), 0);
+    }
+    drop(holder);
+    assert_eq!(ObjectArc::strong_count(TestObjectBase::data(&child)), 1);
+}
+"""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src/lib.rs").write_text(source, encoding="utf-8")
+    crate = Path(__file__).resolve().parents[2] / "rust/tvm-ffi"
+    (tmp_path / "Cargo.toml").write_text(
+        '[package]\nname = "generated_contracts"\nversion = "0.0.0"\nedition = "2021"\n'
+        f'[dependencies]\ntvm-ffi = {{ path = "{crate.as_posix()}" }}\n',
+        encoding="utf-8",
+    )
+    shutil.copyfile(crate.parent / "Cargo.lock", tmp_path / "Cargo.lock")
+    env = os.environ.copy()
+    # Do not inherit a workspace target directory: parallel test runs are independent.
+    env["CARGO_TARGET_DIR"] = str(tmp_path / "target")
+    loader = (
+        "PATH"
+        if sys.platform == "win32"
+        else ("DYLD_LIBRARY_PATH" if sys.platform == "darwin" else "LD_LIBRARY_PATH")
+    )
+    env[loader] = str(Path(find_libtvm_ffi()).parent) + os.pathsep + env.get(loader, "")
+    result = subprocess.run(
+        ["cargo", "test", "--quiet"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=180,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize(
+    ("name", "target"),
+    [
+        ("no-alloc", "testing.MissingObjectContract"),
+        ("nullable-storage", "testing.TestCxxClassBase.missing"),
+    ],
+)
+def test_cli_rejects_invalid_object_policies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, name: str, target: str
+) -> None:
+    src = tmp_path / "mod.rs"
+    original = (
+        f"{C.RUST_SYNTAX.directive(name)} {target}\n"
+        f"{C.RUST_SYNTAX.begin} object/testing.TestCxxClassBase\n{C.RUST_SYNTAX.end}\n"
+    )
+    src.write_text(original, encoding="utf-8")
+    monkeypatch.setattr("sys.argv", ["tvm-ffi-stubgen", "--target", "rust", str(tmp_path)])
+    assert stub_cli.__main__() == 2
+    assert src.read_text(encoding="utf-8") == original
 
 
 def test_cli_init_generates_a_module_tree(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/python/test_stubgen_rust.py
+++ b/tests/python/test_stubgen_rust.py
@@ -247,7 +247,6 @@ def test_directives_parse() -> None:
     directives.add("upcast", "tirx.Add -> crate::typed::TypedExpr", 7)
     directives.add("custom-new", " tirx.Add ", 8)
     directives.add("no-alloc", " ir.SourceName ", 9)
-    directives.add("nullable-storage", " tirx.PrimFunc.body ", 10)
     assert directives.field_types == {"tirx.Add.a": "PrimExpr"}
     assert directives.nullable == {"ir.Expr.span"}
     assert directives.enums == {
@@ -258,7 +257,6 @@ def test_directives_parse() -> None:
     assert directives.upcasts == {"tirx.Add": ["PrimExpr", "crate::typed::TypedExpr"]}
     assert directives.custom_new == {"tirx.Add"}
     assert directives.no_alloc == {"ir.SourceName"}
-    assert directives.nullable_storage == {"tirx.PrimFunc.body"}
 
 
 @pytest.mark.parametrize(
@@ -294,7 +292,6 @@ def test_generator_declares_its_directives_and_records_imports() -> None:
         "upcast",
         "custom-new",
         "no-alloc",
-        "nullable-storage",
     }
     imports = RUST.new_imports()
     RUST.add_directive(imports, "import-object", "tvm_ffi.libinfo.Foo;False;_Foo", 1)
@@ -932,13 +929,13 @@ def test_custom_new_renames_the_wrapper_allocator() -> None:
     assert "    pub fn new(" not in text
 
 
-def test_object_policies_preserve_fields_and_apply_to_descendants() -> None:
+def test_no_alloc_preserves_fields_and_applies_to_descendants() -> None:
     base = _info("demo.Base", (_field("value", "Object", 24, 8),), total_size=32)
     child = _info("demo.Child", parent="demo.Base", total_size=32)
     _register(base)
     imports = RustImports()
     for name in ("no-alloc", "custom-new"):
-        RUST.add_directive(imports, name, "demo.Base", 1)
+        imports.directives.add(name, "demo.Base", 1)
     for info in (base, child):
         text, _ = _render(info, imports)
         assert "/// Complete:" in text
@@ -946,59 +943,6 @@ def test_object_policies_preserve_fields_and_apply_to_descendants() -> None:
         assert "from_complete_fields" not in text
     text, _ = _render(base, imports)
     assert "pub value: ObjectRef," in text
-
-
-def test_nullable_storage_keeps_constructor_required_and_accessor_borrowed() -> None:
-    base = _info("demo.Base", (_field("body", "Object", 24, 8),), total_size=32)
-    child = _info("demo.Child", parent="demo.Base", total_size=32)
-    _register(base)
-    imports = RustImports()
-    RUST.add_directive(imports, "nullable-storage", "demo.Base.body", 1)
-    text, _ = _render(base, imports)
-    assert "    body: Option<ObjectRef>," in text
-    assert "pub body:" not in text
-    assert "pub fn body(&self) -> &ObjectRef" in text
-    assert 'self.body.as_ref().expect("Base.body has been moved out")' in text
-    assert "pub fn new(body: ObjectRef) -> Self" in text
-    assert "Self { base, body: Some(body) }" in text
-    assert "assert!(::core::mem::size_of::<Option<ObjectRef>>() == 8);" in text
-    assert "assert!(::core::mem::offset_of!(BaseObj, body) == 24);" in text
-    text, _ = _render(child, imports)
-    assert "pub fn new(body: ObjectRef) -> Self" in text
-    assert "BaseObj::new(body)" in text  # not Some(body); the base owns that conversion
-
-
-@pytest.mark.parametrize(
-    ("schema", "size", "extra", "message"),
-    [
-        ("int", 8, None, "requires a pointer-sized object-reference field"),
-        ("str", 16, None, "requires a pointer-sized object-reference field"),
-        ("Object", 16, None, "requires a pointer-sized object-reference field"),
-        (TypeSchema("Optional", (TypeSchema("Object"),)), 8, None, "requires a non-optional field"),
-        ("Object", 8, ("nullable", "demo.Node.body"), "requires a non-optional field"),
-        ("Object", 8, ("field", "demo.Node.body -> i64"), "object-reference field"),
-        ("Object", 8, ("enum", "demo.Node.body -> Kind(i64)"), "cannot be combined with `enum`"),
-    ],
-)
-def test_nullable_storage_rejects_incompatible_fields(
-    schema: str | TypeSchema, size: int, extra: tuple[str, str] | None, message: str
-) -> None:
-    info = _info("demo.Node", (_field("body", schema, 24, size),), total_size=24 + size)
-    imports = RustImports()
-    RUST.add_directive(imports, "nullable-storage", "demo.Node.body", 1)
-    if extra is not None:
-        RUST.add_directive(imports, *extra, 2)
-    with pytest.raises(ValueError, match=re.escape(message)):
-        _render(info, imports)
-
-
-def test_nullable_storage_rejects_unknown_fields_and_opaque_layouts() -> None:
-    imports = RustImports()
-    RUST.add_directive(imports, "nullable-storage", "demo.Node.body", 1)
-    with pytest.raises(ValueError, match="unknown own field"):
-        _render(_info("demo.Node", total_size=24), imports)
-    with pytest.raises(ValueError, match="requires a complete layout"):
-        _render(_info("demo.Node", (_field("body", "Object", 24, 8),)), imports)
 
 
 def test_upcast_directive_adds_typed_views() -> None:
@@ -1230,7 +1174,8 @@ def test_generated_object_contracts_compile_and_drop(tmp_path: Path) -> None:
     """Compile the generated code, including negative API checks, against the real crate."""
     imports = RustImports()
     RUST.add_directive(imports, "no-alloc", "testing.TestCxxClassBase", 1)
-    RUST.add_directive(imports, "nullable-storage", "testing.TestDeepCopyEdges.v_obj", 2)
+    RUST.add_directive(imports, "nullable", "testing.TestDeepCopyEdges.v_obj", 2)
+    RUST.add_directive(imports, "custom-new", "testing.TestDeepCopyEdges", 3)
     keys = ["TestCxxClassBase", "TestCxxClassHiddenField", "TestObjectBase", "TestDeepCopyEdges"]
     bodies = [_render(object_info_from_type_key(f"testing.{key}"), imports)[0] for key in keys]
     docs = "\n".join(
@@ -1246,6 +1191,13 @@ def test_generated_object_contracts_compile_and_drop(tmp_path: Path) -> None:
     source = docs + "\n" + "\n".join(item.as_use_line() for item in imports.items)
     source += "\n" + "\n".join(bodies)
     source += r"""
+// Keep semantic construction in the binding, using the existing nullable allocator.
+impl TestDeepCopyEdges {
+    pub fn new(v_any: tvm_ffi::Any, v_obj: tvm_ffi::object::ObjectRef) -> Self {
+        Self::from_complete_fields(v_any, Some(v_obj))
+    }
+}
+
 #[test]
 fn native_null_storage_is_safe_to_drop() {
     use tvm_ffi::object::ObjectRefCore;
@@ -1255,7 +1207,7 @@ fn native_null_storage_is_safe_to_drop() {
     let child = TestObjectBase::new(1, 2.0, "child".into());
     let object = tvm_ffi::object::ObjectRef::try_from(tvm_ffi::Any::from(child.clone())).unwrap();
     let holder = TestDeepCopyEdges::new(7i64.into(), object);
-    assert!(holder.v_obj().same_as(&child));
+    assert!(holder.v_obj.as_ref().unwrap().same_as(&child));
     let native_child = FieldGetter::new(TestDeepCopyEdgesObj::type_index(), "v_obj")
         .unwrap().get_any(&*holder).unwrap();
     assert!(tvm_ffi::object::ObjectRef::try_from(native_child).unwrap().same_as(&child));
@@ -1272,6 +1224,7 @@ fn native_null_storage_is_safe_to_drop() {
         assert_eq!(setter(ptr.cast_mut().cast::<u8>().offset(field.offset as isize).cast(),
                          &TVMFFIAny::new()), 0);
     }
+    assert!(holder.v_obj.is_none());
     drop(holder);
     assert_eq!(ObjectArc::strong_count(TestObjectBase::data(&child)), 1);
 }
@@ -1306,19 +1259,10 @@ fn native_null_storage_is_safe_to_drop() {
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-@pytest.mark.parametrize(
-    ("name", "target"),
-    [
-        ("no-alloc", "testing.MissingObjectContract"),
-        ("nullable-storage", "testing.TestCxxClassBase.missing"),
-    ],
-)
-def test_cli_rejects_invalid_object_policies(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, name: str, target: str
-) -> None:
+def test_cli_rejects_unknown_no_alloc_type(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     src = tmp_path / "mod.rs"
     original = (
-        f"{C.RUST_SYNTAX.directive(name)} {target}\n"
+        f"{C.RUST_SYNTAX.directive('no-alloc')} testing.MissingObjectContract\n"
         f"{C.RUST_SYNTAX.begin} object/testing.TestCxxClassBase\n{C.RUST_SYNTAX.end}\n"
     )
     src.write_text(original, encoding="utf-8")

--- a/tests/python/test_stubgen_rust.py
+++ b/tests/python/test_stubgen_rust.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import ctypes
 import os
 import re
 import shutil
@@ -889,6 +890,33 @@ def test_complete_optional_field_mirrors() -> None:
     assert "tvm_ffi::Optional" in _uses(imports)
 
 
+@pytest.mark.parametrize("pointer_size", [4, 8])
+def test_object_reference_fields_use_native_pointer_size(
+    monkeypatch: pytest.MonkeyPatch, pointer_size: int
+) -> None:
+    assert RC.RUST_POINTER_SIZE == ctypes.sizeof(ctypes.c_void_p)
+    monkeypatch.setattr(RC, "RUST_POINTER_SIZE", pointer_size)
+    info = _info(
+        "demo.References",
+        (
+            _field("value", "Object", 24, pointer_size),
+            _field(
+                "optional",
+                TypeSchema("Optional", (TypeSchema("Object"),)),
+                24 + pointer_size,
+                pointer_size,
+            ),
+        ),
+        total_size=24 + 2 * pointer_size,
+    )
+    imports = RustImports()
+    RUST.add_directive(imports, "nullable", "demo.References.value", 1)
+    text, _ = _render(info, imports)
+    assert "/// Complete:" in text
+    assert "pub value: Option<ObjectRef>," in text
+    assert "pub optional: Option<ObjectRef>," in text
+
+
 @pytest.mark.parametrize(
     "field",
     [
@@ -1166,6 +1194,43 @@ def test_cli_shares_object_policies_across_files(
         text = (tmp_path / filename).read_text(encoding="utf-8")
         assert "/// Complete:" in text
         assert "fn new(" not in text
+    assert stub_cli.__main__() == 0
+
+
+@pytest.mark.parametrize("policy", ["nullable", "opaque"])
+def test_cli_preserves_parent_layout_policies_across_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, policy: str
+) -> None:
+    base = _info("demo.Base", (_field("value", "Object", 24, 8),), total_size=32)
+    child = _info("demo.Child", parent="demo.Base", total_size=32)
+    _register(base, child)
+    monkeypatch.setattr(stub_cli, "object_info_from_type_key", codegen.object_info_from_type_key)
+    target = "demo.Base.value" if policy == "nullable" else "demo.Base"
+    for filename, key in (("parent.rs", "demo.Base"), ("child.rs", "demo.Child")):
+        directive = f"{C.RUST_SYNTAX.directive(policy)} {target}\n" if key == "demo.Base" else ""
+        (tmp_path / filename).write_text(
+            f"{directive}{C.RUST_SYNTAX.begin} object/{key}\n{C.RUST_SYNTAX.end}\n",
+            encoding="utf-8",
+        )
+    # Process the child first: generation must not depend on its parent's file order.
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "tvm-ffi-stubgen",
+            "--target",
+            "rust",
+            str(tmp_path / "child.rs"),
+            str(tmp_path / "parent.rs"),
+        ],
+    )
+    assert stub_cli.__main__() == 0
+    for filename in ("parent.rs", "child.rs"):
+        text = (tmp_path / filename).read_text(encoding="utf-8")
+        if policy == "nullable":
+            assert "pub fn new(value: Option<ObjectRef>) -> Self" in text
+        else:
+            assert "/// Opaque:" in text
+            assert "fn new(" not in text
     assert stub_cli.__main__() == 0
 
 


### PR DESCRIPTION
This PR addresses object construction and lifetime issues in Rust bindings without changing the C ABI.
- Add a no-alloc stubgen directive to preserve readable fields while suppressing generated allocators for registry-owned types and their descendants.
- Reuse the existing nullable and custom-new directives for fields that native code may move out, without introducing a separate nullable-storage mechanism.
- Make objects non-Send/non-Sync by default, including erased and borrowed views. Keep Function shareable by requiring thread-safe callback captures.
- Require unique ownership for mutable ObjectArc access, align reference-count ordering with C++, and preserve allocation metadata when weak references outlive objects with trailing storage.

These changes tighten Rust source-level contracts. Downstream code relying on cross-thread object sharing or non-thread-safe callback captures may require adaptation.