### PR TITLE
[PERF] Forward single StructuralMutate callbacks directly

### DIFF
--- a/include/tvm/ffi/extra/structural_mutate.h
+++ b/include/tvm/ffi/extra/structural_mutate.h
@@ -585,8 +585,8 @@ class StructuralMutatorObj : public Object {
   }
 
   /*! \brief Keep address-taking for error decoration off the successful raw-result path. */
-  TVM_FFI_COLD_CODE TVM_FFI_NO_INLINE static TVMFFIAny AnnotateDefaultErrorRaw(
-      TVMFFIAny result, AnyView value) noexcept {
+  TVM_FFI_COLD_CODE static TVMFFIAny AnnotateDefaultErrorRaw(TVMFFIAny result,
+                                                             AnyView value) noexcept {
     details::UpdateVisitErrorContext(result, value);
     return result;
   }
@@ -1608,8 +1608,8 @@ class StructuralMutateEngine : public Parent {
 
   /*! \brief Mutate one value, handing a matched callback ownership of descent. */
   TVMFFIAny MutateImplRaw(AnyView value) noexcept {
-    if (std::optional<Expected<Any>> matched = DispatchCallbacks(value, false)) {
-      Expected<Any> result = *std::move(matched);
+    Expected<Any> result{Any()};
+    if (DispatchCallbacks(value, false, &result)) {
       if (TVM_FFI_PREDICT_FALSE(result.is_err())) {
         // Keep callback-boundary context in addition to the default-descent
         // context: a callback may return a rebuilt value, so the two nodes can differ.
@@ -1622,8 +1622,8 @@ class StructuralMutateEngine : public Parent {
 
   /*! \brief Maybe mutate one value in place, with callback-owned descent. */
   TVMFFIAny MaybeInplaceMutateImplRaw(AnyView value) noexcept {
-    if (std::optional<Expected<Any>> matched = DispatchCallbacks(value, true)) {
-      Expected<Any> result = *std::move(matched);
+    Expected<Any> result{Any()};
+    if (DispatchCallbacks(value, true, &result)) {
       if (TVM_FFI_PREDICT_FALSE(result.is_err())) {
         // Keep callback-boundary context in addition to the default-descent
         // context: a callback may return a rebuilt value, so the two nodes can differ.
@@ -1666,8 +1666,7 @@ class StructuralMutateEngine : public Parent {
   }
 
   /*! \brief Materialize the callback result only on the cold Parent error-decoration path. */
-  TVM_FFI_COLD_CODE TVM_FFI_NO_INLINE TVMFFIAny AnnotateCallbackErrorRaw(TVMFFIAny raw,
-                                                                         AnyView value) noexcept {
+  TVM_FFI_COLD_CODE TVMFFIAny AnnotateCallbackErrorRaw(TVMFFIAny raw, AnyView value) noexcept {
     Expected<Any> result = details::ExpectedUnsafe::MoveFromTVMFFIAny<Any>(raw);
     Parent::UpdateVisitErrorContext(result, value);
     return details::ExpectedUnsafe::MoveToTVMFFIAny(std::move(result));
@@ -1706,35 +1705,37 @@ class StructuralMutateEngine : public Parent {
     return result;
   }
 
-  /*! \brief Try one typed callback and preserve Error as an expected result. */
+  /*! \brief Write a matched callback result, leaving out untouched on a type miss. */
   template <typename Callback>
-  TVM_FFI_INLINE std::optional<Expected<Any>> TryLink(Callback& callback, AnyView value,
-                                                      bool allow_inplace) noexcept {
+  TVM_FFI_INLINE bool TryLink(Callback& callback, AnyView value, bool allow_inplace,
+                              Expected<Any>* out) noexcept {
     using FuncInfo = details::FunctionInfo<std::decay_t<Callback>>;
     using FirstArg = std::tuple_element_t<0, typename FuncInfo::ArgType>;
     using TSub = std::remove_cv_t<std::remove_reference_t<FirstArg>>;
     if constexpr (std::is_same_v<TSub, AnyView>) {
-      return InvokeCallback(callback, value, allow_inplace);
+      *out = InvokeCallback(callback, value, allow_inplace);
+      return true;
     } else if constexpr (std::is_same_v<TSub, Any>) {
-      return InvokeCallback(callback, Any(value), allow_inplace);
+      *out = InvokeCallback(callback, Any(value), allow_inplace);
+      return true;
     } else if (auto matched = value.template as<TSub>()) {
-      return InvokeCallback(callback, *std::move(matched), allow_inplace);
+      *out = InvokeCallback(callback, *std::move(matched), allow_inplace);
+      return true;
     }
-    return std::nullopt;
+    return false;
   }
 
   /*! \brief Fold callbacks in declaration order, stopping at the first match. */
   template <size_t... Is>
-  TVM_FFI_INLINE std::optional<Expected<Any>> TryLinks(AnyView value, bool allow_inplace,
-                                                       std::index_sequence<Is...>) noexcept {
-    std::optional<Expected<Any>> result;
-    (... || (result = TryLink(std::get<Is>(callbacks_), value, allow_inplace)).has_value());
-    return result;
+  TVM_FFI_INLINE bool TryLinks(AnyView value, bool allow_inplace, Expected<Any>* out,
+                               std::index_sequence<Is...>) noexcept {
+    return (TryLink(std::get<Is>(callbacks_), value, allow_inplace, out) || ...);
   }
 
-  /*! \brief Run the callback chain, or return empty when no callback matched. */
-  std::optional<Expected<Any>> DispatchCallbacks(AnyView value, bool allow_inplace) noexcept {
-    return TryLinks(value, allow_inplace, std::index_sequence_for<Callbacks...>{});
+  /*! \brief Run the callback chain, returning whether a callback matched. */
+  TVM_FFI_INLINE bool DispatchCallbacks(AnyView value, bool allow_inplace,
+                                        Expected<Any>* out) noexcept {
+    return TryLinks(value, allow_inplace, out, std::index_sequence_for<Callbacks...>{});
   }
 
   /*! \brief Typed callbacks tested in declaration order, first match wins. */

--- a/include/tvm/ffi/extra/structural_mutate.h
+++ b/include/tvm/ffi/extra/structural_mutate.h
@@ -579,14 +579,14 @@ class StructuralMutatorObj : public Object {
       result = DefaultMutateRawTail(value, attr);
     }
     if (TVM_FFI_PREDICT_FALSE(result.type_index == TypeIndex::kTVMFFIError)) {
-      return AnnotateDefaultErrorRaw(result, value);
+      return AttachVisitErrorContextRaw(result, value);
     }
     return result;
   }
 
   /*! \brief Keep address-taking for error decoration off the successful raw-result path. */
-  TVM_FFI_COLD_CODE static TVMFFIAny AnnotateDefaultErrorRaw(TVMFFIAny result,
-                                                             AnyView value) noexcept {
+  TVM_FFI_COLD_CODE static TVMFFIAny AttachVisitErrorContextRaw(TVMFFIAny result,
+                                                                AnyView value) noexcept {
     details::UpdateVisitErrorContext(result, value);
     return result;
   }
@@ -661,7 +661,7 @@ class StructuralMutatorObj : public Object {
       // DefaultMutateRaw, which names it there instead -- exactly one frame either way.
       TVMFFIAny result = (*reinterpret_cast<FStructuralMutate>(attr.cast<void*>()))(this, value);
       if (TVM_FFI_PREDICT_FALSE(result.type_index == TypeIndex::kTVMFFIError)) {
-        return AnnotateDefaultErrorRaw(result, value);
+        return AttachVisitErrorContextRaw(result, value);
       }
       return result;
     }
@@ -677,7 +677,7 @@ class StructuralMutatorObj : public Object {
       TVMFFIAny result = details::ExpectedUnsafe::MoveToTVMFFIAny(
           attr.cast<Function>().CallExpected<Any>(this, value));
       if (TVM_FFI_PREDICT_FALSE(result.type_index == TypeIndex::kTVMFFIError)) {
-        return AnnotateDefaultErrorRaw(result, value);
+        return AttachVisitErrorContextRaw(result, value);
       }
       return result;
     }

--- a/include/tvm/ffi/extra/structural_mutate.h
+++ b/include/tvm/ffi/extra/structural_mutate.h
@@ -579,8 +579,15 @@ class StructuralMutatorObj : public Object {
       result = DefaultMutateRawTail(value, attr);
     }
     if (TVM_FFI_PREDICT_FALSE(result.type_index == TypeIndex::kTVMFFIError)) {
-      details::UpdateVisitErrorContext(result, value);
+      return AnnotateDefaultErrorRaw(result, value);
     }
+    return result;
+  }
+
+  /*! \brief Keep address-taking for error decoration off the successful raw-result path. */
+  TVM_FFI_COLD_CODE TVM_FFI_NO_INLINE static TVMFFIAny AnnotateDefaultErrorRaw(
+      TVMFFIAny result, AnyView value) noexcept {
+    details::UpdateVisitErrorContext(result, value);
     return result;
   }
 
@@ -654,7 +661,7 @@ class StructuralMutatorObj : public Object {
       // DefaultMutateRaw, which names it there instead -- exactly one frame either way.
       TVMFFIAny result = (*reinterpret_cast<FStructuralMutate>(attr.cast<void*>()))(this, value);
       if (TVM_FFI_PREDICT_FALSE(result.type_index == TypeIndex::kTVMFFIError)) {
-        details::UpdateVisitErrorContext(result, value);
+        return AnnotateDefaultErrorRaw(result, value);
       }
       return result;
     }
@@ -670,7 +677,7 @@ class StructuralMutatorObj : public Object {
       TVMFFIAny result = details::ExpectedUnsafe::MoveToTVMFFIAny(
           attr.cast<Function>().CallExpected<Any>(this, value));
       if (TVM_FFI_PREDICT_FALSE(result.type_index == TypeIndex::kTVMFFIError)) {
-        details::UpdateVisitErrorContext(result, value);
+        return AnnotateDefaultErrorRaw(result, value);
       }
       return result;
     }
@@ -1580,13 +1587,23 @@ class StructuralMutateEngine : public Parent {
 
   /*! \brief Dispatch ordinary mutation from the erased mutator pointer. */
   static TVMFFIAny DispatchMutate(StructuralMutatorObj* mutator, AnyView value) noexcept {
-    return static_cast<StructuralMutateEngine*>(mutator)->MutateImplRaw(value);
+    auto* self = static_cast<StructuralMutateEngine*>(mutator);
+    if constexpr (sizeof...(Callbacks) == 1) {
+      return self->template MutateSingleCallbackRaw<false>(value);
+    } else {
+      return self->MutateImplRaw(value);
+    }
   }
 
   /*! \brief Dispatch maybe-in-place mutation from the erased mutator pointer. */
   static TVMFFIAny DispatchMaybeInplaceMutate(StructuralMutatorObj* mutator,
                                               AnyView value) noexcept {
-    return static_cast<StructuralMutateEngine*>(mutator)->MaybeInplaceMutateImplRaw(value);
+    auto* self = static_cast<StructuralMutateEngine*>(mutator);
+    if constexpr (sizeof...(Callbacks) == 1) {
+      return self->template MutateSingleCallbackRaw<true>(value);
+    } else {
+      return self->MaybeInplaceMutateImplRaw(value);
+    }
   }
 
   /*! \brief Mutate one value, handing a matched callback ownership of descent. */
@@ -1618,16 +1635,14 @@ class StructuralMutateEngine : public Parent {
         Parent::DefaultMaybeInplaceMutateExpected(value));
   }
 
-  /*! \brief Try one typed callback and preserve Error as an expected result. */
-  template <typename Callback>
-  TVM_FFI_INLINE std::optional<Expected<Any>> TryLink(Callback& callback, AnyView value,
-                                                      bool allow_inplace) noexcept {
+  /*! \brief Invoke a matched callback with the Parent view and preserve returned/thrown Error. */
+  template <typename Callback, typename Matched>
+  TVM_FFI_INLINE Expected<Any> InvokeCallback(Callback& callback, Matched&& matched,
+                                              bool allow_inplace) noexcept {
     using FuncInfo = details::FunctionInfo<std::decay_t<Callback>>;
     static_assert(FuncInfo::num_args == 2 || FuncInfo::num_args == 3,
                   "StructuralMutate callback must take (value, mutator) or "
                   "(value, mutator, allow_inplace)");
-    using FirstArg = std::tuple_element_t<0, typename FuncInfo::ArgType>;
-    using TSub = std::remove_cv_t<std::remove_reference_t<FirstArg>>;
     using SecondArg = std::decay_t<std::tuple_element_t<1, typename FuncInfo::ArgType>>;
     using Second = std::remove_pointer_t<SecondArg>;
     static_assert(std::is_same_v<Second, typename Parent::MutatorObjType>,
@@ -1639,23 +1654,71 @@ class StructuralMutateEngine : public Parent {
                     "third StructuralMutate callback argument must be bool");
     }
     auto* mutator = static_cast<typename Parent::MutatorObjType*>(this);
-    auto invoke = [&](auto&& matched) -> Expected<Any> {
-      try {
-        if constexpr (FuncInfo::num_args == 3) {
-          return callback(std::forward<decltype(matched)>(matched), mutator, allow_inplace);
-        } else {
-          return callback(std::forward<decltype(matched)>(matched), mutator);
-        }
-      } catch (Error& err) {
-        return Unexpected(std::move(err));
+    try {
+      if constexpr (FuncInfo::num_args == 3) {
+        return callback(std::forward<Matched>(matched), mutator, allow_inplace);
+      } else {
+        return callback(std::forward<Matched>(matched), mutator);
       }
-    };
+    } catch (Error& err) {
+      return Unexpected(std::move(err));
+    }
+  }
+
+  /*! \brief Materialize the callback result only on the cold Parent error-decoration path. */
+  TVM_FFI_COLD_CODE TVM_FFI_NO_INLINE TVMFFIAny AnnotateCallbackErrorRaw(TVMFFIAny raw,
+                                                                         AnyView value) noexcept {
+    Expected<Any> result = details::ExpectedUnsafe::MoveFromTVMFFIAny<Any>(raw);
+    Parent::UpdateVisitErrorContext(result, value);
+    return details::ExpectedUnsafe::MoveToTVMFFIAny(std::move(result));
+  }
+
+  // One callback forwards its result directly, without a callback-chain envelope.
+  // AnyView/Any always match; only a typed miss needs the Parent's default descent.
+  template <bool kMaybeInplace>
+  TVM_FFI_INLINE TVMFFIAny MutateSingleCallbackRaw(AnyView value) noexcept {
+    auto& callback = std::get<0>(callbacks_);
+    using FuncInfo = details::FunctionInfo<std::decay_t<decltype(callback)>>;
+    using FirstArg = std::tuple_element_t<0, typename FuncInfo::ArgType>;
+    using TSub = std::remove_cv_t<std::remove_reference_t<FirstArg>>;
+    TVMFFIAny result;
     if constexpr (std::is_same_v<TSub, AnyView>) {
-      return invoke(value);
+      result =
+          details::ExpectedUnsafe::MoveToTVMFFIAny(InvokeCallback(callback, value, kMaybeInplace));
     } else if constexpr (std::is_same_v<TSub, Any>) {
-      return invoke(Any(value));
+      result = details::ExpectedUnsafe::MoveToTVMFFIAny(
+          InvokeCallback(callback, Any(value), kMaybeInplace));
     } else if (auto matched = value.template as<TSub>()) {
-      return invoke(*std::move(matched));
+      result = details::ExpectedUnsafe::MoveToTVMFFIAny(
+          InvokeCallback(callback, *std::move(matched), kMaybeInplace));
+    } else {
+      if constexpr (kMaybeInplace) {
+        return details::ExpectedUnsafe::MoveToTVMFFIAny(
+            Parent::DefaultMaybeInplaceMutateExpected(value));
+      } else {
+        return details::ExpectedUnsafe::MoveToTVMFFIAny(Parent::DefaultMutateExpected(value));
+      }
+    }
+    // Release any owning match before naming the callback boundary, as in the general path.
+    if (TVM_FFI_PREDICT_FALSE(result.type_index == TypeIndex::kTVMFFIError)) {
+      return AnnotateCallbackErrorRaw(result, value);
+    }
+    return result;
+  }
+
+  /*! \brief Try one typed callback and preserve Error as an expected result. */
+  template <typename Callback>
+  TVM_FFI_INLINE std::optional<Expected<Any>> TryLink(Callback& callback, AnyView value,
+                                                      bool allow_inplace) noexcept {
+    using FuncInfo = details::FunctionInfo<std::decay_t<Callback>>;
+    using FirstArg = std::tuple_element_t<0, typename FuncInfo::ArgType>;
+    using TSub = std::remove_cv_t<std::remove_reference_t<FirstArg>>;
+    if constexpr (std::is_same_v<TSub, AnyView>) {
+      return InvokeCallback(callback, value, allow_inplace);
+    } else if constexpr (std::is_same_v<TSub, Any>) {
+      return InvokeCallback(callback, Any(value), allow_inplace);
+    } else if (auto matched = value.template as<TSub>()) {
+      return InvokeCallback(callback, *std::move(matched), allow_inplace);
     }
     return std::nullopt;
   }

--- a/tests/cpp/extra/test_structural_mutate.cc
+++ b/tests/cpp/extra/test_structural_mutate.cc
@@ -432,6 +432,173 @@ TEST(StructuralMutate, CallbackControlsRecursion) {
   EXPECT_TRUE(mapped->rhs.same_as(original_rhs));
 }
 
+// Exercise the single-callback path and the equivalent general callback chain.
+template <typename Parent = StructuralMapEngineBase, typename Callback, typename Check>
+void CheckSingleAndMultiCallback(Callback callback, Check check) {
+  auto never_matches = [](double, typename Parent::MutatorObjType*) -> Expected<Any> {
+    ADD_FAILURE() << "Unexpected callback match";
+    return Unchanged();
+  };
+  using Single = StructuralMutateEngine<Parent, Callback>;
+  using Multi = StructuralMutateEngine<Parent, Callback, decltype(never_matches)>;
+  check(make_object<Single>(callback));
+  check(make_object<Multi>(callback, never_matches));
+}
+
+class SingleCallbackParent : public StructuralMapEngineBase {
+ public:
+  using MutatorObjType = SingleCallbackParent;
+  explicit SingleCallbackParent(const StructuralMutatorVTable* vtable)
+      : StructuralMapEngineBase(vtable) {}
+
+  int error_count = 0;
+  int boundary_use_count = 0;
+
+  void UpdateVisitErrorContext(const Expected<Any>& result, AnyView value) noexcept {
+    ++error_count;
+    boundary_use_count = value.cast<const Object*>()->use_count();
+    StructuralMapEngineBase::UpdateVisitErrorContext(result, value);
+  }
+};
+
+TEST(StructuralMutate, SingleCallbackOwnershipAndParentContext) {
+  TVar root("root");
+  auto check = [&](auto callback) {
+    CheckSingleAndMultiCallback<SingleCallbackParent>(callback, [&](auto engine) {
+      EXPECT_EQ(root.use_count(), 1);
+      auto result = engine->MutateExpected(AnyView(root));
+      ASSERT_TRUE(result.is_err());
+      EXPECT_EQ(result.error().message(), "callback error");
+      EXPECT_EQ(engine->error_count, 1);
+      // An owning match is released before the Parent sees the callback boundary.
+      EXPECT_EQ(engine->boundary_use_count, 1);
+      auto context = VisitErrorContext::TryGetFromError(result.error());
+      ASSERT_TRUE(context.has_value());
+      ASSERT_EQ(context.value()->reverse_visit_pattern.size(), 1U);
+      EXPECT_TRUE(context.value()->reverse_visit_pattern[0].same_as(root));
+    });
+    EXPECT_EQ(root.use_count(), 1);
+  };
+  check([&](AnyView, SingleCallbackParent*) -> Error {
+    EXPECT_EQ(root.use_count(), 1);
+    return Error("ValueError", "callback error", "");
+  });
+  check([&](const Any&, SingleCallbackParent*) -> Error {
+    EXPECT_EQ(root.use_count(), 2);
+    return Error("ValueError", "callback error", "");
+  });
+  check([&](const TVar&, SingleCallbackParent*) -> Expected<TVar> {
+    EXPECT_EQ(root.use_count(), 2);
+    throw Error("ValueError", "callback error", "");
+  });
+  check([&](const TVarObj*, SingleCallbackParent*) -> Expected<Any> {
+    EXPECT_EQ(root.use_count(), 1);
+    return Unexpected(Error("ValueError", "callback error", ""));
+  });
+}
+
+TEST(StructuralMutate, SingleCallbackReturnCarriersAndShortCircuit) {
+  TVar root("root");
+  TVar replacement("replacement");
+  auto check = [&](auto callback, bool unchanged) {
+    // A later matching callback must not run, even for Unchanged or Error.
+    auto later = [](AnyView, StructuralMutatorObj*) -> Any {
+      ADD_FAILURE() << "The first matching callback must own the result";
+      return Any();
+    };
+    auto inspect = [&](auto result) {
+      ASSERT_TRUE(result.is_ok());
+      EXPECT_TRUE(result.value().same_as(unchanged ? root : replacement));
+    };
+    inspect(StructuralMutateExpected(root, callback));
+    inspect(StructuralMutateExpected(root, callback, later));
+  };
+  check([&](AnyView, StructuralMutatorObj*) -> TVar { return replacement; }, false);
+  check([&](const Any&, StructuralMutatorObj*) -> Any { return Any(replacement); }, false);
+  check([&](const TVar&, StructuralMutatorObj*) -> Expected<TVar> { return replacement; }, false);
+  check([&](const TVarObj*, StructuralMutatorObj*) -> Expected<Any> { return replacement; }, false);
+  check([](AnyView, StructuralMutatorObj*) -> Expected<UnchangedOr<TVar>> { return Unchanged(); },
+        true);
+  check([](const Any&, StructuralMutatorObj*) -> UnchangedOr<TVar> { return Unchanged(); }, true);
+
+  auto failure = [](AnyView, StructuralMutatorObj*) -> Any {
+    return Any(Error("ValueError", "first match error", ""));
+  };
+  auto later = [](AnyView, StructuralMutatorObj*) -> Any {
+    ADD_FAILURE() << "Error is a matched result, not a callback miss";
+    return Any();
+  };
+  EXPECT_EQ(StructuralMutateExpected(root, failure).error().message(), "first match error");
+  EXPECT_EQ(StructuralMutateExpected(root, failure, later).error().message(), "first match error");
+}
+
+TEST(StructuralMutate, SingleCallbackArityAndTypedFallback) {
+  std::vector<bool> trace;
+  auto check = [&](auto callback) {
+    CheckSingleAndMultiCallback<SingleCallbackParent>(callback, [&](auto engine) {
+      trace.clear();
+      TVar root("root");
+      EXPECT_TRUE(engine->MutateExpected(AnyView(root)).value().IsUnchanged());
+      EXPECT_TRUE(engine->MaybeInplaceMutateExpected(AnyView(root)).value().IsUnchanged());
+      EXPECT_EQ(trace, (std::vector<bool>{false, true}));
+    });
+  };
+  check([&](AnyView, SingleCallbackParent*, bool allow_inplace) -> Unchanged {
+    trace.push_back(allow_inplace);
+    return Unchanged();
+  });
+  check([&](const Any&, SingleCallbackParent*, bool allow_inplace) -> Expected<Any> {
+    trace.push_back(allow_inplace);
+    return Unchanged();
+  });
+  check([&](const TVar&, SingleCallbackParent*, bool allow_inplace) -> Expected<Any> {
+    trace.push_back(allow_inplace);
+    return Unchanged();
+  });
+
+  auto typed = [](int64_t value, StructuralMutatorObj*) -> Any { return Any(value + 1); };
+  CheckSingleAndMultiCallback<StructuralMapWithMutateCount>(typed, [&](auto engine) {
+    String miss("unmatched heap string");
+    EXPECT_TRUE(engine->MutateExpected(AnyView(miss)).value().IsUnchanged());
+    EXPECT_TRUE(engine->MaybeInplaceMutateExpected(AnyView(miss)).value().IsUnchanged());
+    EXPECT_EQ(engine->count().mutate_expected, 1);
+    EXPECT_EQ(engine->count().maybe_inplace_expected, 1);
+    EXPECT_EQ(engine->MutateExpected(AnyView(int64_t{1}))
+                  .value()
+                  .ValueUnchecked()
+                  .template cast<int64_t>(),
+              2);
+    EXPECT_EQ(engine->count().value, 2);
+  });
+}
+
+TEST(StructuralMutate, SingleCallbackPassthroughKeepsBothErrorContexts) {
+  TVar lhs("lhs");
+  TMutatePair root(lhs, TVar("rhs"));
+  auto passthrough = [](AnyView value, StructuralMutatorObj* mutator,
+                        bool allow_inplace) -> Expected<Any> {
+    if (value.as<const TVarObj*>()) {
+      return Error("ValueError", "hook child error", "");
+    }
+    return allow_inplace ? mutator->DefaultMaybeInplaceMutateExpected(value)
+                         : mutator->DefaultMutateExpected(value);
+  };
+  CheckSingleAndMultiCallback(passthrough, [&](auto engine) {
+    for (bool inplace : {false, true}) {
+      auto result = inplace ? engine->MaybeInplaceMutateExpected(AnyView(root))
+                            : engine->MutateExpected(AnyView(root));
+      ASSERT_TRUE(result.is_err());
+      auto context = VisitErrorContext::TryGetFromError(result.error());
+      ASSERT_TRUE(context.has_value());
+      const auto& pattern = context.value()->reverse_visit_pattern;
+      ASSERT_EQ(pattern.size(), 3U);
+      EXPECT_TRUE(pattern[0].same_as(lhs));
+      EXPECT_TRUE(pattern[1].same_as(root));
+      EXPECT_TRUE(pattern[2].same_as(root));
+    }
+  });
+}
+
 TEST(StructuralMutate, PreservesUniqueContainerIdentity) {
   AnyArray inner{int64_t{1}};
   const Object* inner_address = inner.get();

--- a/tests/cpp/extra/test_structural_mutate.cc
+++ b/tests/cpp/extra/test_structural_mutate.cc
@@ -452,7 +452,7 @@ class SingleCallbackParent : public StructuralMapEngineBase {
       : StructuralMapEngineBase(vtable) {}
 
   int error_count = 0;
-  int boundary_use_count = 0;
+  uint64_t boundary_use_count = 0;
 
   void UpdateVisitErrorContext(const Expected<Any>& result, AnyView value) noexcept {
     ++error_count;
@@ -464,7 +464,7 @@ class SingleCallbackParent : public StructuralMapEngineBase {
 TEST(StructuralMutate, SingleCallbackOwnershipAndParentContext) {
   TVar root("root");
   auto check = [&](auto callback) {
-    CheckSingleAndMultiCallback<SingleCallbackParent>(callback, [&](auto engine) {
+    CheckSingleAndMultiCallback<SingleCallbackParent>(callback, [&](const auto& engine) {
       EXPECT_EQ(root.use_count(), 1);
       auto result = engine->MutateExpected(AnyView(root));
       ASSERT_TRUE(result.is_err());
@@ -506,7 +506,7 @@ TEST(StructuralMutate, SingleCallbackReturnCarriersAndShortCircuit) {
       ADD_FAILURE() << "The first matching callback must own the result";
       return Any();
     };
-    auto inspect = [&](auto result) {
+    auto inspect = [&](const auto& result) {
       ASSERT_TRUE(result.is_ok());
       EXPECT_TRUE(result.value().same_as(unchanged ? root : replacement));
     };
@@ -535,7 +535,7 @@ TEST(StructuralMutate, SingleCallbackReturnCarriersAndShortCircuit) {
 TEST(StructuralMutate, SingleCallbackArityAndTypedFallback) {
   std::vector<bool> trace;
   auto check = [&](auto callback) {
-    CheckSingleAndMultiCallback<SingleCallbackParent>(callback, [&](auto engine) {
+    CheckSingleAndMultiCallback<SingleCallbackParent>(callback, [&](const auto& engine) {
       trace.clear();
       TVar root("root");
       EXPECT_TRUE(engine->MutateExpected(AnyView(root)).value().IsUnchanged());
@@ -557,7 +557,7 @@ TEST(StructuralMutate, SingleCallbackArityAndTypedFallback) {
   });
 
   auto typed = [](int64_t value, StructuralMutatorObj*) -> Any { return Any(value + 1); };
-  CheckSingleAndMultiCallback<StructuralMapWithMutateCount>(typed, [&](auto engine) {
+  CheckSingleAndMultiCallback<StructuralMapWithMutateCount>(typed, [&](const auto& engine) {
     String miss("unmatched heap string");
     EXPECT_TRUE(engine->MutateExpected(AnyView(miss)).value().IsUnchanged());
     EXPECT_TRUE(engine->MaybeInplaceMutateExpected(AnyView(miss)).value().IsUnchanged());
@@ -583,7 +583,7 @@ TEST(StructuralMutate, SingleCallbackPassthroughKeepsBothErrorContexts) {
     return allow_inplace ? mutator->DefaultMaybeInplaceMutateExpected(value)
                          : mutator->DefaultMutateExpected(value);
   };
-  CheckSingleAndMultiCallback(passthrough, [&](auto engine) {
+  CheckSingleAndMultiCallback(passthrough, [&](const auto& engine) {
     for (bool inplace : {false, true}) {
       auto result = inplace ? engine->MaybeInplaceMutateExpected(AnyView(root))
                             : engine->MutateExpected(AnyView(root));

--- a/tests/cpp/extra/test_structural_mutate.cc
+++ b/tests/cpp/extra/test_structural_mutate.cc
@@ -432,171 +432,18 @@ TEST(StructuralMutate, CallbackControlsRecursion) {
   EXPECT_TRUE(mapped->rhs.same_as(original_rhs));
 }
 
-// Exercise the single-callback path and the equivalent general callback chain.
-template <typename Parent = StructuralMapEngineBase, typename Callback, typename Check>
-void CheckSingleAndMultiCallback(Callback callback, Check check) {
-  auto never_matches = [](double, typename Parent::MutatorObjType*) -> Expected<Any> {
-    ADD_FAILURE() << "Unexpected callback match";
-    return Unchanged();
-  };
-  using Single = StructuralMutateEngine<Parent, Callback>;
-  using Multi = StructuralMutateEngine<Parent, Callback, decltype(never_matches)>;
-  check(make_object<Single>(callback));
-  check(make_object<Multi>(callback, never_matches));
-}
-
-class SingleCallbackParent : public StructuralMapEngineBase {
- public:
-  using MutatorObjType = SingleCallbackParent;
-  explicit SingleCallbackParent(const StructuralMutatorVTable* vtable)
-      : StructuralMapEngineBase(vtable) {}
-
-  int error_count = 0;
-  uint64_t boundary_use_count = 0;
-
-  void UpdateVisitErrorContext(const Expected<Any>& result, AnyView value) noexcept {
-    ++error_count;
-    boundary_use_count = value.cast<const Object*>()->use_count();
-    StructuralMapEngineBase::UpdateVisitErrorContext(result, value);
-  }
-};
-
-TEST(StructuralMutate, SingleCallbackOwnershipAndParentContext) {
-  TVar root("root");
-  auto check = [&](auto callback) {
-    CheckSingleAndMultiCallback<SingleCallbackParent>(callback, [&](const auto& engine) {
-      EXPECT_EQ(root.use_count(), 1);
-      auto result = engine->MutateExpected(AnyView(root));
-      ASSERT_TRUE(result.is_err());
-      EXPECT_EQ(result.error().message(), "callback error");
-      EXPECT_EQ(engine->error_count, 1);
-      // An owning match is released before the Parent sees the callback boundary.
-      EXPECT_EQ(engine->boundary_use_count, 1);
-      auto context = VisitErrorContext::TryGetFromError(result.error());
-      ASSERT_TRUE(context.has_value());
-      ASSERT_EQ(context.value()->reverse_visit_pattern.size(), 1U);
-      EXPECT_TRUE(context.value()->reverse_visit_pattern[0].same_as(root));
-    });
-    EXPECT_EQ(root.use_count(), 1);
-  };
-  check([&](AnyView, SingleCallbackParent*) -> Error {
-    EXPECT_EQ(root.use_count(), 1);
-    return Error("ValueError", "callback error", "");
-  });
-  check([&](const Any&, SingleCallbackParent*) -> Error {
-    EXPECT_EQ(root.use_count(), 2);
-    return Error("ValueError", "callback error", "");
-  });
-  check([&](const TVar&, SingleCallbackParent*) -> Expected<TVar> {
-    EXPECT_EQ(root.use_count(), 2);
-    throw Error("ValueError", "callback error", "");
-  });
-  check([&](const TVarObj*, SingleCallbackParent*) -> Expected<Any> {
-    EXPECT_EQ(root.use_count(), 1);
-    return Unexpected(Error("ValueError", "callback error", ""));
-  });
-}
-
-TEST(StructuralMutate, SingleCallbackReturnCarriersAndShortCircuit) {
-  TVar root("root");
-  TVar replacement("replacement");
-  auto check = [&](auto callback, bool unchanged) {
-    // A later matching callback must not run, even for Unchanged or Error.
-    auto later = [](AnyView, StructuralMutatorObj*) -> Any {
-      ADD_FAILURE() << "The first matching callback must own the result";
-      return Any();
-    };
-    auto inspect = [&](const auto& result) {
-      ASSERT_TRUE(result.is_ok());
-      EXPECT_TRUE(result.value().same_as(unchanged ? root : replacement));
-    };
-    inspect(StructuralMutateExpected(root, callback));
-    inspect(StructuralMutateExpected(root, callback, later));
-  };
-  check([&](AnyView, StructuralMutatorObj*) -> TVar { return replacement; }, false);
-  check([&](const Any&, StructuralMutatorObj*) -> Any { return Any(replacement); }, false);
-  check([&](const TVar&, StructuralMutatorObj*) -> Expected<TVar> { return replacement; }, false);
-  check([&](const TVarObj*, StructuralMutatorObj*) -> Expected<Any> { return replacement; }, false);
-  check([](AnyView, StructuralMutatorObj*) -> Expected<UnchangedOr<TVar>> { return Unchanged(); },
-        true);
-  check([](const Any&, StructuralMutatorObj*) -> UnchangedOr<TVar> { return Unchanged(); }, true);
-
-  auto failure = [](AnyView, StructuralMutatorObj*) -> Any {
-    return Any(Error("ValueError", "first match error", ""));
-  };
-  auto later = [](AnyView, StructuralMutatorObj*) -> Any {
-    ADD_FAILURE() << "Error is a matched result, not a callback miss";
-    return Any();
-  };
-  EXPECT_EQ(StructuralMutateExpected(root, failure).error().message(), "first match error");
-  EXPECT_EQ(StructuralMutateExpected(root, failure, later).error().message(), "first match error");
-}
-
-TEST(StructuralMutate, SingleCallbackArityAndTypedFallback) {
-  std::vector<bool> trace;
-  auto check = [&](auto callback) {
-    CheckSingleAndMultiCallback<SingleCallbackParent>(callback, [&](const auto& engine) {
-      trace.clear();
-      TVar root("root");
-      EXPECT_TRUE(engine->MutateExpected(AnyView(root)).value().IsUnchanged());
-      EXPECT_TRUE(engine->MaybeInplaceMutateExpected(AnyView(root)).value().IsUnchanged());
-      EXPECT_EQ(trace, (std::vector<bool>{false, true}));
-    });
-  };
-  check([&](AnyView, SingleCallbackParent*, bool allow_inplace) -> Unchanged {
-    trace.push_back(allow_inplace);
-    return Unchanged();
-  });
-  check([&](const Any&, SingleCallbackParent*, bool allow_inplace) -> Expected<Any> {
-    trace.push_back(allow_inplace);
-    return Unchanged();
-  });
-  check([&](const TVar&, SingleCallbackParent*, bool allow_inplace) -> Expected<Any> {
-    trace.push_back(allow_inplace);
-    return Unchanged();
-  });
-
-  auto typed = [](int64_t value, StructuralMutatorObj*) -> Any { return Any(value + 1); };
-  CheckSingleAndMultiCallback<StructuralMapWithMutateCount>(typed, [&](const auto& engine) {
-    String miss("unmatched heap string");
-    EXPECT_TRUE(engine->MutateExpected(AnyView(miss)).value().IsUnchanged());
-    EXPECT_TRUE(engine->MaybeInplaceMutateExpected(AnyView(miss)).value().IsUnchanged());
-    EXPECT_EQ(engine->count().mutate_expected, 1);
-    EXPECT_EQ(engine->count().maybe_inplace_expected, 1);
-    EXPECT_EQ(engine->MutateExpected(AnyView(int64_t{1}))
-                  .value()
-                  .ValueUnchecked()
-                  .template cast<int64_t>(),
-              2);
-    EXPECT_EQ(engine->count().value, 2);
-  });
-}
-
-TEST(StructuralMutate, SingleCallbackPassthroughKeepsBothErrorContexts) {
-  TVar lhs("lhs");
-  TMutatePair root(lhs, TVar("rhs"));
-  auto passthrough = [](AnyView value, StructuralMutatorObj* mutator,
-                        bool allow_inplace) -> Expected<Any> {
-    if (value.as<const TVarObj*>()) {
-      return Error("ValueError", "hook child error", "");
+TEST(StructuralMutate, SingleCallbackCanDelegateToDefault) {
+  auto mutate = [](AnyView value, StructuralMutatorObj* mutator) -> Expected<UnchangedOr<Any>> {
+    if (auto integer = value.as<int64_t>()) {
+      return Any(*integer + 1);
     }
-    return allow_inplace ? mutator->DefaultMaybeInplaceMutateExpected(value)
-                         : mutator->DefaultMutateExpected(value);
+    return mutator->DefaultMutateExpected(value);
   };
-  CheckSingleAndMultiCallback(passthrough, [&](const auto& engine) {
-    for (bool inplace : {false, true}) {
-      auto result = inplace ? engine->MaybeInplaceMutateExpected(AnyView(root))
-                            : engine->MutateExpected(AnyView(root));
-      ASSERT_TRUE(result.is_err());
-      auto context = VisitErrorContext::TryGetFromError(result.error());
-      ASSERT_TRUE(context.has_value());
-      const auto& pattern = context.value()->reverse_visit_pattern;
-      ASSERT_EQ(pattern.size(), 3U);
-      EXPECT_TRUE(pattern[0].same_as(lhs));
-      EXPECT_TRUE(pattern[1].same_as(root));
-      EXPECT_TRUE(pattern[2].same_as(root));
-    }
-  });
+  AnyArray root{int64_t{1}, AnyArray{int64_t{2}}};
+  AnyArray result = StructuralMutate(root, mutate).cast<AnyArray>();
+  EXPECT_EQ(result[0].cast<int64_t>(), 2);
+  EXPECT_EQ(result[1].cast<AnyArray>()[0].cast<int64_t>(), 3);
+  EXPECT_EQ(root[0].cast<int64_t>(), 1);
 }
 
 TEST(StructuralMutate, PreservesUniqueContainerIdentity) {


### PR DESCRIPTION
Forward single StructuralMutate callback results directly and use bool-match/result-output dispatch for multiple callbacks. Preserve owning conversions, typed fallback, first-match behavior, and cold error-context attachment.