### PR TITLE
[IR] Expose protected remap state and skip empty lookups

### DIFF
--- a/include/tvm/ffi/extra/structural_mutate.h
+++ b/include/tvm/ffi/extra/structural_mutate.h
@@ -1131,6 +1131,7 @@ class StructuralMapEngineBase : public StructuralMutatorObj {
   template <typename Parent>
   friend class details::StructuralMutateDynEngine;
 
+  /*! \brief Identity-substitution environment keyed by object identity. */
   // Raw-pointer key: IncRef once on first insert, DecRef all keys in the destructor.
   std::unordered_map<const Object*, Any> var_remap_;
 };

--- a/include/tvm/ffi/extra/structural_mutate.h
+++ b/include/tvm/ffi/extra/structural_mutate.h
@@ -1085,6 +1085,9 @@ class StructuralMapEngineBase : public StructuralMutatorObj {
     }
   }
 
+  /*! \brief Whether the variable-remap environment is empty. */
+  TVM_FFI_INLINE bool VarRemapEmpty() const noexcept { return var_remap_.empty(); }
+
   /*!
    * \brief Look up a replacement in the identity-substitution environment.
    * \param var The borrowed variable identity to look up.
@@ -1094,6 +1097,7 @@ class StructuralMapEngineBase : public StructuralMutatorObj {
     if (TVM_FFI_PREDICT_FALSE(var.type_index() < TypeIndex::kTVMFFIStaticObjectBegin)) {
       return VarRemapKeyTypeError();
     }
+    if (var_remap_.empty()) return Any(nullptr);
     const Object* var_ptr =
         details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const Object>(var);
     auto it = var_remap_.find(var_ptr);

--- a/include/tvm/ffi/extra/structural_mutate.h
+++ b/include/tvm/ffi/extra/structural_mutate.h
@@ -1031,7 +1031,6 @@ class StructuralMapEngineBase : public StructuralMutatorObj {
   /*! \brief Return the empty state tuple exposed to typed map callbacks. */
   TVM_FFI_INLINE StateTupleType StateTuple() const noexcept { return {}; }
 
- private:
   /// \cond Doxygen_Suppress
   // Out of line so its strings stay out of the per-node dispatch function, which TryLink inlines
   // into. Shared by the typed and dynamic engines below.
@@ -1069,7 +1068,6 @@ class StructuralMapEngineBase : public StructuralMutatorObj {
     return details::ExpectedUnsafe::MoveToTVMFFIAny(self->VarRemapSetImpl(var, mapped_value));
   }
 
- protected:
   /*!
    * \brief Append \p node to a failed result's mutate error context.
    * \param result The failed result whose Error is annotated.
@@ -1084,9 +1082,6 @@ class StructuralMapEngineBase : public StructuralMutatorObj {
       ::tvm::ffi::details::UpdateVisitErrorContext(err, node.cast<ObjectRef>());
     }
   }
-
-  /*! \brief Whether the variable-remap environment is empty. */
-  TVM_FFI_INLINE bool VarRemapEmpty() const noexcept { return var_remap_.empty(); }
 
   /*!
    * \brief Look up a replacement in the identity-substitution environment.
@@ -1127,7 +1122,6 @@ class StructuralMapEngineBase : public StructuralMutatorObj {
     return Expected<void>();
   }
 
- private:
   template <typename Parent, WalkOrder order, typename... Callbacks>
   friend class StructuralMapEngine;
   template <typename Parent, WalkOrder order>

--- a/tests/cpp/extra/test_structural_mutate.cc
+++ b/tests/cpp/extra/test_structural_mutate.cc
@@ -315,6 +315,7 @@ struct MutateCount {
 
 class StructuralMapWithMutateCount : public StructuralMapEngineBase {
  public:
+  using StructuralMapEngineBase::VarRemapEmpty;
   using StateTupleType = std::tuple<const MutateCount&, const int&>;
 
   explicit StructuralMapWithMutateCount(const StructuralMutatorVTable* vtable)
@@ -373,6 +374,13 @@ TEST(StructuralMap, ParentLayerOwnsBothDescentsAndProvidesState) {
                                       decltype(identity), decltype(map_var)>;
   auto engine = make_object<Mutator>(std::move(identity), std::move(map_var));
   StructuralMutator mutator(engine);
+  TVar key("key");
+  EXPECT_TRUE(engine->VarRemapEmpty());
+  EXPECT_EQ(mutator->VarRemapGetExpected(key).value(), nullptr);
+  EXPECT_EQ(mutator->VarRemapGetExpected(nullptr).error().kind(), "TypeError");
+  EXPECT_EQ(mutator->VarRemapGetExpected(1).error().kind(), "TypeError");
+  mutator->VarRemapSetExpected(key, Any(Unchanged())).value();
+  EXPECT_FALSE(engine->VarRemapEmpty());
 
   ASSERT_FALSE(mutator->MutateExpected(String("unmatched")).is_err());
   AnyArray rebuild_root{int64_t{1}};

--- a/tests/cpp/extra/test_structural_mutate.cc
+++ b/tests/cpp/extra/test_structural_mutate.cc
@@ -315,7 +315,6 @@ struct MutateCount {
 
 class StructuralMapWithMutateCount : public StructuralMapEngineBase {
  public:
-  using StructuralMapEngineBase::VarRemapEmpty;
   using StateTupleType = std::tuple<const MutateCount&, const int&>;
 
   explicit StructuralMapWithMutateCount(const StructuralMutatorVTable* vtable)
@@ -375,12 +374,10 @@ TEST(StructuralMap, ParentLayerOwnsBothDescentsAndProvidesState) {
   auto engine = make_object<Mutator>(std::move(identity), std::move(map_var));
   StructuralMutator mutator(engine);
   TVar key("key");
-  EXPECT_TRUE(engine->VarRemapEmpty());
   EXPECT_EQ(mutator->VarRemapGetExpected(key).value(), nullptr);
   EXPECT_EQ(mutator->VarRemapGetExpected(nullptr).error().kind(), "TypeError");
   EXPECT_EQ(mutator->VarRemapGetExpected(1).error().kind(), "TypeError");
   mutator->VarRemapSetExpected(key, Any(Unchanged())).value();
-  EXPECT_FALSE(engine->VarRemapEmpty());
 
   ASSERT_FALSE(mutator->MutateExpected(String("unmatched")).is_err());
   AnyArray rebuild_root{int64_t{1}};


### PR DESCRIPTION
Expose `var_remap_` as protected state so derived structural map engines can inspect the remap environment. Skip the identity-map lookup when the environment is empty, after validating the key.
