### PR TITLE
[EXTRA] Enable typed mutation result conversions and subsumption

### DIFF
--- a/include/tvm/ffi/expected.h
+++ b/include/tvm/ffi/expected.h
@@ -76,9 +76,11 @@ Unexpected(E) -> Unexpected<E>;
 template <typename T>
 class Expected;
 
+/// \cond Doxygen_Suppress
 /*! \brief Whether an Expected success value can reuse another success value's storage. */
 template <typename T, typename U>
 inline constexpr bool type_subsumes_v<Expected<T>, Expected<U>> = type_subsumes_v<T, U>;
+/// \endcond
 
 namespace details {
 

--- a/include/tvm/ffi/expected.h
+++ b/include/tvm/ffi/expected.h
@@ -184,17 +184,19 @@ class Expected {
             typename = std::enable_if_t<!std::is_void_v<U> &&
                                         (type_subsumes_v<T, U> || std::is_convertible_v<U, T>)>>
   // NOLINTNEXTLINE(google-explicit-constructor,runtime/explicit)
-  TVM_FFI_INLINE Expected(Expected<U> other) {
-    if constexpr (type_subsumes_v<T, U>) {
-      // data_ holds a T or an Error. Subsumption proves the source representation already
-      // satisfies that invariant, so the Any moves without inspecting its state. Do not make
-      // this unconditional: value() reads back through MoveFromAnyAfterCheck<T>, whose check is
-      // the success/error state, not the type.
-      data_ = std::move(other.data_);
-    } else {
-      data_ = other.is_err() ? Any(std::move(other).error()) : Any(T(std::move(other).value()));
-    }
-  }
+  TVM_FFI_INLINE Expected(Expected<U> other)
+      : data_([&other]() {
+          if constexpr (type_subsumes_v<T, U>) {
+            // data_ holds a T or an Error. Subsumption proves the source representation already
+            // satisfies that invariant, so adopt the raw storage without inspecting its state.
+            // Do not make this unconditional: value() checks the success/error state, not the type.
+            return details::AnyUnsafe::MoveTVMFFIAnyRawToAny(
+                details::AnyUnsafe::MoveAnyToTVMFFIAny(std::move(other.data_)));
+          } else {
+            return other.is_err() ? Any(std::move(other).error())
+                                  : Any(T(std::move(other).value()));
+          }
+        }()) {}
 
   /*!
    * \brief Implicit constructor from an error.

--- a/include/tvm/ffi/expected.h
+++ b/include/tvm/ffi/expected.h
@@ -76,6 +76,10 @@ Unexpected(E) -> Unexpected<E>;
 template <typename T>
 class Expected;
 
+/*! \brief Whether an Expected success value can reuse another success value's storage. */
+template <typename T, typename U>
+inline constexpr bool type_subsumes_v<Expected<T>, Expected<U>> = type_subsumes_v<T, U>;
+
 namespace details {
 
 struct ExpectedUnsafe;

--- a/include/tvm/ffi/extra/structural_mutate.h
+++ b/include/tvm/ffi/extra/structural_mutate.h
@@ -52,6 +52,11 @@ namespace ffi {
 class StructuralMutatorObj;
 template <typename T>
 class UnchangedOr;
+
+/*! \brief Whether an UnchangedOr replacement can reuse another replacement's storage. */
+template <typename T, typename U>
+inline constexpr bool type_subsumes_v<UnchangedOr<T>, UnchangedOr<U>> = type_subsumes_v<T, U>;
+
 template <typename Parent, WalkOrder order, typename... Callbacks>
 class StructuralMapEngine;
 template <typename Parent, WalkOrder order>
@@ -213,6 +218,24 @@ class UnchangedOr {
   // NOLINTNEXTLINE(google-explicit-constructor,runtime/explicit)
   TVM_FFI_INLINE UnchangedOr(T value) : data_(Any(std::move(value))) {}
 
+  /*!
+   * \brief Implicit converting constructor from another replacement type.
+   * \tparam U Source replacement type whose storage is subsumed by or implicitly convertible to T.
+   * \param other The result to convert, copied from an lvalue or moved from an rvalue.
+   */
+  template <typename U,
+            typename = std::enable_if_t<type_subsumes_v<T, U> || std::is_convertible_v<U, T>>>
+  // NOLINTNEXTLINE(google-explicit-constructor,runtime/explicit)
+  TVM_FFI_INLINE UnchangedOr(UnchangedOr<U> other) {
+    if constexpr (type_subsumes_v<T, U>) {
+      // Reuse materialized storage, including the unchanged marker.
+      data_ = std::move(other.data_);
+    } else {
+      data_ =
+          other.IsUnchanged() ? std::move(other.data_) : Any(T(std::move(other).ValueUnchecked()));
+    }
+  }
+
   /// \cond Doxygen_Suppress
   TVM_FFI_INLINE UnchangedOr(const UnchangedOr&) = default;
   TVM_FFI_INLINE UnchangedOr(UnchangedOr&&) noexcept = default;
@@ -282,6 +305,8 @@ class UnchangedOr {
   }
 
  private:
+  template <typename>
+  friend class UnchangedOr;
   friend struct details::UnchangedOrUnsafe;
   template <typename, typename>
   friend struct TypeTraits;
@@ -1876,7 +1901,7 @@ inline constexpr bool use_default_type_traits_v<UnchangedOr<T>> = false;
 template <typename T>
 struct TypeTraits<UnchangedOr<T>> : public TypeTraitsBase {
   TVM_FFI_INLINE static void CopyToAnyView(const UnchangedOr<T>& src, TVMFFIAny* result) {
-    *result = src.data_.CopyToTVMFFIAny();
+    *result = AnyView(src.data_).CopyToTVMFFIAny();
   }
 
   TVM_FFI_INLINE static void MoveToAny(UnchangedOr<T> src, TVMFFIAny* result) {

--- a/include/tvm/ffi/extra/structural_mutate.h
+++ b/include/tvm/ffi/extra/structural_mutate.h
@@ -875,28 +875,31 @@ TVM_FFI_INLINE static Expected<Any> MutateReflectedFieldsExpected(StructuralMuta
 
 namespace details {
 /// \cond Doxygen_Suppress
-// Return from the current raw or same-T Expected mutation function if Result is an Error.
+// Return an error from the current raw or Expected mutation function.
 // The rvalue-only helper lets the enclosing return type select the representation.
-#define TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(Result)                                \
-  do {                                                                             \
-    auto&& tvm_ffi_res_ = (Result);                                                \
-    if (TVM_FFI_PREDICT_FALSE(tvm_ffi_res_.is_err())) {                            \
-      return ::tvm::ffi::details::ExpectedReturnHelper(::std::move(tvm_ffi_res_)); \
-    }                                                                              \
+#define TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(Result)                   \
+  do {                                                                \
+    auto&& tvm_ffi_res_ = (Result);                                   \
+    if (TVM_FFI_PREDICT_FALSE(tvm_ffi_res_.is_err())) {               \
+      return ::tvm::ffi::details::UnexpectedReturnHelper(             \
+          ::tvm::ffi::Unexpected(::std::move(tvm_ffi_res_).error())); \
+    }                                                                 \
   } while (0)
 
 /// \endcond
 
 /// \cond Doxygen_Suppress
-#define TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN_IMPL_(Result, Type, Name, ResultExpr)    \
-  auto Result = (ResultExpr); /* NOLINT(bugprone-macro-parentheses) */             \
-  TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(Result);                                     \
-  if (TVM_FFI_PREDICT_FALSE(!::tvm::ffi::details::AnyUnsafe::CheckAnyStrict<Type>( \
-          ::tvm::ffi::details::ExpectedUnsafe::GetData(Result)))) {                \
-    return ::tvm::ffi::details::SMutateDeclaredTypeError();                        \
-  }                                                                                \
-  Type Name = /* NOLINT(bugprone-macro-parentheses) */                             \
-      ::tvm::ffi::details::AnyUnsafe::MoveFromAnyAfterCheck<Type>(                 \
+#define TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN_IMPL_(Result, Type, Name, ResultExpr)               \
+  auto Result = (ResultExpr); /* NOLINT(bugprone-macro-parentheses) */                        \
+  TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(Result);                                                \
+  if constexpr (!::tvm::ffi::type_subsumes_v<::tvm::ffi::Expected<Type>, decltype(Result)>) { \
+    if (TVM_FFI_PREDICT_FALSE(!::tvm::ffi::details::AnyUnsafe::CheckAnyStrict<Type>(          \
+            ::tvm::ffi::details::ExpectedUnsafe::GetData(Result)))) {                         \
+      return ::tvm::ffi::details::SMutateDeclaredTypeError();                                 \
+    }                                                                                         \
+  }                                                                                           \
+  Type Name = /* NOLINT(bugprone-macro-parentheses) */                                        \
+      ::tvm::ffi::details::AnyUnsafe::MoveFromAnyAfterCheck<Type>(                            \
           ::std::move(::tvm::ffi::details::ExpectedUnsafe::GetData(Result)))
 /// \endcond
 
@@ -905,10 +908,11 @@ namespace details {
  *
  * ``Type`` must be concrete; use a type alias when it contains a top-level comma. A type mismatch
  * returns ``TypeError`` through the surrounding raw or ``Expected`` function without throwing,
- * reported with a fixed string so a correct hook pays only one predicted-not-taken branch per
- * field. Its early returns work from either a raw ``TVMFFIAny`` hook or an
- * ``Expected<UnchangedOr<Any>>`` helper. This macro declares ``Name`` into the enclosing scope and
- * must be used in a braced block, never as an unbraced control-flow body.
+ * reported with a fixed string. The check is omitted when the declared type subsumes the result's
+ * success type. Its early returns work from either a raw ``TVMFFIAny`` hook or an
+ * ``Expected<T>`` helper, including one with a different success type. This macro declares ``Name``
+ * into the enclosing scope and must be used in a braced block, never as an unbraced control-flow
+ * body.
  *
  * Example:
  * \code{.cpp}

--- a/include/tvm/ffi/extra/structural_mutate.h
+++ b/include/tvm/ffi/extra/structural_mutate.h
@@ -228,15 +228,17 @@ class UnchangedOr {
   template <typename U,
             typename = std::enable_if_t<type_subsumes_v<T, U> || std::is_convertible_v<U, T>>>
   // NOLINTNEXTLINE(google-explicit-constructor,runtime/explicit)
-  TVM_FFI_INLINE UnchangedOr(UnchangedOr<U> other) {
-    if constexpr (type_subsumes_v<T, U>) {
-      // Reuse materialized storage, including the unchanged marker.
-      data_ = std::move(other.data_);
-    } else {
-      data_ =
-          other.IsUnchanged() ? std::move(other.data_) : Any(T(std::move(other).ValueUnchecked()));
-    }
-  }
+  TVM_FFI_INLINE UnchangedOr(UnchangedOr<U> other)
+      : data_([&other]() {
+          if constexpr (type_subsumes_v<T, U>) {
+            // Reuse materialized storage, including the unchanged marker.
+            return details::AnyUnsafe::MoveTVMFFIAnyRawToAny(
+                details::AnyUnsafe::MoveAnyToTVMFFIAny(std::move(other.data_)));
+          } else {
+            return other.IsUnchanged() ? std::move(other.data_)
+                                       : Any(T(std::move(other).ValueUnchecked()));
+          }
+        }()) {}
 
   /// \cond Doxygen_Suppress
   TVM_FFI_INLINE UnchangedOr(const UnchangedOr&) = default;

--- a/include/tvm/ffi/extra/structural_mutate.h
+++ b/include/tvm/ffi/extra/structural_mutate.h
@@ -53,9 +53,11 @@ class StructuralMutatorObj;
 template <typename T>
 class UnchangedOr;
 
+/// \cond Doxygen_Suppress
 /*! \brief Whether an UnchangedOr replacement can reuse another replacement's storage. */
 template <typename T, typename U>
 inline constexpr bool type_subsumes_v<UnchangedOr<T>, UnchangedOr<U>> = type_subsumes_v<T, U>;
+/// \endcond
 
 template <typename Parent, WalkOrder order, typename... Callbacks>
 class StructuralMapEngine;

--- a/tests/cpp/extra/test_structural_mutate.cc
+++ b/tests/cpp/extra/test_structural_mutate.cc
@@ -55,17 +55,11 @@ static_assert(
 Expected<UnchangedOr<String>> ReturnTypedUnchangedExpected() noexcept { return Unchanged(); }
 
 TEST(UnchangedOr, ConversionsAndAssignmentMacro) {
-  static_assert(std::is_convertible_v<const UnchangedOr<TInt>&, UnchangedOr<Any>>);
-  static_assert(std::is_convertible_v<UnchangedOr<int>, UnchangedOr<double>>);
   static_assert(!std::is_convertible_v<UnchangedOr<Any>, UnchangedOr<int>>);
-  static_assert(type_subsumes_v<UnchangedOr<TNumber>, UnchangedOr<TInt>>);
-  static_assert(!type_subsumes_v<UnchangedOr<TInt>, UnchangedOr<TNumber>>);
-  static_assert(!type_subsumes_v<UnchangedOr<double>, UnchangedOr<int>>);
   static_assert(type_subsumes_v<Expected<UnchangedOr<TNumber>>, Expected<UnchangedOr<TInt>>>);
   static_assert(!type_subsumes_v<Expected<UnchangedOr<TInt>>, Expected<UnchangedOr<TNumber>>>);
   static_assert(type_subsumes_v<Expected<Any>, Expected<void>>);
   static_assert(!type_subsumes_v<Expected<void>, Expected<Any>>);
-  static_assert(std::is_nothrow_move_constructible_v<UnchangedOr<TInt>>);
 
   TInt original(42);
   UnchangedOr<TInt> source = original;
@@ -79,42 +73,27 @@ TEST(UnchangedOr, ConversionsAndAssignmentMacro) {
   UnchangedOr<double> numeric = UnchangedOr<int>(42);
   EXPECT_EQ(AnyView(numeric).type_index(), TypeIndex::kTVMFFIFloat);
   EXPECT_DOUBLE_EQ(std::move(numeric).ValueUnchecked(), 42.0);
-  UnchangedOr<int> unchanged = Unchanged();
-  UnchangedOr<double> copied_unchanged = unchanged;
-  UnchangedOr<Any> moved_unchanged = std::move(unchanged);
-  EXPECT_TRUE(copied_unchanged.IsUnchanged());
-  EXPECT_TRUE(moved_unchanged.IsUnchanged());
-
-  Expected<UnchangedOr<TInt>> typed = UnchangedOr<TInt>(original);
-  Expected<UnchangedOr<Any>> widened = typed;
-  EXPECT_TRUE(std::move(widened).value().ValueUnchecked().same_as(original));
-  Error error("ValueError", "child failure", "");
-  Expected<UnchangedOr<Any>> widened_error = Expected<UnchangedOr<TInt>>(error);
-  EXPECT_TRUE(widened_error.error().same_as(error));
+  UnchangedOr<double> unchanged = UnchangedOr<int>(Unchanged());
+  EXPECT_TRUE(unchanged.IsUnchanged());
 
   // One consumer exercises exact, widening, erased and narrowing source types.
-  auto consume = [](auto input, auto original) -> Expected<bool> {
-    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(UnchangedOr<decltype(original)>, value, std::move(input));
+  auto consume = [](auto input, const auto& original) -> Expected<bool> {
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(UnchangedOr<std::decay_t<decltype(original)>>, value,
+                                      std::move(input));
     return value.UnchangedOrSameAs(original);
   };
+  Expected<UnchangedOr<TInt>> typed = UnchangedOr<TInt>(original);
   EXPECT_TRUE(consume(typed, original).value());
   EXPECT_TRUE(consume(typed, TNumber(original)).value());
-  EXPECT_TRUE(consume(Expected<UnchangedOr<TInt>>(Unchanged()), original).value());
   EXPECT_TRUE(consume(Expected<UnchangedOr<Any>>(typed), original).value());
-  EXPECT_TRUE(consume(Expected<UnchangedOr<TNumber>>(typed), original).value());
   EXPECT_EQ(consume(Expected<UnchangedOr<Any>>(Any(42)), original).error().kind(), "TypeError");
   EXPECT_EQ(consume(Expected<UnchangedOr<TNumber>>(UnchangedOr<TNumber>(TFloat(1.0))), original)
                 .error()
                 .kind(),
             "TypeError");
-  EXPECT_TRUE(consume(Expected<UnchangedOr<TInt>>(error), original).error().same_as(error));
-  EXPECT_TRUE(consume(Expected<Any>(error), original).error().same_as(error));
-  auto raw = [](Expected<UnchangedOr<TInt>> input) -> TVMFFIAny {
-    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(UnchangedOr<TInt>, value, std::move(input));
-    return details::UnchangedOrUnsafe::MoveToTVMFFIAny(std::move(value));
-  };
-  auto raw_error = details::ExpectedUnsafe::MoveFromTVMFFIAny<UnchangedOr<TInt>>(raw(error));
-  EXPECT_TRUE(raw_error.error().same_as(error));
+  Error error("ValueError", "child failure", "");
+  Expected<UnchangedOr<Any>> failed = Expected<UnchangedOr<TInt>>(error);
+  EXPECT_TRUE(consume(std::move(failed), original).error().same_as(error));
 }
 
 TEST(UnchangedOr, ErrorRoundTrip) {

--- a/tests/cpp/extra/test_structural_mutate.cc
+++ b/tests/cpp/extra/test_structural_mutate.cc
@@ -54,6 +54,120 @@ static_assert(
 
 Expected<UnchangedOr<String>> ReturnTypedUnchangedExpected() noexcept { return Unchanged(); }
 
+TEST(UnchangedOr, ImplicitConvertingConstructor) {
+  static_assert(type_subsumes_v<UnchangedOr<Any>, UnchangedOr<TInt>>);
+  static_assert(type_subsumes_v<UnchangedOr<TNumber>, UnchangedOr<TInt>>);
+  static_assert(!type_subsumes_v<UnchangedOr<TInt>, UnchangedOr<TNumber>>);
+  static_assert(!type_subsumes_v<UnchangedOr<double>, UnchangedOr<int>>);
+  static_assert(std::is_convertible_v<const UnchangedOr<TInt>&, UnchangedOr<Any>>);
+  static_assert(std::is_convertible_v<UnchangedOr<TInt>&&, UnchangedOr<Any>>);
+  static_assert(std::is_convertible_v<UnchangedOr<TInt>, UnchangedOr<TNumber>>);
+  static_assert(std::is_convertible_v<UnchangedOr<int>, UnchangedOr<double>>);
+  static_assert(!std::is_convertible_v<UnchangedOr<TNumber>, UnchangedOr<TInt>>);
+  static_assert(!std::is_convertible_v<UnchangedOr<Any>, UnchangedOr<int>>);
+  static_assert(!std::is_convertible_v<UnchangedOr<String>, UnchangedOr<int>>);
+  static_assert(std::is_nothrow_move_constructible_v<UnchangedOr<TInt>>);
+  static_assert(std::is_nothrow_move_assignable_v<UnchangedOr<TInt>>);
+
+  TInt replacement(42);
+  UnchangedOr<TInt> source = replacement;
+  EXPECT_EQ(replacement.use_count(), 2);
+  UnchangedOr<Any> copied = std::as_const(source);
+  EXPECT_EQ(replacement.use_count(), 3);
+  UnchangedOr<TNumber> moved = std::move(source);
+  EXPECT_EQ(replacement.use_count(), 3);
+  EXPECT_TRUE(std::move(copied).ValueUnchecked().same_as(replacement));
+  EXPECT_EQ(replacement.use_count(), 2);
+  EXPECT_TRUE(std::move(moved).ValueUnchecked().same_as(replacement));
+  EXPECT_EQ(replacement.use_count(), 1);
+
+  UnchangedOr<TInt> unchanged = Unchanged();
+  UnchangedOr<Any> copied_unchanged = std::as_const(unchanged);
+  UnchangedOr<TNumber> moved_unchanged = std::move(unchanged);
+  EXPECT_TRUE(copied_unchanged.IsUnchanged());
+  EXPECT_TRUE(moved_unchanged.IsUnchanged());
+}
+
+TEST(UnchangedOr, ConvertingConstructorConvertsReplacement) {
+  UnchangedOr<int> source = 42;
+  UnchangedOr<double> copied = source;
+  EXPECT_EQ(AnyView(source).type_index(), TypeIndex::kTVMFFIInt);
+  EXPECT_EQ(AnyView(copied).type_index(), TypeIndex::kTVMFFIFloat);
+  EXPECT_DOUBLE_EQ(std::move(copied).ValueUnchecked(), 42.0);
+  UnchangedOr<double> moved = std::move(source);
+  EXPECT_EQ(AnyView(moved).type_index(), TypeIndex::kTVMFFIFloat);
+  EXPECT_DOUBLE_EQ(std::move(moved).ValueUnchecked(), 42.0);
+
+  UnchangedOr<int> unchanged = Unchanged();
+  UnchangedOr<double> copied_unchanged = unchanged;
+  UnchangedOr<double> moved_unchanged = std::move(unchanged);
+  EXPECT_TRUE(copied_unchanged.IsUnchanged());
+  EXPECT_TRUE(moved_unchanged.IsUnchanged());
+}
+
+class TThrowingConversion : public TInt {
+ public:
+  explicit TThrowingConversion(int value) : TInt(value) {}
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  operator double() const { throw Error("ValueError", "replacement conversion failed", ""); }
+  explicit operator String() const { return String("explicit conversion"); }
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(TThrowingConversion, TInt, TIntObj);
+};
+
+TEST(UnchangedOr, ConvertingConstructorSkipsUnchanged) {
+  static_assert(
+      !std::is_nothrow_constructible_v<UnchangedOr<double>, UnchangedOr<TThrowingConversion>>);
+  static_assert(!std::is_convertible_v<UnchangedOr<TThrowingConversion>, UnchangedOr<String>>);
+
+  UnchangedOr<TThrowingConversion> unchanged = Unchanged();
+  UnchangedOr<double> copied = unchanged;
+  UnchangedOr<double> moved = std::move(unchanged);
+  EXPECT_TRUE(copied.IsUnchanged());
+  EXPECT_TRUE(moved.IsUnchanged());
+
+  UnchangedOr<TThrowingConversion> replacement = TThrowingConversion(42);
+  EXPECT_THROW((UnchangedOr<double>(replacement)), Error);
+  EXPECT_THROW((UnchangedOr<double>(std::move(replacement))), Error);
+}
+
+TEST(UnchangedOr, NestedExpectedConvertingConstructor) {
+  static_assert(std::is_convertible_v<Expected<UnchangedOr<TInt>>, Expected<UnchangedOr<Any>>>);
+  static_assert(std::is_convertible_v<Expected<UnchangedOr<int>>, Expected<UnchangedOr<double>>>);
+  static_assert(!std::is_convertible_v<Expected<UnchangedOr<String>>, Expected<UnchangedOr<int>>>);
+
+  TInt replacement(42);
+  Expected<UnchangedOr<TInt>> source = UnchangedOr<TInt>(replacement);
+  Expected<UnchangedOr<Any>> copied = source;
+  EXPECT_EQ(replacement.use_count(), 3);
+  Expected<UnchangedOr<Any>> moved = std::move(source);
+  EXPECT_EQ(replacement.use_count(), 3);
+  ASSERT_TRUE(copied.is_ok());
+  ASSERT_TRUE(moved.is_ok());
+  EXPECT_TRUE(std::move(copied).value().ValueUnchecked().same_as(replacement));
+  EXPECT_TRUE(std::move(moved).value().ValueUnchecked().same_as(replacement));
+  EXPECT_EQ(replacement.use_count(), 1);
+
+  Expected<UnchangedOr<int>> numeric = UnchangedOr<int>(42);
+  Expected<UnchangedOr<double>> converted = std::move(numeric);
+  ASSERT_TRUE(converted.is_ok());
+  EXPECT_EQ(converted.type_index(), TypeIndex::kTVMFFIFloat);
+  EXPECT_DOUBLE_EQ(std::move(converted).value().ValueUnchecked(), 42.0);
+
+  for (bool move_source : {false, true}) {
+    Expected<UnchangedOr<TInt>> unchanged = Unchanged();
+    Expected<UnchangedOr<Any>> converted_unchanged = move_source ? std::move(unchanged) : unchanged;
+    ASSERT_TRUE(converted_unchanged.is_ok());
+    EXPECT_TRUE(std::move(converted_unchanged).value().IsUnchanged());
+
+    Error error("ValueError", "nested conversion error", "");
+    Expected<UnchangedOr<TInt>> failure = error;
+    Expected<UnchangedOr<Any>> converted_error = move_source ? std::move(failure) : failure;
+    ASSERT_TRUE(converted_error.is_err());
+    EXPECT_TRUE(converted_error.error().same_as(error));
+    EXPECT_EQ(error.use_count(), move_source ? 2 : 3);
+  }
+}
+
 TEST(UnchangedOr, ErrorRoundTrip) {
   static_assert(std::is_copy_constructible_v<UnchangedOr<String>>);
 

--- a/tests/cpp/extra/test_structural_mutate.cc
+++ b/tests/cpp/extra/test_structural_mutate.cc
@@ -54,118 +54,67 @@ static_assert(
 
 Expected<UnchangedOr<String>> ReturnTypedUnchangedExpected() noexcept { return Unchanged(); }
 
-TEST(UnchangedOr, ImplicitConvertingConstructor) {
-  static_assert(type_subsumes_v<UnchangedOr<Any>, UnchangedOr<TInt>>);
+TEST(UnchangedOr, ConversionsAndAssignmentMacro) {
+  static_assert(std::is_convertible_v<const UnchangedOr<TInt>&, UnchangedOr<Any>>);
+  static_assert(std::is_convertible_v<UnchangedOr<int>, UnchangedOr<double>>);
+  static_assert(!std::is_convertible_v<UnchangedOr<Any>, UnchangedOr<int>>);
   static_assert(type_subsumes_v<UnchangedOr<TNumber>, UnchangedOr<TInt>>);
   static_assert(!type_subsumes_v<UnchangedOr<TInt>, UnchangedOr<TNumber>>);
   static_assert(!type_subsumes_v<UnchangedOr<double>, UnchangedOr<int>>);
-  static_assert(std::is_convertible_v<const UnchangedOr<TInt>&, UnchangedOr<Any>>);
-  static_assert(std::is_convertible_v<UnchangedOr<TInt>&&, UnchangedOr<Any>>);
-  static_assert(std::is_convertible_v<UnchangedOr<TInt>, UnchangedOr<TNumber>>);
-  static_assert(std::is_convertible_v<UnchangedOr<int>, UnchangedOr<double>>);
-  static_assert(!std::is_convertible_v<UnchangedOr<TNumber>, UnchangedOr<TInt>>);
-  static_assert(!std::is_convertible_v<UnchangedOr<Any>, UnchangedOr<int>>);
-  static_assert(!std::is_convertible_v<UnchangedOr<String>, UnchangedOr<int>>);
+  static_assert(type_subsumes_v<Expected<UnchangedOr<TNumber>>, Expected<UnchangedOr<TInt>>>);
+  static_assert(!type_subsumes_v<Expected<UnchangedOr<TInt>>, Expected<UnchangedOr<TNumber>>>);
+  static_assert(type_subsumes_v<Expected<Any>, Expected<void>>);
+  static_assert(!type_subsumes_v<Expected<void>, Expected<Any>>);
   static_assert(std::is_nothrow_move_constructible_v<UnchangedOr<TInt>>);
-  static_assert(std::is_nothrow_move_assignable_v<UnchangedOr<TInt>>);
 
-  TInt replacement(42);
-  UnchangedOr<TInt> source = replacement;
-  EXPECT_EQ(replacement.use_count(), 2);
+  TInt original(42);
+  UnchangedOr<TInt> source = original;
   UnchangedOr<Any> copied = std::as_const(source);
-  EXPECT_EQ(replacement.use_count(), 3);
   UnchangedOr<TNumber> moved = std::move(source);
-  EXPECT_EQ(replacement.use_count(), 3);
-  EXPECT_TRUE(std::move(copied).ValueUnchecked().same_as(replacement));
-  EXPECT_EQ(replacement.use_count(), 2);
-  EXPECT_TRUE(std::move(moved).ValueUnchecked().same_as(replacement));
-  EXPECT_EQ(replacement.use_count(), 1);
+  EXPECT_EQ(original.use_count(), 3);
+  EXPECT_TRUE(std::move(copied).ValueUnchecked().same_as(original));
+  EXPECT_TRUE(std::move(moved).ValueUnchecked().same_as(original));
+  EXPECT_EQ(original.use_count(), 1);
 
-  UnchangedOr<TInt> unchanged = Unchanged();
-  UnchangedOr<Any> copied_unchanged = std::as_const(unchanged);
-  UnchangedOr<TNumber> moved_unchanged = std::move(unchanged);
-  EXPECT_TRUE(copied_unchanged.IsUnchanged());
-  EXPECT_TRUE(moved_unchanged.IsUnchanged());
-}
-
-TEST(UnchangedOr, ConvertingConstructorConvertsReplacement) {
-  UnchangedOr<int> source = 42;
-  UnchangedOr<double> copied = source;
-  EXPECT_EQ(AnyView(source).type_index(), TypeIndex::kTVMFFIInt);
-  EXPECT_EQ(AnyView(copied).type_index(), TypeIndex::kTVMFFIFloat);
-  EXPECT_DOUBLE_EQ(std::move(copied).ValueUnchecked(), 42.0);
-  UnchangedOr<double> moved = std::move(source);
-  EXPECT_EQ(AnyView(moved).type_index(), TypeIndex::kTVMFFIFloat);
-  EXPECT_DOUBLE_EQ(std::move(moved).ValueUnchecked(), 42.0);
-
+  UnchangedOr<double> numeric = UnchangedOr<int>(42);
+  EXPECT_EQ(AnyView(numeric).type_index(), TypeIndex::kTVMFFIFloat);
+  EXPECT_DOUBLE_EQ(std::move(numeric).ValueUnchecked(), 42.0);
   UnchangedOr<int> unchanged = Unchanged();
   UnchangedOr<double> copied_unchanged = unchanged;
-  UnchangedOr<double> moved_unchanged = std::move(unchanged);
+  UnchangedOr<Any> moved_unchanged = std::move(unchanged);
   EXPECT_TRUE(copied_unchanged.IsUnchanged());
   EXPECT_TRUE(moved_unchanged.IsUnchanged());
-}
 
-class TThrowingConversion : public TInt {
- public:
-  explicit TThrowingConversion(int value) : TInt(value) {}
-  // NOLINTNEXTLINE(google-explicit-constructor)
-  operator double() const { throw Error("ValueError", "replacement conversion failed", ""); }
-  explicit operator String() const { return String("explicit conversion"); }
-  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NOTNULLABLE(TThrowingConversion, TInt, TIntObj);
-};
+  Expected<UnchangedOr<TInt>> typed = UnchangedOr<TInt>(original);
+  Expected<UnchangedOr<Any>> widened = typed;
+  EXPECT_TRUE(std::move(widened).value().ValueUnchecked().same_as(original));
+  Error error("ValueError", "child failure", "");
+  Expected<UnchangedOr<Any>> widened_error = Expected<UnchangedOr<TInt>>(error);
+  EXPECT_TRUE(widened_error.error().same_as(error));
 
-TEST(UnchangedOr, ConvertingConstructorSkipsUnchanged) {
-  static_assert(
-      !std::is_nothrow_constructible_v<UnchangedOr<double>, UnchangedOr<TThrowingConversion>>);
-  static_assert(!std::is_convertible_v<UnchangedOr<TThrowingConversion>, UnchangedOr<String>>);
-
-  UnchangedOr<TThrowingConversion> unchanged = Unchanged();
-  UnchangedOr<double> copied = unchanged;
-  UnchangedOr<double> moved = std::move(unchanged);
-  EXPECT_TRUE(copied.IsUnchanged());
-  EXPECT_TRUE(moved.IsUnchanged());
-
-  UnchangedOr<TThrowingConversion> replacement = TThrowingConversion(42);
-  EXPECT_THROW((UnchangedOr<double>(replacement)), Error);
-  EXPECT_THROW((UnchangedOr<double>(std::move(replacement))), Error);
-}
-
-TEST(UnchangedOr, NestedExpectedConvertingConstructor) {
-  static_assert(std::is_convertible_v<Expected<UnchangedOr<TInt>>, Expected<UnchangedOr<Any>>>);
-  static_assert(std::is_convertible_v<Expected<UnchangedOr<int>>, Expected<UnchangedOr<double>>>);
-  static_assert(!std::is_convertible_v<Expected<UnchangedOr<String>>, Expected<UnchangedOr<int>>>);
-
-  TInt replacement(42);
-  Expected<UnchangedOr<TInt>> source = UnchangedOr<TInt>(replacement);
-  Expected<UnchangedOr<Any>> copied = source;
-  EXPECT_EQ(replacement.use_count(), 3);
-  Expected<UnchangedOr<Any>> moved = std::move(source);
-  EXPECT_EQ(replacement.use_count(), 3);
-  ASSERT_TRUE(copied.is_ok());
-  ASSERT_TRUE(moved.is_ok());
-  EXPECT_TRUE(std::move(copied).value().ValueUnchecked().same_as(replacement));
-  EXPECT_TRUE(std::move(moved).value().ValueUnchecked().same_as(replacement));
-  EXPECT_EQ(replacement.use_count(), 1);
-
-  Expected<UnchangedOr<int>> numeric = UnchangedOr<int>(42);
-  Expected<UnchangedOr<double>> converted = std::move(numeric);
-  ASSERT_TRUE(converted.is_ok());
-  EXPECT_EQ(converted.type_index(), TypeIndex::kTVMFFIFloat);
-  EXPECT_DOUBLE_EQ(std::move(converted).value().ValueUnchecked(), 42.0);
-
-  for (bool move_source : {false, true}) {
-    Expected<UnchangedOr<TInt>> unchanged = Unchanged();
-    Expected<UnchangedOr<Any>> converted_unchanged = move_source ? std::move(unchanged) : unchanged;
-    ASSERT_TRUE(converted_unchanged.is_ok());
-    EXPECT_TRUE(std::move(converted_unchanged).value().IsUnchanged());
-
-    Error error("ValueError", "nested conversion error", "");
-    Expected<UnchangedOr<TInt>> failure = error;
-    Expected<UnchangedOr<Any>> converted_error = move_source ? std::move(failure) : failure;
-    ASSERT_TRUE(converted_error.is_err());
-    EXPECT_TRUE(converted_error.error().same_as(error));
-    EXPECT_EQ(error.use_count(), move_source ? 2 : 3);
-  }
+  // One consumer exercises exact, widening, erased and narrowing source types.
+  auto consume = [](auto input, auto original) -> Expected<bool> {
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(UnchangedOr<decltype(original)>, value, std::move(input));
+    return value.UnchangedOrSameAs(original);
+  };
+  EXPECT_TRUE(consume(typed, original).value());
+  EXPECT_TRUE(consume(typed, TNumber(original)).value());
+  EXPECT_TRUE(consume(Expected<UnchangedOr<TInt>>(Unchanged()), original).value());
+  EXPECT_TRUE(consume(Expected<UnchangedOr<Any>>(typed), original).value());
+  EXPECT_TRUE(consume(Expected<UnchangedOr<TNumber>>(typed), original).value());
+  EXPECT_EQ(consume(Expected<UnchangedOr<Any>>(Any(42)), original).error().kind(), "TypeError");
+  EXPECT_EQ(consume(Expected<UnchangedOr<TNumber>>(UnchangedOr<TNumber>(TFloat(1.0))), original)
+                .error()
+                .kind(),
+            "TypeError");
+  EXPECT_TRUE(consume(Expected<UnchangedOr<TInt>>(error), original).error().same_as(error));
+  EXPECT_TRUE(consume(Expected<Any>(error), original).error().same_as(error));
+  auto raw = [](Expected<UnchangedOr<TInt>> input) -> TVMFFIAny {
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(UnchangedOr<TInt>, value, std::move(input));
+    return details::UnchangedOrUnsafe::MoveToTVMFFIAny(std::move(value));
+  };
+  auto raw_error = details::ExpectedUnsafe::MoveFromTVMFFIAny<UnchangedOr<TInt>>(raw(error));
+  EXPECT_TRUE(raw_error.error().same_as(error));
 }
 
 TEST(UnchangedOr, ErrorRoundTrip) {


### PR DESCRIPTION
Typed structural mutation helpers need to convert compatible `UnchangedOr` results and propagate child errors across different success types. The assignment macro also repeats checks for already compatible typed results.

Add implicit `UnchangedOr` conversions and storage-subsumption rules for `UnchangedOr` and `Expected`. Initialize subsumed conversions directly from their stored carrier, avoiding an intermediate assignment. Use subsumption to omit redundant assignment checks while retaining checks for erased or narrower sources, and propagate child errors through the existing error-only return helper. Correct the borrowed `AnyView` adapter for wrapper values.
