### PR TITLE
[FFI][PERF] AnyUnsafe::CheckAnyViewStrict for a borrowed AnyView

### DIFF
--- a/include/tvm/ffi/any.h
+++ b/include/tvm/ffi/any.h
@@ -617,6 +617,18 @@ struct AnyUnsafe : public ObjectUnsafe {
     }
   }
 
+  // Borrowed form: a caller checking a field it does not own passes AnyView(field), which
+  // costs no refcount where CheckAnyStrict would build a temporary Any. A distinct name, so
+  // an ObjectRef argument never has two conversions to choose from.
+  template <typename T>
+  TVM_FFI_INLINE static bool CheckAnyViewStrict(const AnyView& ref) {
+    if constexpr (!std::is_same_v<T, Any>) {
+      return TypeTraits<T>::CheckAnyStrict(&(ref.data_));
+    } else {
+      return true;
+    }
+  }
+
   template <typename T>
   TVM_FFI_INLINE static T CopyFromAnyViewAfterCheck(const Any& ref) {
     if constexpr (!std::is_same_v<T, Any>) {


### PR DESCRIPTION
`AnyUnsafe::CheckAnyStrict<T>` takes only `const Any&`, so a caller checking an `ObjectRef` field it does not own (TVM's `TypedExpr` / `TypedVar` traits checking `ty`) builds a temporary owning `Any`: a refcount pair and ~40 instructions per check. Add `CheckAnyViewStrict<T>(const AnyView&)` with the same body; a distinct name rather than an overload, so an `ObjectRef` argument never has two conversions to choose from and existing callers are untouched. Callers pass `AnyView(field)`. Checking an `ObjectRef` through the view: 8 instructions, no atomics, against 50 and 3 for the owning form.