### PR TITLE
[IR] Preserve structural remap state and insertion errors

### DIFF
--- a/include/tvm/ffi/extra/structural_mutate.h
+++ b/include/tvm/ffi/extra/structural_mutate.h
@@ -1085,6 +1085,9 @@ class StructuralMapEngineBase : public StructuralMutatorObj {
     }
   }
 
+  /*! \brief Whether the owned variable-remap environment has any entries. */
+  TVM_FFI_INLINE bool HasVarRemap() const noexcept { return !var_remap_.empty(); }
+
   /*!
    * \brief Look up a replacement in the identity-substitution environment.
    * \param var The borrowed variable identity to look up.
@@ -1094,6 +1097,9 @@ class StructuralMapEngineBase : public StructuralMutatorObj {
     if (TVM_FFI_PREDICT_FALSE(var.type_index() < TypeIndex::kTVMFFIStaticObjectBegin)) {
       return VarRemapKeyTypeError();
     }
+    // An empty environment is common for ordinary unchanged traversal. Avoid
+    // hashing the identity (including a bucket-count division) on this path.
+    if (var_remap_.empty()) return Any(nullptr);
     const Object* var_ptr =
         details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const Object>(var);
     auto it = var_remap_.find(var_ptr);
@@ -1112,15 +1118,24 @@ class StructuralMapEngineBase : public StructuralMutatorObj {
     }
     const Object* var_ptr =
         details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const Object>(var);
-    Any owned_mapped_value(mapped_value);
-    auto [it, inserted] = var_remap_.try_emplace(var_ptr, std::move(owned_mapped_value));
-    if (inserted) {
-      details::ObjectUnsafe::IncRefObjectHandle(
-          reinterpret_cast<TVMFFIObjectHandle>(const_cast<Object*>(var_ptr)));
-    } else {
-      it->second = std::move(owned_mapped_value);
+    // Allocation in the owned binding must not escape this noexcept boundary.
+    // In particular, a failed insertion leaves both the map and borrowed key
+    // unchanged, while the local owning replacement releases normally.
+    try {
+      Any owned_mapped_value(mapped_value);
+      auto [it, inserted] = var_remap_.try_emplace(var_ptr, std::move(owned_mapped_value));
+      if (inserted) {
+        details::ObjectUnsafe::IncRefObjectHandle(
+            reinterpret_cast<TVMFFIObjectHandle>(const_cast<Object*>(var_ptr)));
+      } else {
+        it->second = std::move(owned_mapped_value);
+      }
+      return Expected<void>();
+    } catch (Error& error) {
+      return Unexpected(std::move(error));
+    } catch (const std::exception& error) {
+      return Unexpected(Error("RuntimeError", error.what(), ""));
     }
-    return Expected<void>();
   }
 
  private:

--- a/tests/cpp/extra/test_structural_mutate.cc
+++ b/tests/cpp/extra/test_structural_mutate.cc
@@ -345,6 +345,9 @@ class StructuralMapWithMutateCount : public StructuralMapEngineBase {
 class StructuralMutateLayer : public StructuralMapEngineBase {
  public:
   using MutatorObjType = StructuralMutateLayer;
+  using StructuralMapEngineBase::HasVarRemap;
+  using StructuralMapEngineBase::VarRemapGetImpl;
+  using StructuralMapEngineBase::VarRemapSetImpl;
 
   explicit StructuralMutateLayer(const StructuralMutatorVTable* vtable)
       : StructuralMapEngineBase(vtable) {}
@@ -559,6 +562,25 @@ TEST(StructuralMutate, CallbackArityControlsInplaceMutation) {
 }
 
 TEST(StructuralMutate, MatchedVarOwnsRemapConsistency) {
+  TVar key("key"), replacement("replacement");
+  {
+    auto engine = make_object<StructuralMutateLayer>(nullptr);
+    EXPECT_FALSE(engine->HasVarRemap());
+    EXPECT_TRUE(engine->VarRemapGetImpl(nullptr).is_err());
+    EXPECT_TRUE(engine->VarRemapGetImpl(1).is_err());
+    EXPECT_EQ(engine->VarRemapGetImpl(key).value(), nullptr);
+    engine->VarRemapSetImpl(key, replacement).value();
+    EXPECT_TRUE(engine->HasVarRemap());
+    EXPECT_FALSE(key.unique());
+    EXPECT_TRUE(engine->VarRemapGetImpl(key).value().cast<TVar>().same_as(replacement));
+    EXPECT_EQ(engine->VarRemapGetImpl(TVar("missing")).value(), nullptr);
+    engine->VarRemapSetImpl(key, Any(Unchanged())).value();
+    EXPECT_EQ(engine->VarRemapGetImpl(key).value().type_index(), TypeIndex::kTVMFFIUnchanged);
+    EXPECT_TRUE(engine->HasVarRemap());
+    EXPECT_TRUE(replacement.unique());
+  }
+  EXPECT_TRUE(key.unique());
+
   TVarWithDep var("n", TVar("type"));
   TPair root(TDefHolder(TVarWithDep("pattern"), var), var);
   int type_callback_count = 0;


### PR DESCRIPTION
Expose a protected `VarRemapEmpty()` accessor so derived structural map engines can check whether the remap environment contains any mappings. Skip the identity-map lookup when the environment is empty, after validating the key.
